### PR TITLE
Add CAMPAIGN_SERVICE_API_KEY protection to internal routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ SENTRY_DSN='https://xxx@xxx.ingest.sentry.io/xxx'
 CLERK_SECRET_KEY='sk_live_...'
 
 # Service-to-service auth
-SERVICE_SECRET_KEY='...'
+CAMPAIGN_SERVICE_API_KEY='your-campaign-service-api-key'
 
 # Server
 PORT=3003

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -154,3 +154,27 @@ export function requireOrg(
   }
   next();
 }
+
+/**
+ * Middleware to verify CAMPAIGN_SERVICE_API_KEY for internal service-to-service calls
+ * Checks x-api-key header against CAMPAIGN_SERVICE_API_KEY env var
+ */
+export function requireApiKey(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const apiKey = req.headers["x-api-key"] as string;
+  const expectedKey = process.env.CAMPAIGN_SERVICE_API_KEY;
+
+  if (!expectedKey) {
+    console.error("CAMPAIGN_SERVICE_API_KEY not configured");
+    return res.status(500).json({ error: "API key not configured" });
+  }
+
+  if (!apiKey || apiKey !== expectedKey) {
+    return res.status(401).json({ error: "Invalid or missing API key" });
+  }
+
+  next();
+}


### PR DESCRIPTION
## Summary
Add CAMPAIGN_SERVICE_API_KEY middleware to protect all internal service-to-service routes. Previously unprotected endpoints that exposed campaign data, runs, and leaderboard statistics now require valid API key authentication.

## Changes
- New `requireApiKey` middleware in auth.ts
- Applied to 5 internal routes (leaderboard, campaigns/all, runs endpoints)
- Updated .env.example with CAMPAIGN_SERVICE_API_KEY variable

🤖 Generated with Claude Code