### PR TITLE
fix: copy openapi.json in Dockerfile production stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN pnpm install --prod --frozen-lockfile || pnpm install --prod
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/drizzle ./drizzle
 COPY --from=builder /app/packages/runs-client/dist ./packages/runs-client/dist
+COPY --from=builder /app/openapi.json ./openapi.json
 
 # Force IPv4 first to avoid IPv6 connection issues with Neon
 ENV NODE_OPTIONS="--dns-result-order=ipv4first"


### PR DESCRIPTION
The openapi.json file was generated in the builder stage but not copied to the production stage, causing the /openapi.json endpoint to return 404. This adds an explicit COPY directive to include the generated spec in the final image.