### PR TITLE
feat: add cold email outreach workflow via windmill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,5 +24,9 @@ INSTANTLY_SERVICE_API_KEY='your-instantly-api-key'
 LEAD_SERVICE_URL='http://localhost:3008'
 LEAD_SERVICE_API_KEY='your-lead-api-key'
 
+# Windmill (workflow orchestration)
+WINDMILL_SERVICE_URL='https://windmill.mcpfactory.org'
+WINDMILL_SERVICE_API_KEY='your-windmill-api-key'
+
 # Server
 PORT=3003

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ const openapiPath = join(__dirname, "..", "openapi.json");
 import healthRoutes from "./routes/health.js";
 import campaignsRoutes from "./routes/campaigns.js";
 import runsRoutes from "./routes/runs.js";
+import { deployWorkflows } from "./lib/workflows.js";
 const app = express();
 const PORT = process.env.PORT || 3003;
 
@@ -62,6 +63,9 @@ if (process.env.NODE_ENV !== "test") {
   migrate(db, { migrationsFolder: "./drizzle" })
     .then(() => {
       console.log("[Campaign Service] Migrations complete");
+      deployWorkflows().catch((err) => {
+        console.error("[Campaign Service] Workflow deployment error:", err);
+      });
       app.listen(Number(PORT), "::", () => {
         console.log(`[Campaign Service] Running on port ${PORT}`);
       });

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -1,0 +1,291 @@
+const COLD_EMAIL_PROMPT = `You are an expert sales copywriter. Write a personalized cold email for a potential client.
+
+## Recipient Information
+{{recipientInfo}}
+
+## Sender / Our Company
+{{senderInfo}}
+
+## Reference: Cold Email Frameworks
+Use your expertise to craft the email. Here are proven frameworks for reference:
+
+**PAS (Problem-Agitate-Solution)**
+Identify a problem, amplify its consequences, present solution.
+
+**BAB (Before-After-Bridge)**
+Describe current pain (Before), paint ideal future (After), position solution as the bridge.
+
+**AIDA (Attention-Interest-Desire-Action)**
+Hook attention, build interest with value, create desire, end with CTA.
+
+**SPIN (Situation-Problem-Implication-Need-Payoff)**
+Acknowledge situation, surface problems, explore implications, highlight payoff.
+
+## Reference: Industry Best Practices (Gong Research, 28M+ emails analyzed)
+- Avoid product pitches in cold emails (reduces replies by 57%)
+- Use interest CTAs ("thoughts?" not "15 min call?") - 2x more effective
+- Avoid buzzwords in subject lines (reduces open rates by 17.9%)
+- No ROI claims, no "AI", no jargon in first touch
+- Focus on problems you solve, not features you have
+
+## Task
+Write a compelling cold email using your judgment. Apply or combine frameworks as you see fit based on the data provided.
+
+Keep it short (3-4 sentences max). Be genuine, not salesy. End with a low-friction CTA.
+Do NOT use placeholder text like [Your Name]. Do NOT add any signature block — it will be appended automatically.
+
+## Output Format
+SUBJECT: [subject line]
+---
+[email body in plain text]`;
+
+const APP_ID = "mcpfactory";
+
+function buildColdEmailDag() {
+  return {
+    nodes: [
+      {
+        id: "register-prompt",
+        type: "http.call",
+        config: {
+          service: "emailgeneration",
+          method: "PUT",
+          path: "/prompts",
+          body: {
+            appId: APP_ID,
+            type: "cold-email",
+            prompt: COLD_EMAIL_PROMPT,
+            variables: ["recipientInfo", "senderInfo"],
+          },
+        },
+        inputMapping: {
+          "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
+        },
+      },
+      {
+        id: "extract-brand",
+        type: "http.call",
+        config: {
+          service: "brand",
+          method: "POST",
+          path: "/sales-profile",
+          body: { appId: APP_ID },
+        },
+        inputMapping: {
+          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+          "body.url": "$ref:flow_input.brandUrl",
+          "body.clerkUserId": "$ref:flow_input.clerkUserId",
+          "body.parentRunId": "$ref:flow_input.runId",
+        },
+      },
+      {
+        id: "suggest-icp",
+        type: "http.call",
+        config: {
+          service: "brand",
+          method: "POST",
+          path: "/icp-suggestion",
+          body: { appId: APP_ID },
+        },
+        inputMapping: {
+          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+          "body.url": "$ref:flow_input.brandUrl",
+          "body.clerkUserId": "$ref:flow_input.clerkUserId",
+          "body.targetAudience": "$ref:flow_input.targetAudience",
+        },
+      },
+      {
+        id: "search-leads",
+        type: "http.call",
+        config: {
+          service: "apollo",
+          method: "POST",
+          path: "/search",
+          body: { appId: APP_ID, perPage: 25 },
+        },
+        inputMapping: {
+          "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
+          "body.brandId": "$ref:flow_input.brandId",
+          "body.campaignId": "$ref:flow_input.campaignId",
+          "body.runId": "$ref:flow_input.runId",
+          "body.personTitles": "$ref:suggest-icp.output.suggestion.personTitles",
+          "body.qOrganizationKeywordTags": "$ref:suggest-icp.output.suggestion.qOrganizationKeywordTags",
+          "body.organizationLocations": "$ref:suggest-icp.output.suggestion.organizationLocations",
+        },
+      },
+      {
+        id: "process-leads",
+        type: "for-each",
+        config: {
+          iterator: "$ref:search-leads.output.people",
+          skipFailures: true,
+          dag: {
+            nodes: [
+              {
+                id: "enrich-lead",
+                type: "http.call",
+                config: {
+                  service: "apollo",
+                  method: "POST",
+                  path: "/enrich",
+                  body: { appId: APP_ID },
+                },
+                inputMapping: {
+                  "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
+                  "body.apolloPersonId": "$ref:item.id",
+                  "body.brandId": "$ref:flow_input.brandId",
+                  "body.campaignId": "$ref:flow_input.campaignId",
+                  "body.runId": "$ref:flow_input.runId",
+                },
+              },
+              {
+                id: "generate-email",
+                type: "http.call",
+                config: {
+                  service: "emailgeneration",
+                  method: "POST",
+                  path: "/generate",
+                  body: { appId: APP_ID, type: "cold-email" },
+                },
+                inputMapping: {
+                  "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
+                  "body.runId": "$ref:flow_input.runId",
+                  "body.brandId": "$ref:flow_input.brandId",
+                  "body.campaignId": "$ref:flow_input.campaignId",
+                  "body.apolloEnrichmentId": "$ref:enrich-lead.output.enrichmentId",
+                  "body.variables.recipientInfo": "$ref:enrich-lead.output.person",
+                  "body.variables.senderInfo": "$ref:flow_input.senderInfo",
+                },
+              },
+              {
+                id: "send-email",
+                type: "http.call",
+                config: {
+                  service: "email-gateway",
+                  method: "POST",
+                  path: "/send",
+                  body: { type: "broadcast", appId: APP_ID },
+                },
+                inputMapping: {
+                  "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+                  "body.brandId": "$ref:flow_input.brandId",
+                  "body.campaignId": "$ref:flow_input.campaignId",
+                  "body.runId": "$ref:flow_input.runId",
+                  "body.to": "$ref:enrich-lead.output.person.email",
+                  "body.recipientFirstName": "$ref:enrich-lead.output.person.firstName",
+                  "body.recipientLastName": "$ref:enrich-lead.output.person.lastName",
+                  "body.recipientCompany": "$ref:enrich-lead.output.person.organizationName",
+                  "body.subject": "$ref:generate-email.output.subject",
+                  "body.htmlBody": "$ref:generate-email.output.bodyHtml",
+                  "body.textBody": "$ref:generate-email.output.bodyText",
+                },
+              },
+            ],
+            edges: [
+              { from: "enrich-lead", to: "generate-email" },
+              { from: "generate-email", to: "send-email" },
+            ],
+          },
+        },
+      },
+    ],
+    edges: [
+      { from: "register-prompt", to: "extract-brand" },
+      { from: "extract-brand", to: "suggest-icp" },
+      { from: "suggest-icp", to: "search-leads" },
+      { from: "search-leads", to: "process-leads" },
+    ],
+  };
+}
+
+export async function deployWorkflows(): Promise<void> {
+  const url = process.env.WINDMILL_SERVICE_URL;
+  const apiKey = process.env.WINDMILL_SERVICE_API_KEY;
+
+  if (!url || !apiKey) {
+    console.warn("[Campaign Service] WINDMILL_SERVICE_URL or WINDMILL_SERVICE_API_KEY not set, skipping workflow deployment");
+    return;
+  }
+
+  const res = await fetch(`${url}/workflows/deploy`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+    },
+    body: JSON.stringify({
+      appId: APP_ID,
+      workflows: [
+        {
+          name: "cold-email-outreach",
+          description: "Full cold email pipeline: prompt → brand → ICP → leads → enrich → generate → send",
+          dag: buildColdEmailDag(),
+        },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`[Campaign Service] Workflow deployment failed (${res.status}):`, body);
+    return;
+  }
+
+  const data = await res.json();
+  console.log("[Campaign Service] Workflows deployed:", data.workflows?.map((w: { name: string; action: string }) => `${w.name} (${w.action})`).join(", "));
+}
+
+interface CampaignWorkflowInputs {
+  brandId: string;
+  brandUrl: string;
+  campaignId: string;
+  clerkOrgId: string;
+  clerkUserId?: string;
+  targetAudience?: string | null;
+  targetOutcome?: string | null;
+  valueForTarget?: string | null;
+  salesProfile?: unknown;
+}
+
+export async function executeColdEmailOutreach(inputs: CampaignWorkflowInputs): Promise<void> {
+  const url = process.env.WINDMILL_SERVICE_URL;
+  const apiKey = process.env.WINDMILL_SERVICE_API_KEY;
+
+  if (!url || !apiKey) {
+    console.warn("[Campaign Service] WINDMILL_SERVICE_URL or WINDMILL_SERVICE_API_KEY not set, skipping workflow execution");
+    return;
+  }
+
+  const res = await fetch(`${url}/workflows/by-name/cold-email-outreach/execute`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+    },
+    body: JSON.stringify({
+      appId: APP_ID,
+      orgId: inputs.clerkOrgId,
+      inputs: {
+        brandId: inputs.brandId,
+        brandUrl: inputs.brandUrl,
+        campaignId: inputs.campaignId,
+        clerkOrgId: inputs.clerkOrgId,
+        clerkUserId: inputs.clerkUserId,
+        targetAudience: inputs.targetAudience ?? "",
+        targetOutcome: inputs.targetOutcome ?? "",
+        valueForTarget: inputs.valueForTarget ?? "",
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`[Campaign Service] Workflow execution failed (${res.status}):`, body);
+    return;
+  }
+
+  const data = await res.json();
+  console.log(`[Campaign Service] Cold email workflow started: run=${data.id}, status=${data.status}`);
+}
+
+export { buildColdEmailDag };

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -7,6 +7,7 @@ import { validateBody } from "../middleware/validate.js";
 import { normalizeUrl, extractDomain } from "../lib/domain.js";
 import { listRuns, getRunsBatch, type Run, type RunWithCosts } from "@mcpfactory/runs-client";
 import { CreateCampaignBody, UpdateCampaignBody, StatsFilterBody, BatchBudgetUsageBody } from "../schemas.js";
+import { executeColdEmailOutreach } from "../lib/workflows.js";
 
 const router = Router();
 
@@ -322,6 +323,22 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
       .set(updates)
       .where(eq(campaigns.id, id))
       .returning();
+
+    // Trigger cold email workflow on activation
+    if (req.body.status === "activate" && updated.brandId && updated.brandUrl) {
+      executeColdEmailOutreach({
+        brandId: updated.brandId,
+        brandUrl: updated.brandUrl,
+        campaignId: updated.id,
+        clerkOrgId: req.clerkOrgId!,
+        clerkUserId: req.clerkUserId,
+        targetAudience: updated.targetAudience,
+        targetOutcome: updated.targetOutcome,
+        valueForTarget: updated.valueForTarget,
+      }).catch((err) => {
+        console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
+      });
+    }
 
     res.json({ campaign: updated });
   } catch (error) {

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+
+const { mockExecuteColdEmailOutreach } = vi.hoisted(() => ({
+  mockExecuteColdEmailOutreach: vi.fn(),
+}));
+
+vi.mock("../../src/lib/workflows.js", () => ({
+  executeColdEmailOutreach: mockExecuteColdEmailOutreach,
+  deployWorkflows: vi.fn(),
+}));
+
+import app from "../../src/index.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+
+const validBody = {
+  name: "Activation Test Campaign",
+  clerkOrgId: "org_activation_test",
+  brandUrl: "https://example.com",
+  brandId: crypto.randomUUID(),
+  appId: "mcpfactory",
+  targetOutcome: "Book sales demos",
+  valueForTarget: "Enterprise analytics at startup pricing",
+  targetAudience: "CTOs at SaaS companies",
+};
+
+describe("Workflow activation on PATCH", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+    mockExecuteColdEmailOutreach.mockResolvedValue(undefined);
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("should trigger workflow when status is set to activate", async () => {
+    // Create campaign
+    const createRes = await request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send(validBody)
+      .expect(201);
+
+    const campaignId = createRes.body.campaign.id;
+
+    // Stop it first so we can activate
+    await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "stop" })
+      .expect(200);
+
+    vi.clearAllMocks();
+    mockExecuteColdEmailOutreach.mockResolvedValue(undefined);
+
+    // Activate
+    const activateRes = await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "activate" })
+      .expect(200);
+
+    expect(activateRes.body.campaign.status).toBe("ongoing");
+
+    // Wait a tick for the fire-and-forget promise
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockExecuteColdEmailOutreach).toHaveBeenCalledOnce();
+    expect(mockExecuteColdEmailOutreach).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId: validBody.brandId,
+        brandUrl: "https://example.com",
+        campaignId,
+        clerkOrgId: "org_activation_test",
+        targetAudience: "CTOs at SaaS companies",
+        targetOutcome: "Book sales demos",
+        valueForTarget: "Enterprise analytics at startup pricing",
+      })
+    );
+  });
+
+  it("should NOT trigger workflow when status is set to stop", async () => {
+    const createRes = await request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send(validBody)
+      .expect(201);
+
+    const campaignId = createRes.body.campaign.id;
+
+    await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "stop" })
+      .expect(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockExecuteColdEmailOutreach).not.toHaveBeenCalled();
+  });
+
+  it("should NOT trigger workflow when updating non-status fields", async () => {
+    const createRes = await request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send(validBody)
+      .expect(201);
+
+    const campaignId = createRes.body.campaign.id;
+
+    await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ name: "Updated Name" })
+      .expect(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockExecuteColdEmailOutreach).not.toHaveBeenCalled();
+  });
+
+  it("should still return 200 even if workflow execution fails", async () => {
+    mockExecuteColdEmailOutreach.mockRejectedValue(new Error("Windmill down"));
+
+    const createRes = await request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send(validBody)
+      .expect(201);
+
+    const campaignId = createRes.body.campaign.id;
+
+    // Stop then activate
+    await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "stop" })
+      .expect(200);
+
+    const activateRes = await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "activate" })
+      .expect(200);
+
+    expect(activateRes.body.campaign.status).toBe("ongoing");
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,6 +6,8 @@ process.env.SERVICE_SECRET_KEY = "test-service-secret";
 process.env.RUNS_SERVICE_URL = "https://runs.mcpfactory.org";
 process.env.RUNS_SERVICE_API_KEY = "test-api-key";
 process.env.CAMPAIGN_SERVICE_API_KEY = "test-api-key";
+process.env.WINDMILL_SERVICE_URL = "https://windmill.test.local";
+process.env.WINDMILL_SERVICE_API_KEY = "test-windmill-key";
 
 beforeAll(() => console.log("Test suite starting..."));
 afterAll(() => console.log("Test suite complete."));

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { buildColdEmailDag } from "../../src/lib/workflows.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("Workflow module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("buildColdEmailDag", () => {
+    it("should produce a valid DAG with nodes and edges", () => {
+      const dag = buildColdEmailDag();
+
+      expect(dag.nodes).toBeDefined();
+      expect(dag.edges).toBeDefined();
+      expect(dag.nodes.length).toBeGreaterThan(0);
+      expect(dag.edges.length).toBeGreaterThan(0);
+    });
+
+    it("should have the correct top-level node sequence", () => {
+      const dag = buildColdEmailDag();
+      const nodeIds = dag.nodes.map((n) => n.id);
+
+      expect(nodeIds).toContain("register-prompt");
+      expect(nodeIds).toContain("extract-brand");
+      expect(nodeIds).toContain("suggest-icp");
+      expect(nodeIds).toContain("search-leads");
+      expect(nodeIds).toContain("process-leads");
+    });
+
+    it("should have correct edge ordering", () => {
+      const dag = buildColdEmailDag();
+
+      expect(dag.edges).toEqual([
+        { from: "register-prompt", to: "extract-brand" },
+        { from: "extract-brand", to: "suggest-icp" },
+        { from: "suggest-icp", to: "search-leads" },
+        { from: "search-leads", to: "process-leads" },
+      ]);
+    });
+
+    it("should have process-leads as for-each with sub-nodes", () => {
+      const dag = buildColdEmailDag();
+      const forEachNode = dag.nodes.find((n) => n.id === "process-leads");
+
+      expect(forEachNode).toBeDefined();
+      expect(forEachNode!.type).toBe("for-each");
+      expect(forEachNode!.config.iterator).toBe("$ref:search-leads.output.people");
+
+      const subDag = forEachNode!.config.dag as { nodes: { id: string }[]; edges: { from: string; to: string }[] };
+      expect(subDag.nodes.map((n) => n.id)).toEqual(["enrich-lead", "generate-email", "send-email"]);
+      expect(subDag.edges).toEqual([
+        { from: "enrich-lead", to: "generate-email" },
+        { from: "generate-email", to: "send-email" },
+      ]);
+    });
+
+    it("should use http.call type for all service nodes", () => {
+      const dag = buildColdEmailDag();
+
+      for (const node of dag.nodes) {
+        if (node.type !== "for-each") {
+          expect(node.type).toBe("http.call");
+          expect(node.config.service).toBeDefined();
+          expect(node.config.method).toBeDefined();
+          expect(node.config.path).toBeDefined();
+        }
+      }
+    });
+
+    it("should reference correct services", () => {
+      const dag = buildColdEmailDag();
+      const serviceMap: Record<string, string> = {};
+
+      for (const node of dag.nodes) {
+        if (node.config.service) {
+          serviceMap[node.id] = node.config.service as string;
+        }
+      }
+
+      expect(serviceMap["register-prompt"]).toBe("emailgeneration");
+      expect(serviceMap["extract-brand"]).toBe("brand");
+      expect(serviceMap["suggest-icp"]).toBe("brand");
+      expect(serviceMap["search-leads"]).toBe("apollo");
+    });
+  });
+
+  describe("deployWorkflows", () => {
+    it("should call PUT /workflows/deploy with correct payload", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ workflows: [{ name: "cold-email-outreach", action: "created" }] }),
+      });
+
+      const { deployWorkflows } = await import("../../src/lib/workflows.js");
+      await deployWorkflows();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://windmill.test.local/workflows/deploy");
+      expect(opts.method).toBe("PUT");
+      expect(opts.headers["x-api-key"]).toBe("test-windmill-key");
+
+      const body = JSON.parse(opts.body);
+      expect(body.appId).toBe("mcpfactory");
+      expect(body.workflows).toHaveLength(1);
+      expect(body.workflows[0].name).toBe("cold-email-outreach");
+      expect(body.workflows[0].dag.nodes).toBeDefined();
+    });
+
+    it("should not throw when windmill env vars are missing", async () => {
+      const originalUrl = process.env.WINDMILL_SERVICE_URL;
+      delete process.env.WINDMILL_SERVICE_URL;
+
+      const { deployWorkflows } = await import("../../src/lib/workflows.js");
+      await expect(deployWorkflows()).resolves.not.toThrow();
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      process.env.WINDMILL_SERVICE_URL = originalUrl;
+    });
+
+    it("should not throw when deployment fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "Internal server error",
+      });
+
+      const { deployWorkflows } = await import("../../src/lib/workflows.js");
+      await expect(deployWorkflows()).resolves.not.toThrow();
+    });
+  });
+
+  describe("executeColdEmailOutreach", () => {
+    it("should call POST /workflows/by-name/cold-email-outreach/execute", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-123", status: "queued" }),
+      });
+
+      const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
+      await executeColdEmailOutreach({
+        brandId: "brand-1",
+        brandUrl: "https://example.com",
+        campaignId: "campaign-1",
+        clerkOrgId: "org_test",
+        clerkUserId: "user_test",
+        targetAudience: "CEOs at SaaS startups",
+        targetOutcome: "Book demos",
+        valueForTarget: "Enterprise analytics",
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://windmill.test.local/workflows/by-name/cold-email-outreach/execute");
+      expect(opts.method).toBe("POST");
+
+      const body = JSON.parse(opts.body);
+      expect(body.appId).toBe("mcpfactory");
+      expect(body.orgId).toBe("org_test");
+      expect(body.inputs.brandId).toBe("brand-1");
+      expect(body.inputs.campaignId).toBe("campaign-1");
+      expect(body.inputs.clerkOrgId).toBe("org_test");
+      expect(body.inputs.targetAudience).toBe("CEOs at SaaS startups");
+    });
+
+    it("should handle null optional fields gracefully", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-456", status: "queued" }),
+      });
+
+      const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
+      await executeColdEmailOutreach({
+        brandId: "brand-1",
+        brandUrl: "https://example.com",
+        campaignId: "campaign-1",
+        clerkOrgId: "org_test",
+        targetAudience: null,
+        targetOutcome: null,
+        valueForTarget: null,
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.inputs.targetAudience).toBe("");
+      expect(body.inputs.targetOutcome).toBe("");
+      expect(body.inputs.valueForTarget).toBe("");
+    });
+
+    it("should not throw when execution fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => "Workflow not found",
+      });
+
+      const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
+      await expect(
+        executeColdEmailOutreach({
+          brandId: "brand-1",
+          brandUrl: "https://example.com",
+          campaignId: "campaign-1",
+          clerkOrgId: "org_test",
+        })
+      ).resolves.not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Deploy `cold-email-outreach` DAG to windmill-service at startup (idempotent via `PUT /workflows/deploy`)
- Execute the workflow when a campaign is activated (`PATCH /campaigns/:id` with `status: "activate"`)  
- DAG pipeline: register prompt → extract brand → suggest ICP → search leads → for-each lead (enrich → generate email → send)
- Fire-and-forget execution — workflow errors don't block the PATCH response

## Test plan
- [x] Unit tests for DAG structure, deploy, and execute functions (12 tests)
- [x] Integration tests for PATCH activation trigger (4 tests)
- [x] Verify workflow not triggered on `stop` or non-status updates
- [x] Verify graceful handling when windmill env vars are missing
- [x] All 60 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)