### PR TITLE
feat: fix stats aggregation, add Instantly + batch-stats endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,15 @@ CLERK_SECRET_KEY='sk_live_...'
 # Service-to-service auth
 CAMPAIGN_SERVICE_API_KEY='your-campaign-service-api-key'
 
+# Downstream services (stats aggregation)
+APOLLO_SERVICE_URL='http://localhost:3003'
+APOLLO_SERVICE_API_KEY='your-apollo-api-key'
+EMAILGENERATION_SERVICE_URL='http://localhost:3004'
+EMAILGENERATION_SERVICE_API_KEY='your-emailgen-api-key'
+POSTMARK_SERVICE_URL='http://localhost:3006'
+POSTMARK_SERVICE_API_KEY='your-postmark-api-key'
+INSTANTLY_SERVICE_URL='http://localhost:3007'
+INSTANTLY_SERVICE_API_KEY='your-instantly-api-key'
+
 # Server
 PORT=3003

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -18,6 +18,6 @@ const doc = {
 };
 
 const outputFile = join(projectRoot, "openapi.json");
-const routes = [join(projectRoot, "src/index.ts")];
+const routes = [join(projectRoot, "dist/index.js")];
 
 swaggerAutogen({ openapi: "3.0.0" })(outputFile, routes, doc);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,6 +5,7 @@ process.env.CAMPAIGN_SERVICE_DATABASE_URL = process.env.CAMPAIGN_SERVICE_DATABAS
 process.env.SERVICE_SECRET_KEY = "test-service-secret";
 process.env.RUNS_SERVICE_URL = "https://runs.mcpfactory.org";
 process.env.RUNS_SERVICE_API_KEY = "test-api-key";
+process.env.CAMPAIGN_SERVICE_API_KEY = "test-api-key";
 
 beforeAll(() => console.log("Test suite starting..."));
 afterAll(() => console.log("Test suite complete."));

--- a/tests/unit/service-client.test.ts
+++ b/tests/unit/service-client.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Import after mocking fetch
+const { getAggregatedStats, getStatsByModel } = await import("../../src/lib/service-client.js");
+
+function okResponse(stats: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ stats }),
+  };
+}
+
+function errorResponse(status: number) {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: "fail" }),
+  };
+}
+
+const APOLLO_STATS = { leadsFound: 10, searchesCount: 2, totalPeopleFromSearches: 50 };
+const EMAILGEN_STATS = { emailsGenerated: 8 };
+const POSTMARK_STATS = {
+  emailsSent: 5, emailsOpened: 3, emailsClicked: 1, emailsReplied: 1, emailsBounced: 0,
+  repliesWillingToMeet: 1, repliesInterested: 0, repliesNotInterested: 0,
+  repliesOutOfOffice: 0, repliesUnsubscribe: 0,
+};
+const INSTANTLY_STATS = {
+  emailsSent: 4, emailsOpened: 2, emailsClicked: 1, emailsReplied: 0, emailsBounced: 1,
+  repliesWillingToMeet: 0, repliesInterested: 0, repliesNotInterested: 0,
+  repliesOutOfOffice: 0, repliesUnsubscribe: 0,
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("getAggregatedStats", () => {
+  it("returns empty stats with no errors for empty runIds", async () => {
+    const result = await getAggregatedStats([], "org-1");
+    expect(result.stats.leadsFound).toBe(0);
+    expect(result.stats.emailsSent).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns correct stats when all 4 services respond", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okResponse(APOLLO_STATS))
+      .mockResolvedValueOnce(okResponse(EMAILGEN_STATS))
+      .mockResolvedValueOnce(okResponse(POSTMARK_STATS))
+      .mockResolvedValueOnce(okResponse(INSTANTLY_STATS));
+
+    const result = await getAggregatedStats(["run-1"], "org-1");
+
+    expect(result.errors).toEqual([]);
+    expect(result.stats.leadsFound).toBe(10);
+    expect(result.stats.emailsGenerated).toBe(8);
+    // Postmark + Instantly summed
+    expect(result.stats.emailsSent).toBe(9);
+    expect(result.stats.emailsOpened).toBe(5);
+    expect(result.stats.emailsClicked).toBe(2);
+    expect(result.stats.emailsReplied).toBe(1);
+    expect(result.stats.emailsBounced).toBe(1);
+    expect(result.stats.repliesWillingToMeet).toBe(1);
+  });
+
+  it("reports error when one service fails, keeps other stats", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okResponse(APOLLO_STATS))
+      .mockResolvedValueOnce(okResponse(EMAILGEN_STATS))
+      .mockResolvedValueOnce(errorResponse(500)) // postmark fails
+      .mockResolvedValueOnce(okResponse(INSTANTLY_STATS));
+
+    const result = await getAggregatedStats(["run-1"], "org-1");
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].service).toBe("postmark");
+    expect(result.errors[0].error).toBe("HTTP 500");
+    // Apollo and emailgen stats still present
+    expect(result.stats.leadsFound).toBe(10);
+    expect(result.stats.emailsGenerated).toBe(8);
+    // Only instantly stats (postmark failed)
+    expect(result.stats.emailsSent).toBe(4);
+  });
+
+  it("reports 4 errors when all services fail", async () => {
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(errorResponse(503));
+
+    const result = await getAggregatedStats(["run-1"], "org-1");
+
+    expect(result.errors).toHaveLength(4);
+    expect(result.errors.map(e => e.service).sort()).toEqual(["apollo", "emailgen", "instantly", "postmark"]);
+    expect(result.stats.leadsFound).toBe(0);
+    expect(result.stats.emailsSent).toBe(0);
+  });
+
+  it("handles connection refused errors", async () => {
+    const connError = new Error("fetch failed");
+    (connError as any).cause = { code: "ECONNREFUSED" };
+
+    mockFetch
+      .mockRejectedValueOnce(connError) // apollo
+      .mockResolvedValueOnce(okResponse(EMAILGEN_STATS))
+      .mockResolvedValueOnce(okResponse(POSTMARK_STATS))
+      .mockResolvedValueOnce(okResponse(INSTANTLY_STATS));
+
+    const result = await getAggregatedStats(["run-1"], "org-1");
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual({ service: "apollo", error: "connection refused" });
+    expect(result.stats.leadsFound).toBe(0);
+    expect(result.stats.emailsSent).toBe(9); // postmark + instantly still work
+  });
+
+  it("sums postmark and instantly when both succeed", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okResponse(APOLLO_STATS))
+      .mockResolvedValueOnce(okResponse(EMAILGEN_STATS))
+      .mockResolvedValueOnce(okResponse({ ...POSTMARK_STATS, emailsSent: 10 }))
+      .mockResolvedValueOnce(okResponse({ ...INSTANTLY_STATS, emailsSent: 7 }));
+
+    const result = await getAggregatedStats(["run-1"], "org-1");
+    expect(result.stats.emailsSent).toBe(17);
+  });
+
+  it("uses only postmark stats when instantly fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce(okResponse(APOLLO_STATS))
+      .mockResolvedValueOnce(okResponse(EMAILGEN_STATS))
+      .mockResolvedValueOnce(okResponse(POSTMARK_STATS))
+      .mockResolvedValueOnce(errorResponse(500)); // instantly fails
+
+    const result = await getAggregatedStats(["run-1"], "org-1");
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].service).toBe("instantly");
+    expect(result.stats.emailsSent).toBe(5); // only postmark
+  });
+});
+
+describe("getStatsByModel", () => {
+  it("returns empty stats for empty runIds", async () => {
+    const result = await getStatsByModel([]);
+    expect(result.stats).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns model stats on success", async () => {
+    const modelData = [
+      { model: "gpt-4o", count: 5, runIds: ["run-1"] },
+      { model: "claude-sonnet", count: 3, runIds: ["run-2"] },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ stats: modelData }),
+    });
+
+    const result = await getStatsByModel(["run-1", "run-2"]);
+    expect(result.stats).toEqual(modelData);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns error on failure", async () => {
+    mockFetch.mockResolvedValueOnce(errorResponse(500));
+
+    const result = await getStatsByModel(["run-1"]);
+    expect(result.stats).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].service).toBe("emailgen");
+  });
+});


### PR DESCRIPTION
## Summary
- **Fix stats returning silent 0s**: Refactored `fetchStats` to return `ServiceResult<T>` with explicit errors instead of `null`, so callers can distinguish real zeros from downstream failures
- **Add Instantly as 4th stats source**: Postmark + Instantly email metrics are now summed (a campaign uses one or the other)
- **Add `POST /internal/campaigns/batch-stats`** endpoint for bulk stats retrieval with `requireApiKey` auth
- **Fix OpenAPI generation**: Point `swagger-autogen` at compiled `dist/index.js` instead of source `src/index.ts`
- **Add unit tests**: 10 test cases covering all-services-OK, partial failures, connection refused, and Postmark+Instantly summing

## Test plan
- [x] `pnpm test:unit` — 15/15 tests pass (10 new + 5 existing)
- [x] `pnpm build` — TypeScript compiles clean, `openapi.json` generated
- [ ] Integration tests with live downstream services (apollo, emailgen, postmark, instantly)
- [ ] Verify `serviceErrors` field surfaces correctly in api-service consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)