### PR TITLE
feat: accept brandId in create/update campaign endpoints

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -244,6 +244,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     const {
       name,
       brandUrl,
+      brandId,
       personTitles,
       qOrganizationKeywordTags,
       organizationLocations,
@@ -274,6 +275,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         name,
         appId: appId || null,
         brandUrl: normalizedBrandUrl,
+        brandId: brandId || null,
         personTitles,
         qOrganizationKeywordTags,
         organizationLocations,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -45,6 +45,7 @@ export const CampaignSchema = z.object({
 export const CreateCampaignBody = z.object({
   name: z.string().min(1, "Campaign name is required"),
   brandUrl: z.string().min(1, "brandUrl is required"),
+  brandId: z.string().uuid().optional(),
   personTitles: z.array(z.string()).optional(),
   qOrganizationKeywordTags: z.array(z.string()).optional(),
   organizationLocations: z.array(z.string()).optional(),
@@ -67,6 +68,7 @@ export const CreateCampaignBody = z.object({
 export const UpdateCampaignBody = z.object({
   name: z.string().optional(),
   brandUrl: z.string().optional(),
+  brandId: z.string().uuid().optional(),
   personTitles: z.array(z.string()).optional(),
   qOrganizationKeywordTags: z.array(z.string()).optional(),
   organizationLocations: z.array(z.string()).optional(),

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -49,6 +49,7 @@ export async function insertTestCampaign(
     personTitles?: string[];
     organizationLocations?: string[];
     appId?: string;
+    brandId?: string;
   } = {}
 ) {
   const [campaign] = await db
@@ -62,6 +63,7 @@ export async function insertTestCampaign(
       personTitles: data.personTitles,
       organizationLocations: data.organizationLocations,
       appId: data.appId || null,
+      brandId: data.brandId || null,
     })
     .returning();
   return campaign;

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -88,6 +88,42 @@ describe("Campaign Service Database", () => {
       expect(results[0].appId).toBe(appId);
     });
 
+    it("should create a campaign with brandId", async () => {
+      const org = await insertTestOrg();
+      const brandId = crypto.randomUUID();
+      const campaign = await insertTestCampaign(org.id, {
+        name: "Brand Campaign",
+        brandId,
+      });
+
+      expect(campaign.brandId).toBe(brandId);
+    });
+
+    it("should store null brandId when not provided", async () => {
+      const org = await insertTestOrg();
+      const campaign = await insertTestCampaign(org.id, {
+        name: "No Brand Campaign",
+      });
+
+      expect(campaign.brandId).toBeNull();
+    });
+
+    it("should query campaigns by brandId", async () => {
+      const org = await insertTestOrg();
+      const brandId = crypto.randomUUID();
+      await insertTestCampaign(org.id, { name: "With Brand", brandId });
+      await insertTestCampaign(org.id, { name: "Without Brand" });
+
+      const results = await db
+        .select()
+        .from(campaigns)
+        .where(eq(campaigns.brandId, brandId));
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe("With Brand");
+      expect(results[0].brandId).toBe(brandId);
+    });
+
     it("should cascade delete when org is deleted", async () => {
       const org = await insertTestOrg();
       const campaign = await insertTestCampaign(org.id);


### PR DESCRIPTION
## Summary
- Added `brandId` (optional UUID) to `CreateCampaignBody` and `UpdateCampaignBody` Zod schemas
- Updated `POST /campaigns` handler to destructure and persist `brandId`
- `PATCH /campaigns/:id` already spreads `req.body` so it picks up `brandId` automatically
- Added 3 integration tests for `brandId` persistence and querying

**Root cause:** Campaigns were always created with `brand_id = NULL` because the schema didn't accept the field. The dashboard filters by `brandId`, so it showed zero campaigns for any brand.

**Fix:** The worker (after calling `upsertBrand(brandUrl)`) can now pass `brandId` to campaign-service on create or update.

## Test plan
- [x] 29/29 tests pass (3 new brandId tests)
- [x] Build + OpenAPI regeneration succeeds
- [ ] Verify dashboard shows campaigns after worker sets brandId

🤖 Generated with [Claude Code](https://claude.com/claude-code)