### PR TITLE
Add [Campaign Service] prefix to all logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ Sentry.setupExpressErrorHandler(app);
 
 // Fallback error handler
 app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
-  console.error("Unhandled error:", err);
+  console.error("[Campaign Service] Unhandled error:", err);
   res.status(500).json({ error: "Internal server error" });
 });
 
@@ -48,13 +48,13 @@ app.use((err: Error, req: express.Request, res: express.Response, next: express.
 if (process.env.NODE_ENV !== "test") {
   migrate(db, { migrationsFolder: "./drizzle" })
     .then(() => {
-      console.log("Migrations complete");
+      console.log("[Campaign Service] Migrations complete");
       app.listen(Number(PORT), "::", () => {
-        console.log(`Campaign service running on port ${PORT}`);
+        console.log(`[Campaign Service] Running on port ${PORT}`);
       });
     })
     .catch((err) => {
-      console.error("Migration failed:", err);
+      console.error("[Campaign Service] Migration failed:", err);
       process.exit(1);
     });
 }

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -67,7 +67,7 @@ async function fetchStats<T>(url: string, clerkOrgId: string, body: unknown, api
     });
 
     if (!response.ok) {
-      console.warn(`Stats fetch failed: ${url} - ${response.status}`);
+      console.warn(`[Campaign Service] Stats fetch failed: ${url} - ${response.status}`);
       return null;
     }
 
@@ -76,9 +76,9 @@ async function fetchStats<T>(url: string, clerkOrgId: string, body: unknown, api
   } catch (error) {
     const cause = error instanceof Error && 'cause' in error ? (error.cause as { code?: string }) : null;
     if (cause?.code === 'ECONNREFUSED') {
-      console.warn(`Stats fetch error: ${url} - connection refused`);
+      console.warn(`[Campaign Service] Stats fetch error: ${url} - connection refused`);
     } else {
-      console.warn(`Stats fetch error: ${url} - ${error instanceof Error ? error.message : 'unknown error'}`);
+      console.warn(`[Campaign Service] Stats fetch error: ${url} - ${error instanceof Error ? error.message : 'unknown error'}`);
     }
     return null;
   }
@@ -113,7 +113,7 @@ async function fetchData<T>(url: string, clerkOrgId: string, apiKey?: string): P
     const response = await fetch(url, { headers });
 
     if (!response.ok) {
-      console.warn(`Data fetch failed: ${url} - ${response.status}`);
+      console.warn(`[Campaign Service] Data fetch failed: ${url} - ${response.status}`);
       return null;
     }
 
@@ -121,9 +121,9 @@ async function fetchData<T>(url: string, clerkOrgId: string, apiKey?: string): P
   } catch (error) {
     const cause = error instanceof Error && 'cause' in error ? (error.cause as { code?: string }) : null;
     if (cause?.code === 'ECONNREFUSED') {
-      console.warn(`Data fetch error: ${url} - connection refused`);
+      console.warn(`[Campaign Service] Data fetch error: ${url} - connection refused`);
     } else {
-      console.warn(`Data fetch error: ${url} - ${error instanceof Error ? error.message : 'unknown error'}`);
+      console.warn(`[Campaign Service] Data fetch error: ${url} - ${error instanceof Error ? error.message : 'unknown error'}`);
     }
     return null;
   }
@@ -227,7 +227,7 @@ export async function getStatsByModel(runIds: string[]): Promise<ModelStats[]> {
     });
 
     if (!response.ok) {
-      console.warn(`Stats by model fetch failed: ${response.status}`);
+      console.warn(`[Campaign Service] Stats by model fetch failed: ${response.status}`);
       return [];
     }
 
@@ -236,9 +236,9 @@ export async function getStatsByModel(runIds: string[]): Promise<ModelStats[]> {
   } catch (error) {
     const cause = error instanceof Error && 'cause' in error ? (error.cause as { code?: string }) : null;
     if (cause?.code === 'ECONNREFUSED') {
-      console.warn(`Stats by model fetch error: ${EMAILGENERATION_SERVICE_URL}/stats/by-model - connection refused`);
+      console.warn(`[Campaign Service] Stats by model fetch error: ${EMAILGENERATION_SERVICE_URL}/stats/by-model - connection refused`);
     } else {
-      console.warn(`Stats by model fetch error: ${error instanceof Error ? error.message : 'unknown error'}`);
+      console.warn(`[Campaign Service] Stats by model fetch error: ${error instanceof Error ? error.message : 'unknown error'}`);
     }
     return [];
   }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -68,7 +68,7 @@ export async function serviceAuth(
 
     next();
   } catch (error) {
-    console.error("Service auth error:", error);
+    console.error("[Campaign Service] Service auth error:", error);
     return res.status(401).json({ error: "Service authentication failed" });
   }
 }
@@ -136,7 +136,7 @@ export async function clerkAuth(
 
     next();
   } catch (error) {
-    console.error("Auth error:", error);
+    console.error("[Campaign Service] Auth error:", error);
     return res.status(401).json({ error: "Authentication failed" });
   }
 }
@@ -168,7 +168,7 @@ export function requireApiKey(
   const expectedKey = process.env.CAMPAIGN_SERVICE_API_KEY;
 
   if (!expectedKey) {
-    console.error("CAMPAIGN_SERVICE_API_KEY not configured");
+    console.error("[Campaign Service] CAMPAIGN_SERVICE_API_KEY not configured");
     return res.status(500).json({ error: "API key not configured" });
   }
 

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -28,7 +28,7 @@ router.get("/campaigns", clerkAuth, requireOrg, async (req: AuthenticatedRequest
 
     res.json({ campaigns: results });
   } catch (error) {
-    console.error("List campaigns error:", error);
+    console.error("[Campaign Service] List campaigns error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -53,7 +53,7 @@ router.get("/campaigns/:id", clerkAuth, requireOrg, async (req: AuthenticatedReq
 
     res.json({ campaign });
   } catch (error) {
-    console.error("Get campaign error:", error);
+    console.error("[Campaign Service] Get campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -93,7 +93,7 @@ router.post("/campaigns", clerkAuth, requireOrg, async (req: AuthenticatedReques
 
     // Normalize the brandUrl
     const normalizedBrandUrl = normalizeUrl(brandUrl);
-    console.log(`[campaigns] Creating campaign with brandUrl: ${normalizedBrandUrl}`);
+    console.log(`[Campaign Service] Creating campaign with brandUrl: ${normalizedBrandUrl}`);
 
     const [campaign] = await db
       .insert(campaigns)
@@ -124,7 +124,7 @@ router.post("/campaigns", clerkAuth, requireOrg, async (req: AuthenticatedReques
 
     res.status(201).json({ campaign });
   } catch (error) {
-    console.error("Create campaign error:", error);
+    console.error("[Campaign Service] Create campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -159,7 +159,7 @@ router.patch("/campaigns/:id", clerkAuth, requireOrg, async (req: AuthenticatedR
 
     res.json({ campaign: updated });
   } catch (error) {
-    console.error("Update campaign error:", error);
+    console.error("[Campaign Service] Update campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -189,7 +189,7 @@ router.post("/campaigns/:id/activate", clerkAuth, requireOrg, async (req: Authen
 
     res.json({ campaign: updated });
   } catch (error) {
-    console.error("Activate campaign error:", error);
+    console.error("[Campaign Service] Activate campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -219,7 +219,7 @@ router.post("/campaigns/:id/pause", clerkAuth, requireOrg, async (req: Authentic
 
     res.json({ campaign: updated });
   } catch (error) {
-    console.error("Pause campaign error:", error);
+    console.error("[Campaign Service] Pause campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -245,7 +245,7 @@ router.delete("/campaigns/:id", clerkAuth, requireOrg, async (req: Authenticated
 
     res.json({ message: "Campaign deleted successfully" });
   } catch (error) {
-    console.error("Delete campaign error:", error);
+    console.error("[Campaign Service] Delete campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -151,7 +151,7 @@ router.get("/performance/leaderboard", requireApiKey, async (_req, res) => {
             const runs = await getRunsForCampaign(clerkOrgId, campaignId);
             brandOrgRunIds.push(...runs.map((r: Run) => r.id));
           } catch (err) {
-            console.warn(`Failed to get runs for campaign ${campaignId}:`, err);
+            console.warn(`[Campaign Service] Failed to get runs for campaign ${campaignId}:`, err);
           }
         }
 
@@ -279,7 +279,7 @@ router.get("/performance/leaderboard", requireApiKey, async (_req, res) => {
       updatedAt: new Date().toISOString(),
     });
   } catch (error) {
-    console.error("Leaderboard error:", error);
+    console.error("[Campaign Service] Leaderboard error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -305,7 +305,7 @@ router.get("/campaigns", serviceAuth, async (req: AuthenticatedRequest, res) => 
 
     res.json({ campaigns: orgCampaigns });
   } catch (error) {
-    console.error("List campaigns error:", error);
+    console.error("[Campaign Service] List campaigns error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -354,7 +354,7 @@ router.get("/campaigns/all", requireApiKey, async (_req, res) => {
 
     res.json({ campaigns: enrichedCampaigns });
   } catch (error) {
-    console.error("List all campaigns error:", error);
+    console.error("[Campaign Service] List all campaigns error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -379,7 +379,7 @@ router.get("/campaigns/:id", serviceAuth, async (req: AuthenticatedRequest, res)
 
     res.json({ campaign });
   } catch (error) {
-    console.error("Get campaign error:", error);
+    console.error("[Campaign Service] Get campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -393,7 +393,7 @@ router.get("/campaigns/:id", serviceAuth, async (req: AuthenticatedRequest, res)
  */
 router.post("/campaigns", serviceAuth, async (req: AuthenticatedRequest, res) => {
   try {
-    console.log("POST /internal/campaigns - orgId:", req.orgId, "userId:", req.userId, "body:", JSON.stringify(req.body));
+    console.log("[Campaign Service] POST /internal/campaigns - orgId:", req.orgId, "userId:", req.userId, "body:", JSON.stringify(req.body));
 
     const {
       name,
@@ -433,7 +433,7 @@ router.post("/campaigns", serviceAuth, async (req: AuthenticatedRequest, res) =>
 
     // Store brandUrl directly - brand-service will be called by worker to upsert brand
     const brandDomain = extractDomain(brandUrl);
-    console.log(`[internal/campaigns] Using brandUrl: ${brandUrl} (domain: ${brandDomain})`);
+    console.log(`[Campaign Service] Using brandUrl: ${brandUrl} (domain: ${brandDomain})`);
 
     const insertData = {
       orgId: req.orgId!,
@@ -460,7 +460,7 @@ router.post("/campaigns", serviceAuth, async (req: AuthenticatedRequest, res) =>
       status: "ongoing",
     };
 
-    console.log("Insert data:", JSON.stringify(insertData));
+    console.log("[Campaign Service] Insert data:", JSON.stringify(insertData));
 
     const [campaign] = await db
       .insert(campaigns)
@@ -469,7 +469,7 @@ router.post("/campaigns", serviceAuth, async (req: AuthenticatedRequest, res) =>
 
     res.status(201).json({ campaign });
   } catch (error: any) {
-    console.error("Create campaign error:", error.message, error.stack);
+    console.error("[Campaign Service] Create campaign error:", error.message, error.stack);
     res.status(500).json({ error: error.message || "Internal server error" });
   }
 });
@@ -503,7 +503,7 @@ router.patch("/campaigns/:id", serviceAuth, async (req: AuthenticatedRequest, re
 
     res.json({ campaign: updated });
   } catch (error) {
-    console.error("Update campaign error:", error);
+    console.error("[Campaign Service] Update campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -533,7 +533,7 @@ router.post("/campaigns/:id/stop", serviceAuth, async (req: AuthenticatedRequest
 
     res.json({ campaign: updated });
   } catch (error) {
-    console.error("Stop campaign error:", error);
+    console.error("[Campaign Service] Stop campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -563,7 +563,7 @@ router.post("/campaigns/:id/resume", serviceAuth, async (req: AuthenticatedReque
 
     res.json({ campaign: updated });
   } catch (error) {
-    console.error("Resume campaign error:", error);
+    console.error("[Campaign Service] Resume campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -591,7 +591,7 @@ router.get("/campaigns/:id/runs", serviceAuth, async (req: AuthenticatedRequest,
 
     res.json({ runs });
   } catch (error) {
-    console.error("Get campaign runs error:", error);
+    console.error("[Campaign Service] Get campaign runs error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -613,7 +613,7 @@ router.get("/campaigns/:id/runs/all", requireApiKey, async (req, res) => {
 
     res.json({ runs });
   } catch (error) {
-    console.error("Get campaign runs error:", error);
+    console.error("[Campaign Service] Get campaign runs error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -638,10 +638,10 @@ router.post("/campaigns/:id/runs", requireApiKey, async (req, res) => {
       taskName: id,
     });
 
-    console.log(`Created campaign run ${run.id} for campaign ${id}`);
+    console.log(`[Campaign Service] Created campaign run ${run.id} for campaign ${id}`);
     res.json({ run });
   } catch (error) {
-    console.error("Create campaign run error:", error);
+    console.error("[Campaign Service] Create campaign run error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -663,7 +663,7 @@ router.patch("/runs/:id", requireApiKey, async (req, res) => {
 
     res.json({ run });
   } catch (error) {
-    console.error("Update campaign run error:", error);
+    console.error("[Campaign Service] Update campaign run error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -729,7 +729,7 @@ router.get("/campaigns/:id/debug", serviceAuth, async (req: AuthenticatedRequest
 
     res.json(debug);
   } catch (error) {
-    console.error("Get campaign debug error:", error);
+    console.error("[Campaign Service] Get campaign debug error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -763,7 +763,7 @@ router.get("/campaigns/:id/stats", serviceAuth, async (req: AuthenticatedRequest
       getAggregatedStats(runIds, req.clerkOrgId!),
       runIds.length > 0
         ? getRunsBatch(runIds).catch((err) => {
-            console.warn("Failed to fetch run costs for stats:", err);
+            console.warn("[Campaign Service] Failed to fetch run costs for stats:", err);
             return new Map();
           })
         : Promise.resolve(new Map()),
@@ -802,7 +802,7 @@ router.get("/campaigns/:id/stats", serviceAuth, async (req: AuthenticatedRequest
 
     res.json(stats);
   } catch (error) {
-    console.error("Get campaign stats error:", error);
+    console.error("[Campaign Service] Get campaign stats error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -849,7 +849,7 @@ router.get("/campaigns/:id/leads", serviceAuth, async (req: AuthenticatedRequest
 
     res.json({ leads: mappedLeads });
   } catch (error) {
-    console.error("Get campaign leads error:", error);
+    console.error("[Campaign Service] Get campaign leads error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -885,7 +885,7 @@ router.get("/campaigns/:id/companies", serviceAuth, async (req: AuthenticatedReq
 
     res.json({ companies });
   } catch (error) {
-    console.error("Get campaign companies error:", error);
+    console.error("[Campaign Service] Get campaign companies error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -36,7 +36,7 @@ router.get("/campaigns/:campaignId/runs", clerkAuth, requireOrg, async (req: Aut
 
     res.json({ runs: result.runs });
   } catch (error) {
-    console.error("List runs error:", error);
+    console.error("[Campaign Service] List runs error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -64,7 +64,7 @@ router.get("/campaigns/:campaignId/runs/:runId", clerkAuth, requireOrg, async (r
 
     res.json({ run });
   } catch (error) {
-    console.error("Get run error:", error);
+    console.error("[Campaign Service] Get run error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -102,7 +102,7 @@ router.post("/campaigns/:campaignId/runs", async (req, res) => {
 
     res.status(201).json({ run });
   } catch (error) {
-    console.error("Create run error:", error);
+    console.error("[Campaign Service] Create run error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -123,7 +123,7 @@ router.patch("/runs/:runId", async (req, res) => {
 
     res.json({ run });
   } catch (error) {
-    console.error("Update run error:", error);
+    console.error("[Campaign Service] Update run error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });


### PR DESCRIPTION
Adds [Campaign Service] prefix to all console.log, console.error, and console.warn calls for consistent backend log identification. Consolidates previous inconsistent log prefixes ([campaigns], [internal/campaigns]) into a unified format.

Changes:
- 6 files modified
- ~50 log statements prefixed
- Improves log traceability across all backend operations

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>