### PR TITLE
feat: make brandId, appId, clerkOrgId required for campaign creation

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -245,6 +245,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       name,
       brandUrl,
       brandId,
+      appId,
       personTitles,
       qOrganizationKeywordTags,
       organizationLocations,
@@ -261,7 +262,6 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       notifyFrequency,
       notifyChannel,
       notifyDestination,
-      appId,
     } = req.body;
 
     const normalizedBrandUrl = normalizeUrl(brandUrl);
@@ -271,11 +271,11 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       .insert(campaigns)
       .values({
         orgId: req.orgId!,
-        createdByUserId: req.userId!,
+        createdByUserId: req.userId ?? null,
         name,
-        appId: appId || null,
+        appId,
         brandUrl: normalizedBrandUrl,
-        brandId: brandId || null,
+        brandId,
         personTitles,
         qOrganizationKeywordTags,
         organizationLocations,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -44,8 +44,10 @@ export const CampaignSchema = z.object({
 
 export const CreateCampaignBody = z.object({
   name: z.string().min(1, "Campaign name is required"),
+  clerkOrgId: z.string().min(1, "clerkOrgId is required"),
   brandUrl: z.string().min(1, "brandUrl is required"),
-  brandId: z.string().uuid().optional(),
+  brandId: z.string().uuid("brandId must be a valid UUID"),
+  appId: z.string().min(1, "appId is required"),
   personTitles: z.array(z.string()).optional(),
   qOrganizationKeywordTags: z.array(z.string()).optional(),
   organizationLocations: z.array(z.string()).optional(),
@@ -62,7 +64,6 @@ export const CreateCampaignBody = z.object({
   notifyFrequency: z.string().optional(),
   notifyChannel: z.string().optional(),
   notifyDestination: z.string().optional(),
-  appId: z.string().optional(),
 }).openapi("CreateCampaignBody");
 
 export const UpdateCampaignBody = z.object({

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import app from "../../src/index.js";
+import { cleanTestData, closeDb, insertTestOrg } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+
+describe("Campaign CRUD", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  const validBody = {
+    name: "Test Campaign",
+    clerkOrgId: "org_test_crud",
+    brandUrl: "https://example.com",
+    brandId: crypto.randomUUID(),
+    appId: "mcpfactory",
+  };
+
+  describe("POST /campaigns", () => {
+    it("should create a campaign with all required fields", async () => {
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send(validBody)
+        .expect(201);
+
+      expect(res.body.campaign).toBeDefined();
+      expect(res.body.campaign.name).toBe("Test Campaign");
+      expect(res.body.campaign.brandId).toBe(validBody.brandId);
+      expect(res.body.campaign.appId).toBe("mcpfactory");
+    });
+
+    it("should reject when brandId is missing", async () => {
+      const { brandId, ...body } = validBody;
+
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send(body)
+        .expect(400);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it("should reject when appId is missing", async () => {
+      const { appId, ...body } = validBody;
+
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send(body)
+        .expect(400);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it("should reject when clerkOrgId is missing from body", async () => {
+      const { clerkOrgId, ...body } = validBody;
+
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send(body)
+        .expect(400);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it("should reject when brandId is not a valid UUID", async () => {
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send({ ...validBody, brandId: "not-a-uuid" })
+        .expect(400);
+
+      expect(res.body.error).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `brandId` (UUID), `appId` (string), and `clerkOrgId` (string) are now **required** in `CreateCampaignBody`
- Fixes `createdByUserId` to use `?? null` instead of `!` assertion (avoids Postgres errors when no user context)
- Adds 5 API-level integration tests for the required field validation

## Test plan
- [x] 34/34 tests pass (5 new campaign CRUD tests)
- [x] Build + OpenAPI regeneration succeeds
- [ ] Verify Railway deploys after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)