### PR TITLE
fix: add missing API key to emailgeneration-service call

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -215,9 +215,14 @@ export async function getStatsByModel(runIds: string[]): Promise<ModelStats[]> {
   if (runIds.length === 0) return [];
 
   try {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (EMAILGENERATION_SERVICE_API_KEY) {
+      headers["X-API-Key"] = EMAILGENERATION_SERVICE_API_KEY;
+    }
+
     const response = await fetch(`${EMAILGENERATION_SERVICE_URL}/stats/by-model`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify({ runIds }),
     });
 


### PR DESCRIPTION
The getStatsByModel function was missing the X-API-Key header when calling emailgeneration-service, causing 401 authentication failures. This brings it in line with other service calls that properly include authentication.