### PR TITLE
test: add appId column tests to prevent regression

### DIFF
--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -48,6 +48,7 @@ export async function insertTestCampaign(
     maxBudgetTotalUsd?: string;
     personTitles?: string[];
     organizationLocations?: string[];
+    appId?: string;
   } = {}
 ) {
   const [campaign] = await db
@@ -60,6 +61,7 @@ export async function insertTestCampaign(
       maxBudgetTotalUsd: data.maxBudgetTotalUsd,
       personTitles: data.personTitles,
       organizationLocations: data.organizationLocations,
+      appId: data.appId || null,
     })
     .returning();
   return campaign;


### PR DESCRIPTION
## Summary

Add 4 integration tests that verify the `appId` column is properly stored and returned in campaign queries. These tests exercise the exact query patterns (`.findFirst()` and `.select()`) that were failing in production due to the missing migration.

The tests ensure that if the database migration for the `app_id` column is ever not applied, the test suite will immediately catch the error before deployment.

## Test plan

- Tests verify appId can be set when creating campaigns
- Tests verify appId is nullable
- Tests verify `.findFirst()` queries include appId
- Tests verify `.select()` queries include appId