### PR TITLE
fix: allow non-UUID appId values (e.g., "mcpfactory")

### DIFF
--- a/drizzle/0010_app_id_to_text.sql
+++ b/drizzle/0010_app_id_to_text.sql
@@ -1,0 +1,3 @@
+-- Change app_id from uuid to text to support non-UUID identifiers (e.g. "mcpfactory")
+
+ALTER TABLE "campaigns" ALTER COLUMN "app_id" SET DATA TYPE text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1770400000000,
       "tag": "0009_normalize_status",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1770500000000,
+      "tag": "0010_app_id_to_text",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -50,7 +50,7 @@ export const campaigns = pgTable(
 
     // App ID from external app/product service
     // Nullable, populated when campaign is associated with an app
-    appId: uuid("app_id"),
+    appId: text("app_id"),
 
     // Apollo targeting criteria (using Apollo API naming)
     personTitles: text("person_titles").array(),           // ["CEO", "CTO", "Founder"]

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -16,7 +16,7 @@ export const CampaignSchema = z.object({
   name: z.string(),
   brandUrl: z.string().nullable(),
   brandId: z.string().uuid().nullable(),
-  appId: z.string().uuid().nullable(),
+  appId: z.string().nullable(),
   personTitles: z.array(z.string()).nullable(),
   qOrganizationKeywordTags: z.array(z.string()).nullable(),
   organizationLocations: z.array(z.string()).nullable(),
@@ -60,7 +60,7 @@ export const CreateCampaignBody = z.object({
   notifyFrequency: z.string().optional(),
   notifyChannel: z.string().optional(),
   notifyDestination: z.string().optional(),
-  appId: z.string().uuid().optional(),
+  appId: z.string().optional(),
 }).openapi("CreateCampaignBody");
 
 export const UpdateCampaignBody = z.object({
@@ -83,7 +83,7 @@ export const UpdateCampaignBody = z.object({
   notifyFrequency: z.string().optional(),
   notifyChannel: z.string().optional(),
   notifyDestination: z.string().optional(),
-  appId: z.string().uuid().optional(),
+  appId: z.string().optional(),
 }).openapi("UpdateCampaignBody");
 
 // --- Stats ---


### PR DESCRIPTION
## Summary
Fixed 400 "Invalid UUID" error when creating campaigns with non-UUID appId values like "mcpfactory".

## Changes
- Changed `appId` column from `uuid` to `text` type
- Removed `.uuid()` validation from Zod schemas
- Added database migration to convert column type

## Testing
All 26 tests pass.