### PR TITLE
refactor: unify auth to X-API-Key for all endpoints

### DIFF
--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -20,13 +20,6 @@ const __dirname = dirname(__filename);
 const registry = new OpenAPIRegistry();
 
 // --- Security schemes ---
-const bearerAuth = registry.registerComponent("securitySchemes", "bearerAuth", {
-  type: "http",
-  scheme: "bearer",
-  bearerFormat: "JWT",
-  description: "Clerk JWT token",
-});
-
 const apiKeyAuth = registry.registerComponent("securitySchemes", "apiKeyAuth", {
   type: "apiKey",
   in: "header",
@@ -69,7 +62,7 @@ registry.registerPath({
   path: "/campaigns",
   tags: ["Campaigns"],
   summary: "List campaigns for org",
-  security: [{ [bearerAuth.name]: [] }],
+  security: [{ [apiKeyAuth.name]: [] }],
   request: { query: z.object({ brandId: z.string().optional() }).openapi("CampaignsQuery") },
   responses: {
     200: { description: "List of campaigns", content: { "application/json": { schema: z.object({ campaigns: z.array(CampaignSchema) }) } } },
@@ -82,7 +75,7 @@ registry.registerPath({
   path: "/campaigns/{id}",
   tags: ["Campaigns"],
   summary: "Get a specific campaign",
-  security: [{ [bearerAuth.name]: [] }],
+  security: [{ [apiKeyAuth.name]: [] }],
   request: { params: z.object({ id: z.string().uuid() }) },
   responses: {
     200: { description: "Campaign details", content: { "application/json": { schema: z.object({ campaign: CampaignSchema }) } } },
@@ -95,7 +88,7 @@ registry.registerPath({
   path: "/campaigns",
   tags: ["Campaigns"],
   summary: "Create a new campaign",
-  security: [{ [bearerAuth.name]: [] }],
+  security: [{ [apiKeyAuth.name]: [] }],
   request: { body: { content: { "application/json": { schema: CreateCampaignBody } } } },
   responses: {
     201: { description: "Campaign created", content: { "application/json": { schema: z.object({ campaign: CampaignSchema }) } } },
@@ -108,7 +101,7 @@ registry.registerPath({
   path: "/campaigns/{id}",
   tags: ["Campaigns"],
   summary: "Update a campaign",
-  security: [{ [bearerAuth.name]: [] }],
+  security: [{ [apiKeyAuth.name]: [] }],
   request: {
     params: z.object({ id: z.string().uuid() }),
     body: { content: { "application/json": { schema: UpdateCampaignBody } } },
@@ -124,7 +117,7 @@ registry.registerPath({
   path: "/campaigns/{id}",
   tags: ["Campaigns"],
   summary: "Delete a campaign",
-  security: [{ [bearerAuth.name]: [] }],
+  security: [{ [apiKeyAuth.name]: [] }],
   request: { params: z.object({ id: z.string().uuid() }) },
   responses: {
     200: { description: "Campaign deleted", content: { "application/json": { schema: z.object({ message: z.string() }) } } },
@@ -161,7 +154,7 @@ registry.registerPath({
   path: "/campaigns/{campaignId}/runs",
   tags: ["Runs"],
   summary: "List runs for a campaign",
-  security: [{ [bearerAuth.name]: [] }],
+  security: [{ [apiKeyAuth.name]: [] }],
   request: { params: z.object({ campaignId: z.string().uuid() }) },
   responses: {
     200: { description: "List of runs", content: { "application/json": { schema: z.object({ runs: z.array(RunSchema) }) } } },
@@ -174,7 +167,7 @@ registry.registerPath({
   path: "/campaigns/{campaignId}/runs/{runId}",
   tags: ["Runs"],
   summary: "Get a specific run",
-  security: [{ [bearerAuth.name]: [] }],
+  security: [{ [apiKeyAuth.name]: [] }],
   request: { params: z.object({ campaignId: z.string().uuid(), runId: z.string().uuid() }) },
   responses: {
     200: { description: "Run details", content: { "application/json": { schema: z.object({ run: RunSchema }) } } },

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,4 @@
 import { Request, Response, NextFunction } from "express";
-import { verifyToken } from "@clerk/backend";
 import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { users, orgs } from "../db/schema.js";
@@ -70,74 +69,6 @@ export async function serviceAuth(
   } catch (error) {
     console.error("[Campaign Service] Service auth error:", error);
     return res.status(401).json({ error: "Service authentication failed" });
-  }
-}
-
-/**
- * Middleware to authenticate via Clerk JWT
- */
-export async function clerkAuth(
-  req: AuthenticatedRequest,
-  res: Response,
-  next: NextFunction
-) {
-  try {
-    const authHeader = req.headers.authorization;
-    if (!authHeader?.startsWith("Bearer ")) {
-      return res.status(401).json({ error: "Missing authorization header" });
-    }
-
-    const token = authHeader.slice(7);
-
-    const payload = await verifyToken(token, {
-      secretKey: process.env.CLERK_SECRET_KEY,
-    });
-    
-    const clerkUserId = payload.sub;
-    const clerkOrgId = payload.org_id;
-
-    if (!clerkUserId) {
-      return res.status(401).json({ error: "Invalid token" });
-    }
-
-    // Find or create user
-    let user = await db.query.users.findFirst({
-      where: eq(users.clerkUserId, clerkUserId),
-    });
-
-    if (!user) {
-      const [newUser] = await db
-        .insert(users)
-        .values({ clerkUserId })
-        .returning();
-      user = newUser;
-    }
-
-    req.userId = user.id;
-    req.clerkUserId = clerkUserId;
-
-    // Find or create org if present
-    if (clerkOrgId) {
-      let org = await db.query.orgs.findFirst({
-        where: eq(orgs.clerkOrgId, clerkOrgId),
-      });
-
-      if (!org) {
-        const [newOrg] = await db
-          .insert(orgs)
-          .values({ clerkOrgId })
-          .returning();
-        org = newOrg;
-      }
-
-      req.orgId = org.id;
-      req.clerkOrgId = clerkOrgId;
-    }
-
-    next();
-  } catch (error) {
-    console.error("[Campaign Service] Auth error:", error);
-    return res.status(401).json({ error: "Authentication failed" });
   }
 }
 

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { eq, and, desc, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { campaigns, orgs } from "../db/schema.js";
-import { clerkAuth, requireOrg, requireApiKey, AuthenticatedRequest } from "../middleware/auth.js";
+import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { normalizeUrl, extractDomain } from "../lib/domain.js";
 import { ensureOrganization, listRuns, getRunsBatch, type Run, type RunWithCosts } from "@mcpfactory/runs-client";
@@ -190,7 +190,7 @@ router.post("/campaigns/stats", requireApiKey, validateBody(StatsFilterBody), as
 /**
  * GET /campaigns - List all campaigns for org
  */
-router.get("/campaigns", clerkAuth, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.get("/campaigns", requireApiKey, serviceAuth, async (req: AuthenticatedRequest, res) => {
   try {
     const { brandId } = req.query;
 
@@ -214,7 +214,7 @@ router.get("/campaigns", clerkAuth, requireOrg, async (req: AuthenticatedRequest
 /**
  * GET /campaigns/:id - Get a specific campaign
  */
-router.get("/campaigns/:id", clerkAuth, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.get("/campaigns/:id", requireApiKey, serviceAuth, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
 
@@ -239,7 +239,7 @@ router.get("/campaigns/:id", clerkAuth, requireOrg, async (req: AuthenticatedReq
 /**
  * POST /campaigns - Create a new campaign
  */
-router.post("/campaigns", clerkAuth, requireOrg, validateBody(CreateCampaignBody), async (req: AuthenticatedRequest, res) => {
+router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaignBody), async (req: AuthenticatedRequest, res) => {
   try {
     const {
       name,
@@ -303,7 +303,7 @@ router.post("/campaigns", clerkAuth, requireOrg, validateBody(CreateCampaignBody
 /**
  * PATCH /campaigns/:id - Update a campaign (including status: "active" | "stopped")
  */
-router.patch("/campaigns/:id", clerkAuth, requireOrg, validateBody(UpdateCampaignBody), async (req: AuthenticatedRequest, res) => {
+router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCampaignBody), async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
 
@@ -340,7 +340,7 @@ router.patch("/campaigns/:id", clerkAuth, requireOrg, validateBody(UpdateCampaig
 /**
  * DELETE /campaigns/:id - Delete a campaign
  */
-router.delete("/campaigns/:id", clerkAuth, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.delete("/campaigns/:id", requireApiKey, serviceAuth, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
 

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { campaigns, orgs } from "../db/schema.js";
-import { clerkAuth, requireOrg, requireApiKey, AuthenticatedRequest } from "../middleware/auth.js";
+import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { ensureOrganization, listRuns, getRun, createRun, updateRun } from "@mcpfactory/runs-client";
 import { RunStatusUpdate } from "../schemas.js";
@@ -53,7 +53,7 @@ router.get("/campaigns/:campaignId/runs/list", requireApiKey, async (req, res) =
 /**
  * GET /campaigns/:campaignId/runs - List all runs for a campaign
  */
-router.get("/campaigns/:campaignId/runs", clerkAuth, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.get("/campaigns/:campaignId/runs", requireApiKey, serviceAuth, async (req: AuthenticatedRequest, res) => {
   try {
     const { campaignId } = req.params;
 
@@ -85,7 +85,7 @@ router.get("/campaigns/:campaignId/runs", clerkAuth, requireOrg, async (req: Aut
 /**
  * GET /campaigns/:campaignId/runs/:runId - Get a specific run
  */
-router.get("/campaigns/:campaignId/runs/:runId", clerkAuth, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.get("/campaigns/:campaignId/runs/:runId", requireApiKey, serviceAuth, async (req: AuthenticatedRequest, res) => {
   try {
     const { campaignId, runId } = req.params;
 


### PR DESCRIPTION
## Summary
Unified authentication across campaign-service to use X-API-Key headers instead of Clerk JWT Bearer tokens. All endpoints now use `requireApiKey` middleware, with org/user context passed via `x-clerk-org-id` and `x-clerk-user-id` headers through `serviceAuth` middleware.

## Changes
- Removed `clerkAuth` middleware (Clerk JWT verification)
- Updated all campaign and runs endpoints to use `requireApiKey` + `serviceAuth`
- Updated OpenAPI spec to reflect X-API-Key as the sole security scheme
- Removed unused `@clerk/backend` import

## Testing
All endpoints now expect:
- `x-api-key` header for authentication
- `x-clerk-org-id` header for org context
- `x-clerk-user-id` header (optional) for user context