### PR TITLE
refactor: rename batch-stats endpoint to batch-budget-usage

### DIFF
--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -9,7 +9,7 @@ import {
   UpdateCampaignBody,
   StatsFilterBody,
   StatsResponse,
-  BatchStatsBody,
+  BatchBudgetUsageBody,
   RunStatusUpdate,
   ErrorResponse,
 } from "../src/schemas.js";
@@ -239,12 +239,12 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/campaigns/batch-stats",
+  path: "/campaigns/batch-budget-usage",
   tags: ["Scheduler"],
-  summary: "Get stats for multiple campaigns",
-  description: "Returns campaign DB data + run counts for each campaign",
+  summary: "Get cost and run data for multiple campaigns",
+  description: "Returns budget usage (totalCostInUsdCents) and run counts per campaign",
   security: [{ [apiKeyAuth.name]: [] }],
-  request: { body: { content: { "application/json": { schema: BatchStatsBody } } } },
+  request: { body: { content: { "application/json": { schema: BatchBudgetUsageBody } } } },
   responses: {
     200: {
       description: "Stats per campaign",

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -6,7 +6,7 @@ import { clerkAuth, requireOrg, requireApiKey, AuthenticatedRequest } from "../m
 import { validateBody } from "../middleware/validate.js";
 import { normalizeUrl, extractDomain } from "../lib/domain.js";
 import { ensureOrganization, listRuns, getRunsBatch, type Run, type RunWithCosts } from "@mcpfactory/runs-client";
-import { CreateCampaignBody, UpdateCampaignBody, StatsFilterBody, BatchStatsBody } from "../schemas.js";
+import { CreateCampaignBody, UpdateCampaignBody, StatsFilterBody, BatchBudgetUsageBody } from "../schemas.js";
 
 const router = Router();
 
@@ -57,9 +57,9 @@ router.get("/campaigns/list", requireApiKey, async (_req, res) => {
 });
 
 /**
- * POST /campaigns/batch-stats - Get stats for multiple campaigns
+ * POST /campaigns/batch-budget-usage - Get cost and run data for multiple campaigns
  */
-router.post("/campaigns/batch-stats", requireApiKey, validateBody(BatchStatsBody), async (req, res) => {
+router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBudgetUsageBody), async (req, res) => {
   try {
     const { campaignIds } = req.body;
 
@@ -121,7 +121,7 @@ router.post("/campaigns/batch-stats", requireApiKey, validateBody(BatchStatsBody
             totalCostInUsdCents: totalCostInUsdCents > 0 ? String(totalCostInUsdCents) : null,
           };
         } catch (err) {
-          console.warn(`[Campaign Service] Batch stats failed for campaign ${campaignId}:`, err);
+          console.warn(`[Campaign Service] Batch budget usage failed for campaign ${campaignId}:`, err);
           results[campaignId] = { error: "Failed to fetch stats" };
         }
       })
@@ -129,7 +129,7 @@ router.post("/campaigns/batch-stats", requireApiKey, validateBody(BatchStatsBody
 
     res.json({ results });
   } catch (error) {
-    console.error("[Campaign Service] Batch stats error:", error);
+    console.error("[Campaign Service] Batch budget usage error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -107,11 +107,11 @@ export const StatsResponse = z.object({
   }),
 }).openapi("StatsResponse");
 
-// --- Batch stats ---
+// --- Batch budget usage ---
 
-export const BatchStatsBody = z.object({
+export const BatchBudgetUsageBody = z.object({
   campaignIds: z.array(z.string()).min(1, "campaignIds array is required"),
-}).openapi("BatchStatsBody");
+}).openapi("BatchBudgetUsageBody");
 
 // --- Run status ---
 


### PR DESCRIPTION
Make the endpoint purpose clearer: it fetches campaign cost consumption (totalCostInUsdCents) and run data for budget enforcement.