### PR TITLE
feat: rewrite cold email workflow to 1-lead-per-run pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,5 +24,9 @@ INSTANTLY_SERVICE_API_KEY='your-instantly-api-key'
 LEAD_SERVICE_URL='http://localhost:3008'
 LEAD_SERVICE_API_KEY='your-lead-api-key'
 
+# Windmill (workflow orchestration)
+WINDMILL_SERVICE_URL='https://windmill.mcpfactory.org'
+WINDMILL_SERVICE_API_KEY='your-windmill-api-key'
+
 # Server
 PORT=3003

--- a/.env.example
+++ b/.env.example
@@ -14,15 +14,21 @@ CLERK_SECRET_KEY='sk_live_...'
 # Service-to-service auth
 CAMPAIGN_SERVICE_API_KEY='your-campaign-service-api-key'
 
-# Downstream services (stats aggregation)
+# Downstream services
 EMAILGENERATION_SERVICE_URL='http://localhost:3004'
 EMAILGENERATION_SERVICE_API_KEY='your-emailgen-api-key'
+BRAND_SERVICE_URL='https://brand.mcpfactory.org'
+BRAND_SERVICE_API_KEY='your-brand-api-key'
+LEAD_SERVICE_URL='http://localhost:3008'
+LEAD_SERVICE_API_KEY='your-lead-api-key'
+EMAIL_GATEWAY_SERVICE_URL='https://email-gateway.mcpfactory.org'
+EMAIL_GATEWAY_SERVICE_API_KEY='your-gateway-api-key'
+
+# Legacy downstream services (stats aggregation)
 POSTMARK_SERVICE_URL='http://localhost:3006'
 POSTMARK_SERVICE_API_KEY='your-postmark-api-key'
 INSTANTLY_SERVICE_URL='http://localhost:3007'
 INSTANTLY_SERVICE_API_KEY='your-instantly-api-key'
-LEAD_SERVICE_URL='http://localhost:3008'
-LEAD_SERVICE_API_KEY='your-lead-api-key'
 
 # Windmill (workflow orchestration)
 WINDMILL_SERVICE_URL='https://windmill.mcpfactory.org'

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ const openapiPath = join(__dirname, "..", "openapi.json");
 import healthRoutes from "./routes/health.js";
 import campaignsRoutes from "./routes/campaigns.js";
 import runsRoutes from "./routes/runs.js";
+import { deployWorkflows } from "./lib/workflows.js";
 const app = express();
 const PORT = process.env.PORT || 3003;
 
@@ -62,6 +63,9 @@ if (process.env.NODE_ENV !== "test") {
   migrate(db, { migrationsFolder: "./drizzle" })
     .then(() => {
       console.log("[Campaign Service] Migrations complete");
+      deployWorkflows().catch((err) => {
+        console.error("[Campaign Service] Workflow deployment error:", err);
+      });
       app.listen(Number(PORT), "::", () => {
         console.log(`[Campaign Service] Running on port ${PORT}`);
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ const openapiPath = join(__dirname, "..", "openapi.json");
 import healthRoutes from "./routes/health.js";
 import campaignsRoutes from "./routes/campaigns.js";
 import runsRoutes from "./routes/runs.js";
+import internalRoutes from "./routes/internal.js";
 import { deployWorkflows } from "./lib/workflows.js";
 const app = express();
 const PORT = process.env.PORT || 3003;
@@ -34,6 +35,7 @@ app.use(express.json());
 app.use(healthRoutes);
 app.use(campaignsRoutes);
 app.use(runsRoutes);
+app.use(internalRoutes);
 
 // OpenAPI spec endpoint
 app.get("/openapi.json", (_req, res) => {

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -1,0 +1,195 @@
+import { listRuns, updateRun, getRunsBatch, type Run } from "@mcpfactory/runs-client";
+import { db } from "../db/index.js";
+import { campaigns } from "../db/schema.js";
+import { eq } from "drizzle-orm";
+
+const APP_ID = "mcpfactory";
+const STALE_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+export interface GateCheckInput {
+  campaignId: string;
+  clerkOrgId: string;
+  brandId: string;
+  status: string;
+  maxBudgetDailyUsd: string | null;
+  maxBudgetWeeklyUsd: string | null;
+  maxBudgetMonthlyUsd: string | null;
+  maxBudgetTotalUsd: string | null;
+  maxLeads: number | null;
+}
+
+export interface GateCheckResult {
+  allowed: boolean;
+  reason?: string;
+  autoStopped?: boolean;
+}
+
+export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheckResult> {
+  // Campaign must be ongoing
+  if (campaign.status !== "ongoing") {
+    return { allowed: false, reason: "Campaign is not ongoing" };
+  }
+
+  // Fetch all runs for this campaign
+  const { runs } = await listRuns({
+    clerkOrgId: campaign.clerkOrgId,
+    appId: APP_ID,
+    serviceName: "campaign-service",
+    taskName: campaign.campaignId,
+  });
+
+  // 1. Stale run cleanup — mark runs running > 30 min as failed
+  const now = Date.now();
+  for (const run of runs) {
+    if (run.status === "running" && (now - new Date(run.startedAt).getTime()) > STALE_THRESHOLD_MS) {
+      try {
+        await updateRun(run.id, "failed");
+        run.status = "failed"; // update in-memory
+      } catch (err) {
+        console.error(`[Gate Check] Failed to clean stale run ${run.id}:`, err);
+      }
+    }
+  }
+
+  // 2. Running run check — only 1 run at a time per campaign
+  if (runs.some((r: Run) => r.status === "running")) {
+    return { allowed: false, reason: "A run is already in progress" };
+  }
+
+  // 3. Budget check (fail-closed: no budget defined = blocked)
+  const hasAnyBudget = campaign.maxBudgetDailyUsd || campaign.maxBudgetWeeklyUsd ||
+                       campaign.maxBudgetMonthlyUsd || campaign.maxBudgetTotalUsd;
+  if (!hasAnyBudget) {
+    return { allowed: false, reason: "No budget defined (fail-closed)" };
+  }
+
+  // Batch-fetch costs for completed/failed runs
+  const finishedRuns = runs.filter((r: Run) => r.status === "completed" || r.status === "failed");
+  const runsWithCosts = finishedRuns.length > 0
+    ? await getRunsBatch(finishedRuns.map((r: Run) => r.id)).catch(() => new Map())
+    : new Map();
+
+  const budgetWindows: Array<{
+    limit: string | null;
+    since: Date | undefined;
+    label: string;
+    autoStop: boolean;
+  }> = [
+    { limit: campaign.maxBudgetDailyUsd, since: startOfToday(), label: "daily", autoStop: false },
+    { limit: campaign.maxBudgetWeeklyUsd, since: daysAgo(7), label: "weekly", autoStop: false },
+    { limit: campaign.maxBudgetMonthlyUsd, since: startOfMonth(), label: "monthly", autoStop: false },
+    { limit: campaign.maxBudgetTotalUsd, since: undefined, label: "total", autoStop: true },
+  ];
+
+  for (const window of budgetWindows) {
+    if (!window.limit) continue;
+    const limitCents = parseFloat(window.limit) * 100;
+
+    let totalCostCents = 0;
+    for (const run of finishedRuns) {
+      if (window.since && new Date(run.startedAt) < window.since) continue;
+      const runWithCosts = runsWithCosts.get(run.id);
+      if (runWithCosts) {
+        totalCostCents += parseFloat(runWithCosts.totalCostInUsdCents) || 0;
+      }
+    }
+
+    if (totalCostCents >= limitCents) {
+      if (window.autoStop) {
+        await autoStopCampaign(campaign.campaignId);
+        return { allowed: false, reason: "Total budget exceeded", autoStopped: true };
+      }
+      return { allowed: false, reason: `${window.label} budget exceeded` };
+    }
+  }
+
+  // 4. Volume check
+  if (campaign.maxLeads != null) {
+    let totalServed: number;
+    try {
+      const leadStats = await fetchLeadStats(campaign.clerkOrgId, campaign.campaignId, campaign.brandId);
+      const completedCount = finishedRuns.filter((r: Run) => r.status === "completed").length;
+      totalServed = Math.max(leadStats.totalServed, completedCount);
+    } catch (err: unknown) {
+      if (err instanceof Error && "status" in err && (err as { status: number }).status === 404) {
+        totalServed = finishedRuns.filter((r: Run) => r.status === "completed").length;
+      } else {
+        return { allowed: false, reason: "Lead stats unavailable (fail-closed)" };
+      }
+    }
+
+    if (totalServed >= campaign.maxLeads) {
+      await autoStopCampaign(campaign.campaignId);
+      return { allowed: false, reason: "Max leads reached", autoStopped: true };
+    }
+  }
+
+  // 5. Consecutive failures check
+  const sortedRuns = [...runs].sort((a, b) =>
+    new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+  );
+  let consecutiveFailures = 0;
+  for (const run of sortedRuns) {
+    if (run.status === "failed") consecutiveFailures++;
+    else break;
+  }
+  if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+    await autoStopCampaign(campaign.campaignId);
+    return { allowed: false, reason: `${MAX_CONSECUTIVE_FAILURES} consecutive failures`, autoStopped: true };
+  }
+
+  return { allowed: true };
+}
+
+async function autoStopCampaign(campaignId: string): Promise<void> {
+  await db.update(campaigns)
+    .set({ status: "stopped", updatedAt: new Date() })
+    .where(eq(campaigns.id, campaignId));
+  console.log(`[Campaign Service] Auto-stopped campaign ${campaignId}`);
+}
+
+async function fetchLeadStats(
+  clerkOrgId: string,
+  campaignId: string,
+  brandId: string,
+): Promise<{ totalServed: number }> {
+  const url = process.env.LEAD_SERVICE_URL;
+  const apiKey = process.env.LEAD_SERVICE_API_KEY;
+  if (!url || !apiKey) throw new Error("Lead service not configured");
+
+  const params = new URLSearchParams({ brandId, campaignId });
+  const res = await fetch(`${url}/stats?${params}`, {
+    headers: {
+      "x-api-key": apiKey,
+      "x-app-id": APP_ID,
+      "x-org-id": clerkOrgId,
+    },
+  });
+
+  if (!res.ok) {
+    const err = new Error(`Lead stats failed: ${res.status}`) as Error & { status: number };
+    err.status = res.status;
+    throw err;
+  }
+
+  const data = await res.json() as Record<string, unknown>;
+  return { totalServed: (data.totalServed as number) || (data.served as number) || 0 };
+}
+
+function startOfToday(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function daysAgo(n: number): Date {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+}
+
+function startOfMonth(): Date {
+  const d = new Date();
+  d.setDate(1);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -1,0 +1,291 @@
+const COLD_EMAIL_PROMPT = `You are an expert sales copywriter. Write a personalized cold email for a potential client.
+
+## Recipient Information
+{{recipientInfo}}
+
+## Sender / Our Company
+{{senderInfo}}
+
+## Reference: Cold Email Frameworks
+Use your expertise to craft the email. Here are proven frameworks for reference:
+
+**PAS (Problem-Agitate-Solution)**
+Identify a problem, amplify its consequences, present solution.
+
+**BAB (Before-After-Bridge)**
+Describe current pain (Before), paint ideal future (After), position solution as the bridge.
+
+**AIDA (Attention-Interest-Desire-Action)**
+Hook attention, build interest with value, create desire, end with CTA.
+
+**SPIN (Situation-Problem-Implication-Need-Payoff)**
+Acknowledge situation, surface problems, explore implications, highlight payoff.
+
+## Reference: Industry Best Practices (Gong Research, 28M+ emails analyzed)
+- Avoid product pitches in cold emails (reduces replies by 57%)
+- Use interest CTAs ("thoughts?" not "15 min call?") - 2x more effective
+- Avoid buzzwords in subject lines (reduces open rates by 17.9%)
+- No ROI claims, no "AI", no jargon in first touch
+- Focus on problems you solve, not features you have
+
+## Task
+Write a compelling cold email using your judgment. Apply or combine frameworks as you see fit based on the data provided.
+
+Keep it short (3-4 sentences max). Be genuine, not salesy. End with a low-friction CTA.
+Do NOT use placeholder text like [Your Name]. Do NOT add any signature block — it will be appended automatically.
+
+## Output Format
+SUBJECT: [subject line]
+---
+[email body in plain text]`;
+
+const APP_ID = "mcpfactory";
+
+function buildColdEmailDag() {
+  return {
+    nodes: [
+      {
+        id: "register-prompt",
+        type: "http.call",
+        config: {
+          service: "emailgeneration",
+          method: "PUT",
+          path: "/prompts",
+          body: {
+            appId: APP_ID,
+            type: "cold-email",
+            prompt: COLD_EMAIL_PROMPT,
+            variables: ["recipientInfo", "senderInfo"],
+          },
+        },
+        inputMapping: {
+          "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
+        },
+      },
+      {
+        id: "extract-brand",
+        type: "http.call",
+        config: {
+          service: "brand",
+          method: "POST",
+          path: "/sales-profile",
+          body: { appId: APP_ID },
+        },
+        inputMapping: {
+          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+          "body.url": "$ref:flow_input.brandUrl",
+          "body.clerkUserId": "$ref:flow_input.clerkUserId",
+          "body.parentRunId": "$ref:flow_input.runId",
+        },
+      },
+      {
+        id: "suggest-icp",
+        type: "http.call",
+        config: {
+          service: "brand",
+          method: "POST",
+          path: "/icp-suggestion",
+          body: { appId: APP_ID },
+        },
+        inputMapping: {
+          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+          "body.url": "$ref:flow_input.brandUrl",
+          "body.clerkUserId": "$ref:flow_input.clerkUserId",
+          "body.targetAudience": "$ref:flow_input.targetAudience",
+        },
+      },
+      {
+        id: "search-leads",
+        type: "http.call",
+        config: {
+          service: "apollo",
+          method: "POST",
+          path: "/search",
+          body: { appId: APP_ID, perPage: 25 },
+        },
+        inputMapping: {
+          "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
+          "body.brandId": "$ref:flow_input.brandId",
+          "body.campaignId": "$ref:flow_input.campaignId",
+          "body.runId": "$ref:flow_input.runId",
+          "body.personTitles": "$ref:suggest-icp.output.suggestion.personTitles",
+          "body.qOrganizationKeywordTags": "$ref:suggest-icp.output.suggestion.qOrganizationKeywordTags",
+          "body.organizationLocations": "$ref:suggest-icp.output.suggestion.organizationLocations",
+        },
+      },
+      {
+        id: "process-leads",
+        type: "for-each",
+        config: {
+          iterator: "$ref:search-leads.output.people",
+          skipFailures: true,
+          dag: {
+            nodes: [
+              {
+                id: "enrich-lead",
+                type: "http.call",
+                config: {
+                  service: "apollo",
+                  method: "POST",
+                  path: "/enrich",
+                  body: { appId: APP_ID },
+                },
+                inputMapping: {
+                  "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
+                  "body.apolloPersonId": "$ref:item.id",
+                  "body.brandId": "$ref:flow_input.brandId",
+                  "body.campaignId": "$ref:flow_input.campaignId",
+                  "body.runId": "$ref:flow_input.runId",
+                },
+              },
+              {
+                id: "generate-email",
+                type: "http.call",
+                config: {
+                  service: "emailgeneration",
+                  method: "POST",
+                  path: "/generate",
+                  body: { appId: APP_ID, type: "cold-email" },
+                },
+                inputMapping: {
+                  "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
+                  "body.runId": "$ref:flow_input.runId",
+                  "body.brandId": "$ref:flow_input.brandId",
+                  "body.campaignId": "$ref:flow_input.campaignId",
+                  "body.apolloEnrichmentId": "$ref:enrich-lead.output.enrichmentId",
+                  "body.variables.recipientInfo": "$ref:enrich-lead.output.person",
+                  "body.variables.senderInfo": "$ref:flow_input.senderInfo",
+                },
+              },
+              {
+                id: "send-email",
+                type: "http.call",
+                config: {
+                  service: "email-gateway",
+                  method: "POST",
+                  path: "/send",
+                  body: { type: "broadcast", appId: APP_ID },
+                },
+                inputMapping: {
+                  "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+                  "body.brandId": "$ref:flow_input.brandId",
+                  "body.campaignId": "$ref:flow_input.campaignId",
+                  "body.runId": "$ref:flow_input.runId",
+                  "body.to": "$ref:enrich-lead.output.person.email",
+                  "body.recipientFirstName": "$ref:enrich-lead.output.person.firstName",
+                  "body.recipientLastName": "$ref:enrich-lead.output.person.lastName",
+                  "body.recipientCompany": "$ref:enrich-lead.output.person.organizationName",
+                  "body.subject": "$ref:generate-email.output.subject",
+                  "body.htmlBody": "$ref:generate-email.output.bodyHtml",
+                  "body.textBody": "$ref:generate-email.output.bodyText",
+                },
+              },
+            ],
+            edges: [
+              { from: "enrich-lead", to: "generate-email" },
+              { from: "generate-email", to: "send-email" },
+            ],
+          },
+        },
+      },
+    ],
+    edges: [
+      { from: "register-prompt", to: "extract-brand" },
+      { from: "extract-brand", to: "suggest-icp" },
+      { from: "suggest-icp", to: "search-leads" },
+      { from: "search-leads", to: "process-leads" },
+    ],
+  };
+}
+
+export async function deployWorkflows(): Promise<void> {
+  const url = process.env.WINDMILL_SERVICE_URL;
+  const apiKey = process.env.WINDMILL_SERVICE_API_KEY;
+
+  if (!url || !apiKey) {
+    console.warn("[Campaign Service] WINDMILL_SERVICE_URL or WINDMILL_SERVICE_API_KEY not set, skipping workflow deployment");
+    return;
+  }
+
+  const res = await fetch(`${url}/workflows/deploy`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+    },
+    body: JSON.stringify({
+      appId: APP_ID,
+      workflows: [
+        {
+          name: "cold-email-outreach",
+          description: "Full cold email pipeline: prompt → brand → ICP → leads → enrich → generate → send",
+          dag: buildColdEmailDag(),
+        },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`[Campaign Service] Workflow deployment failed (${res.status}):`, body);
+    return;
+  }
+
+  const data = await res.json();
+  console.log("[Campaign Service] Workflows deployed:", data.workflows?.map((w: { name: string; action: string }) => `${w.name} (${w.action})`).join(", "));
+}
+
+interface CampaignWorkflowInputs {
+  brandId: string;
+  brandUrl: string;
+  campaignId: string;
+  clerkOrgId: string;
+  clerkUserId?: string;
+  targetAudience?: string | null;
+  targetOutcome?: string | null;
+  valueForTarget?: string | null;
+  salesProfile?: unknown;
+}
+
+export async function executeColdEmailOutreach(inputs: CampaignWorkflowInputs): Promise<void> {
+  const url = process.env.WINDMILL_SERVICE_URL;
+  const apiKey = process.env.WINDMILL_SERVICE_API_KEY;
+
+  if (!url || !apiKey) {
+    console.warn("[Campaign Service] WINDMILL_SERVICE_URL or WINDMILL_SERVICE_API_KEY not set, skipping workflow execution");
+    return;
+  }
+
+  const res = await fetch(`${url}/workflows/by-name/cold-email-outreach/execute`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+    },
+    body: JSON.stringify({
+      appId: APP_ID,
+      orgId: inputs.clerkOrgId,
+      inputs: {
+        brandId: inputs.brandId,
+        brandUrl: inputs.brandUrl,
+        campaignId: inputs.campaignId,
+        clerkOrgId: inputs.clerkOrgId,
+        clerkUserId: inputs.clerkUserId,
+        targetAudience: inputs.targetAudience ?? "",
+        targetOutcome: inputs.targetOutcome ?? "",
+        valueForTarget: inputs.valueForTarget ?? "",
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`[Campaign Service] Workflow execution failed (${res.status}):`, body);
+    return;
+  }
+
+  const data = await res.json();
+  console.log(`[Campaign Service] Cold email workflow started: run=${data.id}, status=${data.status}`);
+}
+
+export { buildColdEmailDag };

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -1,10 +1,33 @@
-const COLD_EMAIL_PROMPT = `You are an expert sales copywriter. Write a personalized cold email for a potential client.
+export const COLD_EMAIL_PROMPT = `You are an expert sales copywriter. Write a personalized cold email for a potential client.
 
 ## Recipient Information
-{{recipientInfo}}
+- Name: {{leadFirstName}} {{leadLastName}}
+- Title: {{leadTitle}}
+- Email: {{leadEmail}}
+- LinkedIn: {{leadLinkedinUrl}}
+- Company: {{leadCompanyName}}
+- Domain: {{leadCompanyDomain}}
+- Industry: {{leadCompanyIndustry}}
+- Company Size: {{leadCompanySize}} employees
+- Revenue: {{leadCompanyRevenueUsd}}
 
 ## Sender / Our Company
-{{senderInfo}}
+- Company: {{clientCompanyName}}
+- Website: {{clientBrandUrl}}
+- Overview: {{clientCompanyOverview}}
+- Value Proposition: {{clientValueProposition}}
+- Target Audience: {{clientTargetAudience}}
+- Pain Points We Solve: {{clientCustomerPainPoints}}
+- Key Features: {{clientKeyFeatures}}
+- Differentiators: {{clientProductDifferentiators}}
+- Competitors: {{clientCompetitors}}
+- Social Proof: {{clientSocialProof}}
+- CTA: {{clientCallToAction}}
+- Additional Context: {{clientAdditionalContext}}
+
+## Campaign Goals
+- Target Outcome: {{targetOutcome}}
+- Value for Target: {{valueForTarget}}
 
 ## Reference: Cold Email Frameworks
 Use your expertise to craft the email. Here are proven frameworks for reference:
@@ -17,9 +40,6 @@ Describe current pain (Before), paint ideal future (After), position solution as
 
 **AIDA (Attention-Interest-Desire-Action)**
 Hook attention, build interest with value, create desire, end with CTA.
-
-**SPIN (Situation-Problem-Implication-Need-Payoff)**
-Acknowledge situation, surface problems, explore implications, highlight payoff.
 
 ## Reference: Industry Best Practices (Gong Research, 28M+ emails analyzed)
 - Avoid product pitches in cold emails (reduces replies by 57%)
@@ -39,162 +59,158 @@ SUBJECT: [subject line]
 ---
 [email body in plain text]`;
 
+export const COLD_EMAIL_VARIABLES = [
+  "leadFirstName", "leadLastName", "leadTitle", "leadEmail",
+  "leadLinkedinUrl", "leadCompanyName", "leadCompanyDomain",
+  "leadCompanyIndustry", "leadCompanySize", "leadCompanyRevenueUsd",
+  "clientCompanyName", "clientBrandUrl", "clientCompanyOverview",
+  "clientValueProposition", "clientTargetAudience", "clientCustomerPainPoints",
+  "clientKeyFeatures", "clientProductDifferentiators", "clientCompetitors",
+  "clientSocialProof", "clientCallToAction", "clientAdditionalContext",
+  "targetOutcome", "valueForTarget",
+];
+
 const APP_ID = "mcpfactory";
 
+/**
+ * Build the cold-email-outreach DAG.
+ *
+ * Pipeline: start-run → email-generate → email-send → end-run
+ *
+ * - start-run: gate checks + create run + campaign/brand/lead fetch (campaign-service internal)
+ * - email-generate: generate email via AI (emailgeneration-service, NO RETRY)
+ * - email-send: send email (email-gateway-service, NO RETRY, validate success field)
+ * - end-run: finalize run + re-trigger (campaign-service internal)
+ *
+ * On DAG error: end-run is called with success=false via onError handler.
+ */
 function buildColdEmailDag() {
   return {
     nodes: [
+      // Step 1–4: Gate checks + create run + fetch campaign + brand profile + lead
       {
-        id: "register-prompt",
+        id: "start-run",
+        type: "http.call",
+        config: {
+          service: "campaign",
+          method: "POST",
+          path: "/internal/start-run",
+          retries: 0, // Contains non-idempotent lead fetch
+        },
+        inputMapping: {
+          "body.campaignId": "$ref:flow_input.campaignId",
+          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+        },
+      },
+      // Step 5: Generate email (non-idempotent, NO RETRY)
+      {
+        id: "email-generate",
         type: "http.call",
         config: {
           service: "emailgeneration",
-          method: "PUT",
-          path: "/prompts",
+          method: "POST",
+          path: "/generate",
+          retries: 0,
           body: {
-            appId: APP_ID,
             type: "cold-email",
-            prompt: COLD_EMAIL_PROMPT,
-            variables: ["recipientInfo", "senderInfo"],
           },
         },
         inputMapping: {
-          "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
+          "headers.x-clerk-org-id": "$ref:start-run.output.clerkOrgId",
+          "body.appId": "$ref:start-run.output.appId",
+          "body.brandId": "$ref:start-run.output.brandId",
+          "body.campaignId": "$ref:start-run.output.campaignId",
+          "body.runId": "$ref:start-run.output.runId",
+          "body.apolloEnrichmentId": "$ref:start-run.output.lead.externalId",
+          // Lead fields
+          "body.leadFirstName": "$ref:start-run.output.lead.data.first_name",
+          "body.leadLastName": "$ref:start-run.output.lead.data.last_name",
+          "body.leadTitle": "$ref:start-run.output.lead.data.title",
+          "body.leadEmail": "$ref:start-run.output.lead.data.email",
+          "body.leadLinkedinUrl": "$ref:start-run.output.lead.data.linkedin_url",
+          "body.leadCompanyName": "$ref:start-run.output.lead.data.organization_name",
+          "body.leadCompanyDomain": "$ref:start-run.output.lead.data.organization.primary_domain",
+          "body.leadCompanyIndustry": "$ref:start-run.output.lead.data.organization.industry",
+          "body.leadCompanySize": "$ref:start-run.output.lead.data.organization.estimated_num_employees",
+          "body.leadCompanyRevenueUsd": "$ref:start-run.output.lead.data.organization.annual_revenue_printed",
+          // Client/brand fields
+          "body.clientCompanyName": "$ref:start-run.output.clientData.companyName",
+          "body.clientBrandUrl": "$ref:start-run.output.clientData.brandUrl",
+          "body.clientCompanyOverview": "$ref:start-run.output.clientData.companyOverview",
+          "body.clientValueProposition": "$ref:start-run.output.clientData.valueProposition",
+          "body.clientTargetAudience": "$ref:start-run.output.clientData.targetAudience",
+          "body.clientCustomerPainPoints": "$ref:start-run.output.clientData.customerPainPoints",
+          "body.clientKeyFeatures": "$ref:start-run.output.clientData.keyFeatures",
+          "body.clientProductDifferentiators": "$ref:start-run.output.clientData.productDifferentiators",
+          "body.clientCompetitors": "$ref:start-run.output.clientData.competitors",
+          "body.clientSocialProof": "$ref:start-run.output.clientData.socialProof",
+          "body.clientCallToAction": "$ref:start-run.output.clientData.callToAction",
+          "body.clientAdditionalContext": "$ref:start-run.output.clientData.additionalContext",
+          // Campaign fields
+          "body.targetOutcome": "$ref:start-run.output.targetOutcome",
+          "body.valueForTarget": "$ref:start-run.output.valueForTarget",
         },
       },
+      // Step 6: Send email (non-idempotent, NO RETRY)
       {
-        id: "extract-brand",
+        id: "email-send",
         type: "http.call",
         config: {
-          service: "brand",
+          service: "email-gateway",
           method: "POST",
-          path: "/sales-profile",
-          body: { appId: APP_ID },
-        },
-        inputMapping: {
-          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
-          "body.url": "$ref:flow_input.brandUrl",
-          "body.clerkUserId": "$ref:flow_input.clerkUserId",
-          "body.parentRunId": "$ref:flow_input.runId",
-        },
-      },
-      {
-        id: "suggest-icp",
-        type: "http.call",
-        config: {
-          service: "brand",
-          method: "POST",
-          path: "/icp-suggestion",
-          body: { appId: APP_ID },
-        },
-        inputMapping: {
-          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
-          "body.url": "$ref:flow_input.brandUrl",
-          "body.clerkUserId": "$ref:flow_input.clerkUserId",
-          "body.targetAudience": "$ref:flow_input.targetAudience",
-        },
-      },
-      {
-        id: "search-leads",
-        type: "http.call",
-        config: {
-          service: "apollo",
-          method: "POST",
-          path: "/search",
-          body: { appId: APP_ID, perPage: 25 },
-        },
-        inputMapping: {
-          "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
-          "body.brandId": "$ref:flow_input.brandId",
-          "body.campaignId": "$ref:flow_input.campaignId",
-          "body.runId": "$ref:flow_input.runId",
-          "body.personTitles": "$ref:suggest-icp.output.suggestion.personTitles",
-          "body.qOrganizationKeywordTags": "$ref:suggest-icp.output.suggestion.qOrganizationKeywordTags",
-          "body.organizationLocations": "$ref:suggest-icp.output.suggestion.organizationLocations",
-        },
-      },
-      {
-        id: "process-leads",
-        type: "for-each",
-        config: {
-          iterator: "$ref:search-leads.output.people",
-          skipFailures: true,
-          dag: {
-            nodes: [
-              {
-                id: "enrich-lead",
-                type: "http.call",
-                config: {
-                  service: "apollo",
-                  method: "POST",
-                  path: "/enrich",
-                  body: { appId: APP_ID },
-                },
-                inputMapping: {
-                  "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
-                  "body.apolloPersonId": "$ref:item.id",
-                  "body.brandId": "$ref:flow_input.brandId",
-                  "body.campaignId": "$ref:flow_input.campaignId",
-                  "body.runId": "$ref:flow_input.runId",
-                },
-              },
-              {
-                id: "generate-email",
-                type: "http.call",
-                config: {
-                  service: "emailgeneration",
-                  method: "POST",
-                  path: "/generate",
-                  body: { appId: APP_ID, type: "cold-email" },
-                },
-                inputMapping: {
-                  "headers.x-clerk-org-id": "$ref:flow_input.clerkOrgId",
-                  "body.runId": "$ref:flow_input.runId",
-                  "body.brandId": "$ref:flow_input.brandId",
-                  "body.campaignId": "$ref:flow_input.campaignId",
-                  "body.apolloEnrichmentId": "$ref:enrich-lead.output.enrichmentId",
-                  "body.variables.recipientInfo": "$ref:enrich-lead.output.person",
-                  "body.variables.senderInfo": "$ref:flow_input.senderInfo",
-                },
-              },
-              {
-                id: "send-email",
-                type: "http.call",
-                config: {
-                  service: "email-gateway",
-                  method: "POST",
-                  path: "/send",
-                  body: { type: "broadcast", appId: APP_ID },
-                },
-                inputMapping: {
-                  "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
-                  "body.brandId": "$ref:flow_input.brandId",
-                  "body.campaignId": "$ref:flow_input.campaignId",
-                  "body.runId": "$ref:flow_input.runId",
-                  "body.to": "$ref:enrich-lead.output.person.email",
-                  "body.recipientFirstName": "$ref:enrich-lead.output.person.firstName",
-                  "body.recipientLastName": "$ref:enrich-lead.output.person.lastName",
-                  "body.recipientCompany": "$ref:enrich-lead.output.person.organizationName",
-                  "body.subject": "$ref:generate-email.output.subject",
-                  "body.htmlBody": "$ref:generate-email.output.bodyHtml",
-                  "body.textBody": "$ref:generate-email.output.bodyText",
-                },
-              },
-            ],
-            edges: [
-              { from: "enrich-lead", to: "generate-email" },
-              { from: "generate-email", to: "send-email" },
-            ],
+          path: "/send",
+          retries: 0,
+          body: {
+            type: "broadcast",
+            tag: "cold-email",
+            metadata: {
+              source: "mcpfactory-campaign-service",
+            },
           },
+          // Validate that gateway returns success: true (HTTP 200 with success: false is an error)
+          validateResponse: { field: "success", equals: true },
+        },
+        inputMapping: {
+          "body.appId": "$ref:start-run.output.appId",
+          "body.clerkOrgId": "$ref:start-run.output.clerkOrgId",
+          "body.brandId": "$ref:start-run.output.brandId",
+          "body.campaignId": "$ref:start-run.output.campaignId",
+          "body.runId": "$ref:start-run.output.runId",
+          "body.to": "$ref:start-run.output.lead.data.email",
+          "body.recipientFirstName": "$ref:start-run.output.lead.data.first_name",
+          "body.recipientLastName": "$ref:start-run.output.lead.data.last_name",
+          "body.recipientCompany": "$ref:start-run.output.lead.data.organization_name",
+          "body.subject": "$ref:email-generate.output.subject",
+          "body.htmlBody": "$ref:email-generate.output.bodyHtml",
+          "body.metadata.emailGenerationId": "$ref:email-generate.output.id",
+        },
+      },
+      // Step 7: Finalize run + re-trigger
+      {
+        id: "end-run",
+        type: "http.call",
+        config: {
+          service: "campaign",
+          method: "POST",
+          path: "/internal/end-run",
+          body: {
+            success: true,
+          },
+        },
+        inputMapping: {
+          "body.runId": "$ref:start-run.output.runId",
+          "body.campaignId": "$ref:start-run.output.campaignId",
+          "body.clerkOrgId": "$ref:start-run.output.clerkOrgId",
         },
       },
     ],
     edges: [
-      { from: "register-prompt", to: "extract-brand" },
-      { from: "extract-brand", to: "suggest-icp" },
-      { from: "suggest-icp", to: "search-leads" },
-      { from: "search-leads", to: "process-leads" },
+      { from: "start-run", to: "email-generate" },
+      { from: "email-generate", to: "email-send" },
+      { from: "email-send", to: "end-run" },
     ],
+    // Error handler: call end-run with success=false when any node fails.
+    onError: "end-run",
   };
 }
 
@@ -218,7 +234,7 @@ export async function deployWorkflows(): Promise<void> {
       workflows: [
         {
           name: "cold-email-outreach",
-          description: "Full cold email pipeline: prompt → brand → ICP → leads → enrich → generate → send",
+          description: "Cold email pipeline: gate checks → lead → generate → send → re-trigger (1 lead per run)",
           dag: buildColdEmailDag(),
         },
       ],
@@ -231,23 +247,14 @@ export async function deployWorkflows(): Promise<void> {
     return;
   }
 
-  const data = await res.json();
-  console.log("[Campaign Service] Workflows deployed:", data.workflows?.map((w: { name: string; action: string }) => `${w.name} (${w.action})`).join(", "));
+  const data = await res.json() as { workflows?: Array<{ name: string; action: string }> };
+  console.log("[Campaign Service] Workflows deployed:", data.workflows?.map((w) => `${w.name} (${w.action})`).join(", "));
 }
 
-interface CampaignWorkflowInputs {
-  brandId: string;
-  brandUrl: string;
+export async function executeColdEmailOutreach(inputs: {
   campaignId: string;
   clerkOrgId: string;
-  clerkUserId?: string;
-  targetAudience?: string | null;
-  targetOutcome?: string | null;
-  valueForTarget?: string | null;
-  salesProfile?: unknown;
-}
-
-export async function executeColdEmailOutreach(inputs: CampaignWorkflowInputs): Promise<void> {
+}): Promise<void> {
   const url = process.env.WINDMILL_SERVICE_URL;
   const apiKey = process.env.WINDMILL_SERVICE_API_KEY;
 
@@ -266,14 +273,8 @@ export async function executeColdEmailOutreach(inputs: CampaignWorkflowInputs): 
       appId: APP_ID,
       orgId: inputs.clerkOrgId,
       inputs: {
-        brandId: inputs.brandId,
-        brandUrl: inputs.brandUrl,
         campaignId: inputs.campaignId,
         clerkOrgId: inputs.clerkOrgId,
-        clerkUserId: inputs.clerkUserId,
-        targetAudience: inputs.targetAudience ?? "",
-        targetOutcome: inputs.targetOutcome ?? "",
-        valueForTarget: inputs.valueForTarget ?? "",
       },
     }),
   });
@@ -284,7 +285,7 @@ export async function executeColdEmailOutreach(inputs: CampaignWorkflowInputs): 
     return;
   }
 
-  const data = await res.json();
+  const data = await res.json() as { id?: string; status?: string };
   console.log(`[Campaign Service] Cold email workflow started: run=${data.id}, status=${data.status}`);
 }
 

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -7,6 +7,7 @@ import { validateBody } from "../middleware/validate.js";
 import { normalizeUrl, extractDomain } from "../lib/domain.js";
 import { listRuns, getRunsBatch, type Run, type RunWithCosts } from "@mcpfactory/runs-client";
 import { CreateCampaignBody, UpdateCampaignBody, StatsFilterBody, BatchBudgetUsageBody } from "../schemas.js";
+import { executeColdEmailOutreach } from "../lib/workflows.js";
 
 const router = Router();
 
@@ -322,6 +323,22 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
       .set(updates)
       .where(eq(campaigns.id, id))
       .returning();
+
+    // Trigger cold email workflow on activation
+    if (req.body.status === "activate" && updated.brandId && updated.brandUrl) {
+      executeColdEmailOutreach({
+        brandId: updated.brandId,
+        brandUrl: updated.brandUrl,
+        campaignId: updated.id,
+        clerkOrgId: req.clerkOrgId!,
+        clerkUserId: req.clerkUserId,
+        targetAudience: updated.targetAudience,
+        targetOutcome: updated.targetOutcome,
+        valueForTarget: updated.valueForTarget,
+      }).catch((err) => {
+        console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
+      });
+    }
 
     res.json({ campaign: updated });
   } catch (error) {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -325,16 +325,10 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
       .returning();
 
     // Trigger cold email workflow on activation
-    if (req.body.status === "activate" && updated.brandId && updated.brandUrl) {
+    if (req.body.status === "activate") {
       executeColdEmailOutreach({
-        brandId: updated.brandId,
-        brandUrl: updated.brandUrl,
         campaignId: updated.id,
         clerkOrgId: req.clerkOrgId!,
-        clerkUserId: req.clerkUserId,
-        targetAudience: updated.targetAudience,
-        targetOutcome: updated.targetOutcome,
-        valueForTarget: updated.valueForTarget,
       }).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,0 +1,285 @@
+import { Router } from "express";
+import { eq, and } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { campaigns, orgs } from "../db/schema.js";
+import { requireApiKey } from "../middleware/auth.js";
+import { createRun, updateRun } from "@mcpfactory/runs-client";
+import { runGateChecks } from "../lib/gate-check.js";
+import { executeColdEmailOutreach } from "../lib/workflows.js";
+import { extractDomain } from "../lib/domain.js";
+
+const router = Router();
+const APP_ID = "mcpfactory";
+
+// In-memory cache: skip prompt registration if already done for this org
+const promptRegisteredOrgs = new Set<string>();
+
+async function ensurePromptRegistered(clerkOrgId: string): Promise<void> {
+  if (promptRegisteredOrgs.has(clerkOrgId)) return;
+
+  const url = process.env.EMAILGENERATION_SERVICE_URL;
+  const apiKey = process.env.EMAILGENERATION_SERVICE_API_KEY;
+  if (!url || !apiKey) return;
+
+  try {
+    const { COLD_EMAIL_PROMPT, COLD_EMAIL_VARIABLES } = await import("../lib/workflows.js");
+    const res = await fetch(`${url}/prompts`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "x-clerk-org-id": clerkOrgId,
+      },
+      body: JSON.stringify({
+        appId: APP_ID,
+        type: "cold-email",
+        prompt: COLD_EMAIL_PROMPT,
+        variables: COLD_EMAIL_VARIABLES,
+      }),
+    });
+
+    if (res.ok) {
+      promptRegisteredOrgs.add(clerkOrgId);
+    } else {
+      console.warn(`[Start Run] Prompt registration failed (${res.status})`);
+    }
+  } catch (err) {
+    console.warn("[Start Run] Prompt registration error (best-effort):", err);
+  }
+}
+
+/**
+ * POST /internal/start-run
+ *
+ * Performs gate checks, creates a run, fetches campaign + brand profile + next lead.
+ * Returns all data needed for the email pipeline, or an error status.
+ *
+ * Returns:
+ *   200 — run started, lead found
+ *   204 — no lead found (run created then immediately failed)
+ *   400 — bad request
+ *   404 — campaign/org not found
+ *   409 — gate check blocked
+ *   500 — internal error
+ */
+router.post("/internal/start-run", requireApiKey, async (req, res) => {
+  try {
+    const { campaignId, clerkOrgId } = req.body;
+    if (!campaignId || !clerkOrgId) {
+      return res.status(400).json({ error: "campaignId and clerkOrgId are required" });
+    }
+
+    // Look up org + campaign
+    const org = await db.query.orgs.findFirst({
+      where: eq(orgs.clerkOrgId, clerkOrgId),
+    });
+    if (!org) {
+      return res.status(404).json({ error: "Organization not found" });
+    }
+
+    const campaign = await db.query.campaigns.findFirst({
+      where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
+    });
+    if (!campaign) {
+      return res.status(404).json({ error: "Campaign not found" });
+    }
+    if (!campaign.brandUrl) {
+      return res.status(400).json({ error: "Campaign has no brandUrl" });
+    }
+    if (!campaign.brandId) {
+      return res.status(400).json({ error: "Campaign has no brandId" });
+    }
+
+    // Gate checks
+    const gateResult = await runGateChecks({
+      campaignId,
+      clerkOrgId,
+      brandId: campaign.brandId,
+      status: campaign.status,
+      maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
+      maxBudgetWeeklyUsd: campaign.maxBudgetWeeklyUsd,
+      maxBudgetMonthlyUsd: campaign.maxBudgetMonthlyUsd,
+      maxBudgetTotalUsd: campaign.maxBudgetTotalUsd,
+      maxLeads: campaign.maxLeads,
+    });
+    if (!gateResult.allowed) {
+      return res.status(409).json({
+        error: "Gate check failed",
+        reason: gateResult.reason,
+        autoStopped: gateResult.autoStopped || false,
+      });
+    }
+
+    // Register prompt template (best-effort, cached per org)
+    await ensurePromptRegistered(clerkOrgId);
+
+    // Create run in runs-service
+    const run = await createRun({
+      clerkOrgId,
+      appId: APP_ID,
+      serviceName: "campaign-service",
+      taskName: campaignId,
+      campaignId,
+      brandId: campaign.brandId,
+      clerkUserId: campaign.createdByUserId || undefined,
+    });
+
+    // Fetch brand sales profile (best-effort)
+    const brandDomain = extractDomain(campaign.brandUrl);
+    let clientData: Record<string, unknown> = {
+      companyName: brandDomain,
+      brandUrl: campaign.brandUrl,
+    };
+
+    try {
+      const brandUrl = process.env.BRAND_SERVICE_URL;
+      const brandApiKey = process.env.BRAND_SERVICE_API_KEY;
+      if (brandUrl && brandApiKey) {
+        const profileRes = await fetch(`${brandUrl}/sales-profile`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-api-key": brandApiKey,
+          },
+          body: JSON.stringify({
+            appId: campaign.appId || APP_ID,
+            clerkOrgId,
+            url: campaign.brandUrl,
+            clerkUserId: campaign.createdByUserId || "system",
+            keyType: "byok",
+            parentRunId: run.id,
+          }),
+        });
+        if (profileRes.ok) {
+          const profile = await profileRes.json() as Record<string, unknown>;
+          clientData = {
+            companyName: (profile.companyName as string) || brandDomain,
+            brandUrl: campaign.brandUrl,
+            companyOverview: profile.companyOverview,
+            valueProposition: profile.valueProposition,
+            targetAudience: profile.targetAudience,
+            customerPainPoints: Array.isArray(profile.customerPainPoints) && profile.customerPainPoints.length ? profile.customerPainPoints : undefined,
+            keyFeatures: Array.isArray(profile.keyFeatures) && profile.keyFeatures.length ? profile.keyFeatures : undefined,
+            productDifferentiators: Array.isArray(profile.productDifferentiators) && profile.productDifferentiators.length ? profile.productDifferentiators : undefined,
+            competitors: Array.isArray(profile.competitors) && profile.competitors.length ? profile.competitors : undefined,
+            socialProof: profile.socialProof,
+            callToAction: profile.callToAction,
+            additionalContext: profile.additionalContext,
+          };
+        }
+      }
+    } catch (err) {
+      console.warn("[Start Run] Brand profile fetch failed (best-effort):", err);
+    }
+
+    // Fetch next lead from lead-service (non-idempotent, no retry)
+    const leadServiceUrl = process.env.LEAD_SERVICE_URL;
+    const leadApiKey = process.env.LEAD_SERVICE_API_KEY;
+    if (!leadServiceUrl || !leadApiKey) {
+      await updateRun(run.id, "failed");
+      return res.status(500).json({ error: "Lead service not configured" });
+    }
+
+    let lead: { externalId: string; data: Record<string, unknown> } | null = null;
+    try {
+      const leadRes = await fetch(`${leadServiceUrl}/buffer/next`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": leadApiKey,
+          "x-app-id": APP_ID,
+          "x-org-id": clerkOrgId,
+        },
+        body: JSON.stringify({
+          campaignId,
+          brandId: campaign.brandId,
+          parentRunId: run.id,
+        }),
+      });
+
+      if (!leadRes.ok) {
+        throw new Error(`Lead service returned ${leadRes.status}`);
+      }
+
+      const leadData = await leadRes.json() as { found?: boolean; lead?: { externalId: string; data: Record<string, unknown> } };
+      if (!leadData.found || !leadData.lead || !leadData.lead.data?.email) {
+        // No lead found or no email → fail run immediately
+        await updateRun(run.id, "failed");
+        return res.status(204).send();
+      }
+      lead = leadData.lead;
+    } catch (err) {
+      console.error("[Start Run] Lead fetch failed:", err);
+      await updateRun(run.id, "failed");
+      return res.status(204).send();
+    }
+
+    // Return all data for the downstream DAG nodes
+    res.json({
+      runId: run.id,
+      campaignId,
+      clerkOrgId,
+      brandId: campaign.brandId,
+      appId: campaign.appId || APP_ID,
+      clerkUserId: campaign.createdByUserId,
+      targetOutcome: campaign.targetOutcome,
+      valueForTarget: campaign.valueForTarget,
+      lead: {
+        externalId: lead.externalId,
+        data: lead.data,
+      },
+      clientData,
+    });
+  } catch (error) {
+    console.error("[Start Run] Error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * POST /internal/end-run
+ *
+ * Marks a run as completed or failed, then re-triggers the workflow
+ * if the campaign is still ongoing.
+ */
+router.post("/internal/end-run", requireApiKey, async (req, res) => {
+  try {
+    const { runId, campaignId, clerkOrgId, success } = req.body;
+    if (!runId || !campaignId || !clerkOrgId) {
+      return res.status(400).json({ error: "runId, campaignId, and clerkOrgId are required" });
+    }
+
+    // Determine run status:
+    // success === true → completed; anything else → failed
+    const status = success === true ? "completed" : "failed";
+    await updateRun(runId, status);
+
+    // Respond immediately, then re-trigger asynchronously
+    res.json({ status });
+
+    // Re-trigger if campaign is still ongoing
+    try {
+      const org = await db.query.orgs.findFirst({
+        where: eq(orgs.clerkOrgId, clerkOrgId),
+      });
+      if (!org) return;
+
+      const campaign = await db.query.campaigns.findFirst({
+        where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
+      });
+      if (campaign?.status !== "ongoing") return;
+
+      // Fire-and-forget: start-run in the next workflow execution will do gate checks
+      executeColdEmailOutreach({ campaignId, clerkOrgId }).catch((err) => {
+        console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
+      });
+    } catch (err) {
+      console.error(`[End Run] Re-trigger check failed:`, err);
+    }
+  } catch (error) {
+    console.error("[End Run] Error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -44,13 +44,17 @@ export async function insertTestCampaign(
   data: {
     name?: string;
     status?: string;
+    brandUrl?: string;
+    brandId?: string;
+    appId?: string;
     maxBudgetDailyUsd?: string;
+    maxBudgetWeeklyUsd?: string;
+    maxBudgetMonthlyUsd?: string;
     maxBudgetTotalUsd?: string;
+    maxLeads?: number;
     targetAudience?: string;
     targetOutcome?: string;
     valueForTarget?: string;
-    appId?: string;
-    brandId?: string;
   } = {}
 ) {
   const [campaign] = await db
@@ -59,13 +63,17 @@ export async function insertTestCampaign(
       orgId,
       name: data.name || `Test Campaign ${Date.now()}`,
       status: data.status || "ongoing",
+      brandUrl: data.brandUrl || null,
+      brandId: data.brandId || null,
+      appId: data.appId || null,
       maxBudgetDailyUsd: data.maxBudgetDailyUsd || "10.00",
-      maxBudgetTotalUsd: data.maxBudgetTotalUsd,
+      maxBudgetWeeklyUsd: data.maxBudgetWeeklyUsd || null,
+      maxBudgetMonthlyUsd: data.maxBudgetMonthlyUsd || null,
+      maxBudgetTotalUsd: data.maxBudgetTotalUsd || null,
+      maxLeads: data.maxLeads || null,
       targetAudience: data.targetAudience || null,
       targetOutcome: data.targetOutcome || null,
       valueForTarget: data.valueForTarget || null,
-      appId: data.appId || null,
-      brandId: data.brandId || null,
     })
     .returning();
   return campaign;

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+
+const {
+  mockCreateRun,
+  mockUpdateRun,
+  mockListRuns,
+  mockGetRunsBatch,
+  mockExecute,
+  mockGateChecks,
+  mockFetch,
+} = vi.hoisted(() => ({
+  mockCreateRun: vi.fn(),
+  mockUpdateRun: vi.fn(),
+  mockListRuns: vi.fn(),
+  mockGetRunsBatch: vi.fn(),
+  mockExecute: vi.fn(),
+  mockGateChecks: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("@mcpfactory/runs-client", () => ({
+  createRun: mockCreateRun,
+  updateRun: mockUpdateRun,
+  listRuns: mockListRuns,
+  getRun: vi.fn(),
+  getRunsBatch: mockGetRunsBatch,
+  addCosts: vi.fn(),
+}));
+
+vi.mock("../../src/lib/workflows.js", () => ({
+  executeColdEmailOutreach: mockExecute,
+  deployWorkflows: vi.fn(),
+  COLD_EMAIL_PROMPT: "test prompt {{leadFirstName}}",
+  COLD_EMAIL_VARIABLES: ["leadFirstName"],
+}));
+
+vi.mock("../../src/lib/gate-check.js", () => ({
+  runGateChecks: mockGateChecks,
+}));
+
+vi.stubGlobal("fetch", mockFetch);
+
+import app from "../../src/index.js";
+import { cleanTestData, closeDb, insertTestOrg, insertTestCampaign } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+
+describe("Internal routes", () => {
+  let org: { id: string; clerkOrgId: string };
+  const brandId = crypto.randomUUID();
+
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+
+    org = await insertTestOrg({ clerkOrgId: "org_internal_test" });
+
+    // Default mock behaviors
+    mockCreateRun.mockResolvedValue({ id: "run-123" });
+    mockUpdateRun.mockResolvedValue({});
+    mockListRuns.mockResolvedValue({ runs: [] });
+    mockGetRunsBatch.mockResolvedValue(new Map());
+    mockGateChecks.mockResolvedValue({ allowed: true });
+    mockExecute.mockResolvedValue(undefined);
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /internal/start-run", () => {
+    it("should return 400 if campaignId or clerkOrgId is missing", async () => {
+      await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: "some-id" })
+        .expect(400);
+
+      await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ clerkOrgId: "some-org" })
+        .expect(400);
+    });
+
+    it("should return 404 if org not found", async () => {
+      const res = await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: "fake", clerkOrgId: "nonexistent-org" })
+        .expect(404);
+
+      expect(res.body.error).toBe("Organization not found");
+    });
+
+    it("should return 404 if campaign not found", async () => {
+      const res = await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: crypto.randomUUID(), clerkOrgId: org.clerkOrgId })
+        .expect(404);
+
+      expect(res.body.error).toBe("Campaign not found");
+    });
+
+    it("should return 400 if campaign has no brandUrl", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandId,
+        brandUrl: undefined,
+      });
+
+      const res = await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(400);
+
+      expect(res.body.error).toBe("Campaign has no brandUrl");
+    });
+
+    it("should return 400 if campaign has no brandId", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId: undefined,
+      });
+
+      const res = await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(400);
+
+      expect(res.body.error).toBe("Campaign has no brandId");
+    });
+
+    it("should return 409 when gate check fails", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      mockGateChecks.mockResolvedValue({
+        allowed: false,
+        reason: "daily budget exceeded",
+      });
+
+      const res = await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(409);
+
+      expect(res.body.error).toBe("Gate check failed");
+      expect(res.body.reason).toBe("daily budget exceeded");
+    });
+
+    it("should return 204 when no lead is found", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      // Mock prompt registration
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      // Mock brand profile (skip)
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+      // Mock lead fetch — no lead found
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ found: false }),
+      });
+
+      await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(204);
+
+      // Run should be created then immediately failed
+      expect(mockCreateRun).toHaveBeenCalledOnce();
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-123", "failed");
+    });
+
+    it("should return 200 with full pipeline data when lead is found", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+        appId: "mcpfactory",
+        targetOutcome: "Book demos",
+        valueForTarget: "Analytics platform",
+      });
+
+      // Use URL-based mock to avoid cache ordering issues
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes("/prompts")) {
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+        }
+        if (url.includes("/sales-profile")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              companyName: "Example Inc",
+              companyOverview: "A great company",
+              valueProposition: "We make things better",
+            }),
+          });
+        }
+        if (url.includes("/buffer/next")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              found: true,
+              lead: {
+                externalId: "lead-ext-1",
+                data: {
+                  first_name: "John",
+                  last_name: "Doe",
+                  title: "CTO",
+                  email: "john@acme.com",
+                  organization_name: "Acme Corp",
+                },
+              },
+            }),
+          });
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      });
+
+      const res = await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(res.body.runId).toBe("run-123");
+      expect(res.body.campaignId).toBe(campaign.id);
+      expect(res.body.clerkOrgId).toBe(org.clerkOrgId);
+      expect(res.body.brandId).toBe(brandId);
+      expect(res.body.targetOutcome).toBe("Book demos");
+      expect(res.body.lead.externalId).toBe("lead-ext-1");
+      expect(res.body.lead.data.email).toBe("john@acme.com");
+      expect(res.body.clientData.companyName).toBe("Example Inc");
+      expect(res.body.clientData.companyOverview).toBe("A great company");
+    });
+
+    it("should use fallback clientData when brand profile fails", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://www.example.com",
+        brandId,
+      });
+
+      // Use URL-based mock to avoid cache ordering issues
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes("/prompts")) {
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+        }
+        if (url.includes("/sales-profile")) {
+          return Promise.resolve({ ok: false, status: 500, text: async () => "error" });
+        }
+        if (url.includes("/buffer/next")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              found: true,
+              lead: {
+                externalId: "lead-ext-2",
+                data: { first_name: "Jane", email: "jane@test.com" },
+              },
+            }),
+          });
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      });
+
+      const res = await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      // Should fall back to domain-based clientData
+      expect(res.body.clientData.companyName).toBe("example.com");
+      expect(res.body.clientData.brandUrl).toBe("https://www.example.com");
+    });
+  });
+
+  describe("POST /internal/end-run", () => {
+    it("should return 400 if required fields are missing", async () => {
+      await request(app)
+        .post("/internal/end-run")
+        .set("x-api-key", API_KEY)
+        .send({ runId: "run-1", campaignId: "camp-1" })
+        .expect(400);
+    });
+
+    it("should mark run as completed when success is true", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      const res = await request(app)
+        .post("/internal/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          runId: "run-123",
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+          success: true,
+        })
+        .expect(200);
+
+      expect(res.body.status).toBe("completed");
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-123", "completed");
+    });
+
+    it("should mark run as failed when success is false", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      const res = await request(app)
+        .post("/internal/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          runId: "run-456",
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+          success: false,
+        })
+        .expect(200);
+
+      expect(res.body.status).toBe("failed");
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-456", "failed");
+    });
+
+    it("should re-trigger workflow if campaign is still ongoing", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+        status: "ongoing",
+      });
+
+      await request(app)
+        .post("/internal/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          runId: "run-789",
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+          success: true,
+        })
+        .expect(200);
+
+      // Wait for async re-trigger
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockExecute).toHaveBeenCalledWith({
+        campaignId: campaign.id,
+        clerkOrgId: org.clerkOrgId,
+      });
+    });
+
+    it("should NOT re-trigger if campaign is stopped", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+        status: "stopped",
+      });
+
+      await request(app)
+        .post("/internal/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          runId: "run-stopped",
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+          success: true,
+        })
+        .expect(200);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+
+const { mockExecuteColdEmailOutreach } = vi.hoisted(() => ({
+  mockExecuteColdEmailOutreach: vi.fn(),
+}));
+
+vi.mock("../../src/lib/workflows.js", () => ({
+  executeColdEmailOutreach: mockExecuteColdEmailOutreach,
+  deployWorkflows: vi.fn(),
+}));
+
+import app from "../../src/index.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+
+const validBody = {
+  name: "Activation Test Campaign",
+  clerkOrgId: "org_activation_test",
+  brandUrl: "https://example.com",
+  brandId: crypto.randomUUID(),
+  appId: "mcpfactory",
+  targetOutcome: "Book sales demos",
+  valueForTarget: "Enterprise analytics at startup pricing",
+  targetAudience: "CTOs at SaaS companies",
+};
+
+describe("Workflow activation on PATCH", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+    mockExecuteColdEmailOutreach.mockResolvedValue(undefined);
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("should trigger workflow when status is set to activate", async () => {
+    // Create campaign
+    const createRes = await request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send(validBody)
+      .expect(201);
+
+    const campaignId = createRes.body.campaign.id;
+
+    // Stop it first so we can activate
+    await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "stop" })
+      .expect(200);
+
+    vi.clearAllMocks();
+    mockExecuteColdEmailOutreach.mockResolvedValue(undefined);
+
+    // Activate
+    const activateRes = await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "activate" })
+      .expect(200);
+
+    expect(activateRes.body.campaign.status).toBe("ongoing");
+
+    // Wait a tick for the fire-and-forget promise
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockExecuteColdEmailOutreach).toHaveBeenCalledOnce();
+    expect(mockExecuteColdEmailOutreach).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId: validBody.brandId,
+        brandUrl: "https://example.com",
+        campaignId,
+        clerkOrgId: "org_activation_test",
+        targetAudience: "CTOs at SaaS companies",
+        targetOutcome: "Book sales demos",
+        valueForTarget: "Enterprise analytics at startup pricing",
+      })
+    );
+  });
+
+  it("should NOT trigger workflow when status is set to stop", async () => {
+    const createRes = await request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send(validBody)
+      .expect(201);
+
+    const campaignId = createRes.body.campaign.id;
+
+    await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "stop" })
+      .expect(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockExecuteColdEmailOutreach).not.toHaveBeenCalled();
+  });
+
+  it("should NOT trigger workflow when updating non-status fields", async () => {
+    const createRes = await request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send(validBody)
+      .expect(201);
+
+    const campaignId = createRes.body.campaign.id;
+
+    await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ name: "Updated Name" })
+      .expect(200);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockExecuteColdEmailOutreach).not.toHaveBeenCalled();
+  });
+
+  it("should still return 200 even if workflow execution fails", async () => {
+    mockExecuteColdEmailOutreach.mockRejectedValue(new Error("Windmill down"));
+
+    const createRes = await request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send(validBody)
+      .expect(201);
+
+    const campaignId = createRes.body.campaign.id;
+
+    // Stop then activate
+    await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "stop" })
+      .expect(200);
+
+    const activateRes = await request(app)
+      .patch(`/campaigns/${campaignId}`)
+      .set("x-api-key", API_KEY)
+      .set("x-clerk-org-id", "org_activation_test")
+      .send({ status: "activate" })
+      .expect(200);
+
+    expect(activateRes.body.campaign.status).toBe("ongoing");
+  });
+});

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -8,6 +8,21 @@ const { mockExecuteColdEmailOutreach } = vi.hoisted(() => ({
 vi.mock("../../src/lib/workflows.js", () => ({
   executeColdEmailOutreach: mockExecuteColdEmailOutreach,
   deployWorkflows: vi.fn(),
+  COLD_EMAIL_PROMPT: "test prompt",
+  COLD_EMAIL_VARIABLES: ["leadFirstName"],
+}));
+
+vi.mock("../../src/lib/gate-check.js", () => ({
+  runGateChecks: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock("@mcpfactory/runs-client", () => ({
+  createRun: vi.fn().mockResolvedValue({ id: "mock-run-id" }),
+  updateRun: vi.fn().mockResolvedValue({}),
+  listRuns: vi.fn().mockResolvedValue({ runs: [] }),
+  getRun: vi.fn(),
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+  addCosts: vi.fn(),
 }));
 
 import app from "../../src/index.js";
@@ -74,17 +89,10 @@ describe("Workflow activation on PATCH", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(mockExecuteColdEmailOutreach).toHaveBeenCalledOnce();
-    expect(mockExecuteColdEmailOutreach).toHaveBeenCalledWith(
-      expect.objectContaining({
-        brandId: validBody.brandId,
-        brandUrl: "https://example.com",
-        campaignId,
-        clerkOrgId: "org_activation_test",
-        targetAudience: "CTOs at SaaS companies",
-        targetOutcome: "Book sales demos",
-        valueForTarget: "Enterprise analytics at startup pricing",
-      })
-    );
+    expect(mockExecuteColdEmailOutreach).toHaveBeenCalledWith({
+      campaignId,
+      clerkOrgId: "org_activation_test",
+    });
   });
 
   it("should NOT trigger workflow when status is set to stop", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,6 +6,8 @@ process.env.SERVICE_SECRET_KEY = "test-service-secret";
 process.env.RUNS_SERVICE_URL = "https://runs.mcpfactory.org";
 process.env.RUNS_SERVICE_API_KEY = "test-api-key";
 process.env.CAMPAIGN_SERVICE_API_KEY = "test-api-key";
+process.env.WINDMILL_SERVICE_URL = "https://windmill.test.local";
+process.env.WINDMILL_SERVICE_API_KEY = "test-windmill-key";
 
 beforeAll(() => console.log("Test suite starting..."));
 afterAll(() => console.log("Test suite complete."));

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,6 +8,14 @@ process.env.RUNS_SERVICE_API_KEY = "test-api-key";
 process.env.CAMPAIGN_SERVICE_API_KEY = "test-api-key";
 process.env.WINDMILL_SERVICE_URL = "https://windmill.test.local";
 process.env.WINDMILL_SERVICE_API_KEY = "test-windmill-key";
+process.env.BRAND_SERVICE_URL = "https://brand.test.local";
+process.env.BRAND_SERVICE_API_KEY = "test-brand-key";
+process.env.LEAD_SERVICE_URL = "https://lead.test.local";
+process.env.LEAD_SERVICE_API_KEY = "test-lead-key";
+process.env.EMAILGENERATION_SERVICE_URL = "https://emailgen.test.local";
+process.env.EMAILGENERATION_SERVICE_API_KEY = "test-emailgen-key";
+process.env.EMAIL_GATEWAY_SERVICE_URL = "https://email-gateway.test.local";
+process.env.EMAIL_GATEWAY_SERVICE_API_KEY = "test-gateway-key";
 
 beforeAll(() => console.log("Test suite starting..."));
 afterAll(() => console.log("Test suite complete."));

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  mockListRuns,
+  mockUpdateRun,
+  mockGetRunsBatch,
+  mockDbUpdate,
+} = vi.hoisted(() => {
+  const mockSet = vi.fn().mockReturnValue({
+    where: vi.fn().mockResolvedValue(undefined),
+  });
+  return {
+    mockListRuns: vi.fn(),
+    mockUpdateRun: vi.fn(),
+    mockGetRunsBatch: vi.fn(),
+    mockDbUpdate: vi.fn().mockReturnValue({ set: mockSet }),
+  };
+});
+
+vi.mock("@mcpfactory/runs-client", () => ({
+  listRuns: mockListRuns,
+  updateRun: mockUpdateRun,
+  getRunsBatch: mockGetRunsBatch,
+  getRun: vi.fn(),
+}));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    update: mockDbUpdate,
+  },
+}));
+
+vi.mock("../../src/db/schema.js", () => ({
+  campaigns: { id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+}));
+
+// Mock fetch for lead stats
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { runGateChecks, type GateCheckInput } from "../../src/lib/gate-check.js";
+
+function makeCampaign(overrides: Partial<GateCheckInput> = {}): GateCheckInput {
+  return {
+    campaignId: "campaign-1",
+    clerkOrgId: "org-1",
+    brandId: "brand-1",
+    status: "ongoing",
+    maxBudgetDailyUsd: "10.00",
+    maxBudgetWeeklyUsd: null,
+    maxBudgetMonthlyUsd: null,
+    maxBudgetTotalUsd: null,
+    maxLeads: null,
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<{ id: string; status: string; startedAt: string }> = {}) {
+  return {
+    id: overrides.id || crypto.randomUUID(),
+    status: overrides.status || "completed",
+    startedAt: overrides.startedAt || new Date().toISOString(),
+    parentRunId: null,
+    organizationId: "org-1",
+    userId: null,
+    appId: "mcpfactory",
+    brandId: null,
+    campaignId: "campaign-1",
+    serviceName: "campaign-service",
+    taskName: "campaign-1",
+    completedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe("Gate Check", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListRuns.mockResolvedValue({ runs: [] });
+    mockGetRunsBatch.mockResolvedValue(new Map());
+    mockUpdateRun.mockResolvedValue({});
+  });
+
+  it("should block if campaign is not ongoing", async () => {
+    const result = await runGateChecks(makeCampaign({ status: "stopped" }));
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("Campaign is not ongoing");
+  });
+
+  it("should allow when campaign is ongoing and gates pass", async () => {
+    const result = await runGateChecks(makeCampaign());
+    expect(result.allowed).toBe(true);
+  });
+
+  describe("Stale run cleanup", () => {
+    it("should mark runs running > 30 min as failed", async () => {
+      const staleRun = makeRun({
+        id: "stale-run-1",
+        status: "running",
+        startedAt: new Date(Date.now() - 31 * 60 * 1000).toISOString(),
+      });
+      mockListRuns.mockResolvedValue({ runs: [staleRun] });
+
+      await runGateChecks(makeCampaign());
+
+      expect(mockUpdateRun).toHaveBeenCalledWith("stale-run-1", "failed");
+    });
+
+    it("should NOT mark recent running runs as stale", async () => {
+      const recentRun = makeRun({
+        id: "recent-run",
+        status: "running",
+        startedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      });
+      mockListRuns.mockResolvedValue({ runs: [recentRun] });
+
+      const result = await runGateChecks(makeCampaign());
+
+      expect(mockUpdateRun).not.toHaveBeenCalled();
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("A run is already in progress");
+    });
+  });
+
+  describe("Running run check", () => {
+    it("should block if a run is already in progress", async () => {
+      const runningRun = makeRun({
+        status: "running",
+        startedAt: new Date(Date.now() - 1000).toISOString(),
+      });
+      mockListRuns.mockResolvedValue({ runs: [runningRun] });
+
+      const result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("A run is already in progress");
+    });
+  });
+
+  describe("Budget check", () => {
+    it("should block if no budget is defined (fail-closed)", async () => {
+      const result = await runGateChecks(makeCampaign({
+        maxBudgetDailyUsd: null,
+        maxBudgetWeeklyUsd: null,
+        maxBudgetMonthlyUsd: null,
+        maxBudgetTotalUsd: null,
+      }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("No budget defined (fail-closed)");
+    });
+
+    it("should block when daily budget is exceeded", async () => {
+      const run = makeRun({ id: "run-1", status: "completed" });
+      mockListRuns.mockResolvedValue({ runs: [run] });
+      mockGetRunsBatch.mockResolvedValue(
+        new Map([["run-1", { totalCostInUsdCents: "1500" }]])
+      );
+
+      const result = await runGateChecks(makeCampaign({
+        maxBudgetDailyUsd: "10.00", // 1000 cents
+      }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("daily budget exceeded");
+    });
+
+    it("should allow when budget is not exceeded", async () => {
+      const run = makeRun({ id: "run-1", status: "completed" });
+      mockListRuns.mockResolvedValue({ runs: [run] });
+      mockGetRunsBatch.mockResolvedValue(
+        new Map([["run-1", { totalCostInUsdCents: "500" }]])
+      );
+
+      const result = await runGateChecks(makeCampaign({
+        maxBudgetDailyUsd: "10.00",
+      }));
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should auto-stop campaign when total budget is exceeded", async () => {
+      const run = makeRun({ id: "run-1", status: "completed" });
+      mockListRuns.mockResolvedValue({ runs: [run] });
+      mockGetRunsBatch.mockResolvedValue(
+        new Map([["run-1", { totalCostInUsdCents: "5500" }]])
+      );
+
+      const result = await runGateChecks(makeCampaign({
+        maxBudgetDailyUsd: "100.00",
+        maxBudgetTotalUsd: "50.00",
+      }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Total budget exceeded");
+      expect(result.autoStopped).toBe(true);
+      expect(mockDbUpdate).toHaveBeenCalled();
+    });
+  });
+
+  describe("Volume check", () => {
+    it("should auto-stop when maxLeads is reached", async () => {
+      const runs = [
+        makeRun({ id: "r1", status: "completed" }),
+        makeRun({ id: "r2", status: "completed" }),
+        makeRun({ id: "r3", status: "completed" }),
+      ];
+      mockListRuns.mockResolvedValue({ runs });
+      mockGetRunsBatch.mockResolvedValue(new Map());
+
+      // Mock lead stats
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ totalServed: 3 }),
+      });
+
+      const result = await runGateChecks(makeCampaign({ maxLeads: 3 }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Max leads reached");
+      expect(result.autoStopped).toBe(true);
+    });
+
+    it("should allow when maxLeads is not reached", async () => {
+      const runs = [makeRun({ id: "r1", status: "completed" })];
+      mockListRuns.mockResolvedValue({ runs });
+      mockGetRunsBatch.mockResolvedValue(new Map());
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ totalServed: 1 }),
+      });
+
+      const result = await runGateChecks(makeCampaign({ maxLeads: 10 }));
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should fallback to completed run count on 404 from lead-service", async () => {
+      const runs = [
+        makeRun({ id: "r1", status: "completed" }),
+        makeRun({ id: "r2", status: "completed" }),
+      ];
+      mockListRuns.mockResolvedValue({ runs });
+      mockGetRunsBatch.mockResolvedValue(new Map());
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await runGateChecks(makeCampaign({ maxLeads: 5 }));
+      expect(result.allowed).toBe(true); // 2 completed < 5 maxLeads
+    });
+
+    it("should block on non-404 lead-service error (fail-closed)", async () => {
+      mockListRuns.mockResolvedValue({ runs: [] });
+      mockGetRunsBatch.mockResolvedValue(new Map());
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      const result = await runGateChecks(makeCampaign({ maxLeads: 10 }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Lead stats unavailable (fail-closed)");
+    });
+  });
+
+  describe("Consecutive failures check", () => {
+    it("should auto-stop after 3 consecutive failures", async () => {
+      const runs = [
+        makeRun({ id: "r1", status: "failed", startedAt: new Date(Date.now() - 1000).toISOString() }),
+        makeRun({ id: "r2", status: "failed", startedAt: new Date(Date.now() - 2000).toISOString() }),
+        makeRun({ id: "r3", status: "failed", startedAt: new Date(Date.now() - 3000).toISOString() }),
+      ];
+      mockListRuns.mockResolvedValue({ runs });
+      mockGetRunsBatch.mockResolvedValue(new Map());
+
+      const result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("3 consecutive failures");
+      expect(result.autoStopped).toBe(true);
+    });
+
+    it("should allow when failures are not consecutive", async () => {
+      const runs = [
+        makeRun({ id: "r1", status: "failed", startedAt: new Date(Date.now() - 1000).toISOString() }),
+        makeRun({ id: "r2", status: "completed", startedAt: new Date(Date.now() - 2000).toISOString() }),
+        makeRun({ id: "r3", status: "failed", startedAt: new Date(Date.now() - 3000).toISOString() }),
+      ];
+      mockListRuns.mockResolvedValue({ runs });
+      mockGetRunsBatch.mockResolvedValue(new Map());
+
+      const result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should allow when fewer than 3 consecutive failures", async () => {
+      const runs = [
+        makeRun({ id: "r1", status: "failed", startedAt: new Date(Date.now() - 1000).toISOString() }),
+        makeRun({ id: "r2", status: "failed", startedAt: new Date(Date.now() - 2000).toISOString() }),
+      ];
+      mockListRuns.mockResolvedValue({ runs });
+      mockGetRunsBatch.mockResolvedValue(new Map());
+
+      const result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+    });
+  });
+});

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { buildColdEmailDag } from "../../src/lib/workflows.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("Workflow module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("buildColdEmailDag", () => {
+    it("should produce a valid DAG with nodes and edges", () => {
+      const dag = buildColdEmailDag();
+
+      expect(dag.nodes).toBeDefined();
+      expect(dag.edges).toBeDefined();
+      expect(dag.nodes.length).toBeGreaterThan(0);
+      expect(dag.edges.length).toBeGreaterThan(0);
+    });
+
+    it("should have the correct top-level node sequence", () => {
+      const dag = buildColdEmailDag();
+      const nodeIds = dag.nodes.map((n) => n.id);
+
+      expect(nodeIds).toContain("register-prompt");
+      expect(nodeIds).toContain("extract-brand");
+      expect(nodeIds).toContain("suggest-icp");
+      expect(nodeIds).toContain("search-leads");
+      expect(nodeIds).toContain("process-leads");
+    });
+
+    it("should have correct edge ordering", () => {
+      const dag = buildColdEmailDag();
+
+      expect(dag.edges).toEqual([
+        { from: "register-prompt", to: "extract-brand" },
+        { from: "extract-brand", to: "suggest-icp" },
+        { from: "suggest-icp", to: "search-leads" },
+        { from: "search-leads", to: "process-leads" },
+      ]);
+    });
+
+    it("should have process-leads as for-each with sub-nodes", () => {
+      const dag = buildColdEmailDag();
+      const forEachNode = dag.nodes.find((n) => n.id === "process-leads");
+
+      expect(forEachNode).toBeDefined();
+      expect(forEachNode!.type).toBe("for-each");
+      expect(forEachNode!.config.iterator).toBe("$ref:search-leads.output.people");
+
+      const subDag = forEachNode!.config.dag as { nodes: { id: string }[]; edges: { from: string; to: string }[] };
+      expect(subDag.nodes.map((n) => n.id)).toEqual(["enrich-lead", "generate-email", "send-email"]);
+      expect(subDag.edges).toEqual([
+        { from: "enrich-lead", to: "generate-email" },
+        { from: "generate-email", to: "send-email" },
+      ]);
+    });
+
+    it("should use http.call type for all service nodes", () => {
+      const dag = buildColdEmailDag();
+
+      for (const node of dag.nodes) {
+        if (node.type !== "for-each") {
+          expect(node.type).toBe("http.call");
+          expect(node.config.service).toBeDefined();
+          expect(node.config.method).toBeDefined();
+          expect(node.config.path).toBeDefined();
+        }
+      }
+    });
+
+    it("should reference correct services", () => {
+      const dag = buildColdEmailDag();
+      const serviceMap: Record<string, string> = {};
+
+      for (const node of dag.nodes) {
+        if (node.config.service) {
+          serviceMap[node.id] = node.config.service as string;
+        }
+      }
+
+      expect(serviceMap["register-prompt"]).toBe("emailgeneration");
+      expect(serviceMap["extract-brand"]).toBe("brand");
+      expect(serviceMap["suggest-icp"]).toBe("brand");
+      expect(serviceMap["search-leads"]).toBe("apollo");
+    });
+  });
+
+  describe("deployWorkflows", () => {
+    it("should call PUT /workflows/deploy with correct payload", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ workflows: [{ name: "cold-email-outreach", action: "created" }] }),
+      });
+
+      const { deployWorkflows } = await import("../../src/lib/workflows.js");
+      await deployWorkflows();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://windmill.test.local/workflows/deploy");
+      expect(opts.method).toBe("PUT");
+      expect(opts.headers["x-api-key"]).toBe("test-windmill-key");
+
+      const body = JSON.parse(opts.body);
+      expect(body.appId).toBe("mcpfactory");
+      expect(body.workflows).toHaveLength(1);
+      expect(body.workflows[0].name).toBe("cold-email-outreach");
+      expect(body.workflows[0].dag.nodes).toBeDefined();
+    });
+
+    it("should not throw when windmill env vars are missing", async () => {
+      const originalUrl = process.env.WINDMILL_SERVICE_URL;
+      delete process.env.WINDMILL_SERVICE_URL;
+
+      const { deployWorkflows } = await import("../../src/lib/workflows.js");
+      await expect(deployWorkflows()).resolves.not.toThrow();
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      process.env.WINDMILL_SERVICE_URL = originalUrl;
+    });
+
+    it("should not throw when deployment fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "Internal server error",
+      });
+
+      const { deployWorkflows } = await import("../../src/lib/workflows.js");
+      await expect(deployWorkflows()).resolves.not.toThrow();
+    });
+  });
+
+  describe("executeColdEmailOutreach", () => {
+    it("should call POST /workflows/by-name/cold-email-outreach/execute", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-123", status: "queued" }),
+      });
+
+      const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
+      await executeColdEmailOutreach({
+        brandId: "brand-1",
+        brandUrl: "https://example.com",
+        campaignId: "campaign-1",
+        clerkOrgId: "org_test",
+        clerkUserId: "user_test",
+        targetAudience: "CEOs at SaaS startups",
+        targetOutcome: "Book demos",
+        valueForTarget: "Enterprise analytics",
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://windmill.test.local/workflows/by-name/cold-email-outreach/execute");
+      expect(opts.method).toBe("POST");
+
+      const body = JSON.parse(opts.body);
+      expect(body.appId).toBe("mcpfactory");
+      expect(body.orgId).toBe("org_test");
+      expect(body.inputs.brandId).toBe("brand-1");
+      expect(body.inputs.campaignId).toBe("campaign-1");
+      expect(body.inputs.clerkOrgId).toBe("org_test");
+      expect(body.inputs.targetAudience).toBe("CEOs at SaaS startups");
+    });
+
+    it("should handle null optional fields gracefully", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-456", status: "queued" }),
+      });
+
+      const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
+      await executeColdEmailOutreach({
+        brandId: "brand-1",
+        brandUrl: "https://example.com",
+        campaignId: "campaign-1",
+        clerkOrgId: "org_test",
+        targetAudience: null,
+        targetOutcome: null,
+        valueForTarget: null,
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.inputs.targetAudience).toBe("");
+      expect(body.inputs.targetOutcome).toBe("");
+      expect(body.inputs.valueForTarget).toBe("");
+    });
+
+    it("should not throw when execution fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => "Workflow not found",
+      });
+
+      const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
+      await expect(
+        executeColdEmailOutreach({
+          brandId: "brand-1",
+          brandUrl: "https://example.com",
+          campaignId: "campaign-1",
+          clerkOrgId: "org_test",
+        })
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { buildColdEmailDag } from "../../src/lib/workflows.js";
+import { buildColdEmailDag, COLD_EMAIL_PROMPT, COLD_EMAIL_VARIABLES } from "../../src/lib/workflows.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -13,81 +13,126 @@ describe("Workflow module", () => {
     vi.restoreAllMocks();
   });
 
+  describe("COLD_EMAIL_PROMPT", () => {
+    it("should contain all variable placeholders", () => {
+      for (const variable of COLD_EMAIL_VARIABLES) {
+        expect(COLD_EMAIL_PROMPT).toContain(`{{${variable}}}`);
+      }
+    });
+  });
+
   describe("buildColdEmailDag", () => {
     it("should produce a valid DAG with nodes and edges", () => {
       const dag = buildColdEmailDag();
-
       expect(dag.nodes).toBeDefined();
       expect(dag.edges).toBeDefined();
-      expect(dag.nodes.length).toBeGreaterThan(0);
-      expect(dag.edges.length).toBeGreaterThan(0);
+      expect(dag.nodes.length).toBe(4);
+      expect(dag.edges.length).toBe(3);
     });
 
-    it("should have the correct top-level node sequence", () => {
+    it("should have the correct node sequence: start-run → email-generate → email-send → end-run", () => {
       const dag = buildColdEmailDag();
       const nodeIds = dag.nodes.map((n) => n.id);
-
-      expect(nodeIds).toContain("register-prompt");
-      expect(nodeIds).toContain("extract-brand");
-      expect(nodeIds).toContain("suggest-icp");
-      expect(nodeIds).toContain("search-leads");
-      expect(nodeIds).toContain("process-leads");
+      expect(nodeIds).toEqual(["start-run", "email-generate", "email-send", "end-run"]);
     });
 
     it("should have correct edge ordering", () => {
       const dag = buildColdEmailDag();
-
       expect(dag.edges).toEqual([
-        { from: "register-prompt", to: "extract-brand" },
-        { from: "extract-brand", to: "suggest-icp" },
-        { from: "suggest-icp", to: "search-leads" },
-        { from: "search-leads", to: "process-leads" },
+        { from: "start-run", to: "email-generate" },
+        { from: "email-generate", to: "email-send" },
+        { from: "email-send", to: "end-run" },
       ]);
     });
 
-    it("should have process-leads as for-each with sub-nodes", () => {
+    it("should use http.call type for all nodes", () => {
       const dag = buildColdEmailDag();
-      const forEachNode = dag.nodes.find((n) => n.id === "process-leads");
-
-      expect(forEachNode).toBeDefined();
-      expect(forEachNode!.type).toBe("for-each");
-      expect(forEachNode!.config.iterator).toBe("$ref:search-leads.output.people");
-
-      const subDag = forEachNode!.config.dag as { nodes: { id: string }[]; edges: { from: string; to: string }[] };
-      expect(subDag.nodes.map((n) => n.id)).toEqual(["enrich-lead", "generate-email", "send-email"]);
-      expect(subDag.edges).toEqual([
-        { from: "enrich-lead", to: "generate-email" },
-        { from: "generate-email", to: "send-email" },
-      ]);
-    });
-
-    it("should use http.call type for all service nodes", () => {
-      const dag = buildColdEmailDag();
-
       for (const node of dag.nodes) {
-        if (node.type !== "for-each") {
-          expect(node.type).toBe("http.call");
-          expect(node.config.service).toBeDefined();
-          expect(node.config.method).toBeDefined();
-          expect(node.config.path).toBeDefined();
-        }
+        expect(node.type).toBe("http.call");
+        expect(node.config.service).toBeDefined();
+        expect(node.config.method).toBeDefined();
+        expect(node.config.path).toBeDefined();
       }
     });
 
     it("should reference correct services", () => {
       const dag = buildColdEmailDag();
       const serviceMap: Record<string, string> = {};
-
       for (const node of dag.nodes) {
-        if (node.config.service) {
-          serviceMap[node.id] = node.config.service as string;
-        }
+        serviceMap[node.id] = node.config.service as string;
       }
+      expect(serviceMap["start-run"]).toBe("campaign");
+      expect(serviceMap["email-generate"]).toBe("emailgeneration");
+      expect(serviceMap["email-send"]).toBe("email-gateway");
+      expect(serviceMap["end-run"]).toBe("campaign");
+    });
 
-      expect(serviceMap["register-prompt"]).toBe("emailgeneration");
-      expect(serviceMap["extract-brand"]).toBe("brand");
-      expect(serviceMap["suggest-icp"]).toBe("brand");
-      expect(serviceMap["search-leads"]).toBe("apollo");
+    it("should set retries: 0 on non-idempotent nodes", () => {
+      const dag = buildColdEmailDag();
+      const noRetryNodes = ["start-run", "email-generate", "email-send"];
+      for (const nodeId of noRetryNodes) {
+        const node = dag.nodes.find((n) => n.id === nodeId);
+        expect(node?.config.retries).toBe(0);
+      }
+    });
+
+    it("should have validateResponse on email-send to catch success: false", () => {
+      const dag = buildColdEmailDag();
+      const emailSend = dag.nodes.find((n) => n.id === "email-send");
+      expect(emailSend?.config.validateResponse).toEqual({
+        field: "success",
+        equals: true,
+      });
+    });
+
+    it("should have onError handler pointing to end-run", () => {
+      const dag = buildColdEmailDag();
+      expect(dag.onError).toBe("end-run");
+    });
+
+    it("should set success: true in end-run body (overridden to false by onError)", () => {
+      const dag = buildColdEmailDag();
+      const endRun = dag.nodes.find((n) => n.id === "end-run");
+      expect(endRun?.config.body).toEqual({ success: true });
+    });
+
+    it("should map all lead data fields from start-run to email-generate", () => {
+      const dag = buildColdEmailDag();
+      const emailGen = dag.nodes.find((n) => n.id === "email-generate");
+      const mapping = emailGen?.inputMapping || {};
+
+      // Lead fields
+      expect(mapping["body.leadFirstName"]).toBe("$ref:start-run.output.lead.data.first_name");
+      expect(mapping["body.leadLastName"]).toBe("$ref:start-run.output.lead.data.last_name");
+      expect(mapping["body.leadEmail"]).toBe("$ref:start-run.output.lead.data.email");
+      expect(mapping["body.leadCompanyName"]).toBe("$ref:start-run.output.lead.data.organization_name");
+
+      // Client fields
+      expect(mapping["body.clientCompanyName"]).toBe("$ref:start-run.output.clientData.companyName");
+      expect(mapping["body.clientBrandUrl"]).toBe("$ref:start-run.output.clientData.brandUrl");
+
+      // Campaign fields
+      expect(mapping["body.targetOutcome"]).toBe("$ref:start-run.output.targetOutcome");
+      expect(mapping["body.valueForTarget"]).toBe("$ref:start-run.output.valueForTarget");
+    });
+
+    it("should pass email-generate output to email-send", () => {
+      const dag = buildColdEmailDag();
+      const emailSend = dag.nodes.find((n) => n.id === "email-send");
+      const mapping = emailSend?.inputMapping || {};
+
+      expect(mapping["body.subject"]).toBe("$ref:email-generate.output.subject");
+      expect(mapping["body.htmlBody"]).toBe("$ref:email-generate.output.bodyHtml");
+      expect(mapping["body.metadata.emailGenerationId"]).toBe("$ref:email-generate.output.id");
+    });
+
+    it("should use flow_input for start-run inputs", () => {
+      const dag = buildColdEmailDag();
+      const startRun = dag.nodes.find((n) => n.id === "start-run");
+      expect(startRun?.inputMapping).toEqual({
+        "body.campaignId": "$ref:flow_input.campaignId",
+        "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+      });
     });
   });
 
@@ -111,7 +156,8 @@ describe("Workflow module", () => {
       expect(body.appId).toBe("mcpfactory");
       expect(body.workflows).toHaveLength(1);
       expect(body.workflows[0].name).toBe("cold-email-outreach");
-      expect(body.workflows[0].dag.nodes).toBeDefined();
+      expect(body.workflows[0].dag.nodes).toHaveLength(4);
+      expect(body.workflows[0].dag.onError).toBe("end-run");
     });
 
     it("should not throw when windmill env vars are missing", async () => {
@@ -138,7 +184,7 @@ describe("Workflow module", () => {
   });
 
   describe("executeColdEmailOutreach", () => {
-    it("should call POST /workflows/by-name/cold-email-outreach/execute", async () => {
+    it("should call POST /workflows/by-name/cold-email-outreach/execute with campaignId and clerkOrgId", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ id: "run-123", status: "queued" }),
@@ -146,14 +192,8 @@ describe("Workflow module", () => {
 
       const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
       await executeColdEmailOutreach({
-        brandId: "brand-1",
-        brandUrl: "https://example.com",
         campaignId: "campaign-1",
         clerkOrgId: "org_test",
-        clerkUserId: "user_test",
-        targetAudience: "CEOs at SaaS startups",
-        targetOutcome: "Book demos",
-        valueForTarget: "Enterprise analytics",
       });
 
       expect(mockFetch).toHaveBeenCalledOnce();
@@ -164,33 +204,10 @@ describe("Workflow module", () => {
       const body = JSON.parse(opts.body);
       expect(body.appId).toBe("mcpfactory");
       expect(body.orgId).toBe("org_test");
-      expect(body.inputs.brandId).toBe("brand-1");
-      expect(body.inputs.campaignId).toBe("campaign-1");
-      expect(body.inputs.clerkOrgId).toBe("org_test");
-      expect(body.inputs.targetAudience).toBe("CEOs at SaaS startups");
-    });
-
-    it("should handle null optional fields gracefully", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ id: "run-456", status: "queued" }),
-      });
-
-      const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
-      await executeColdEmailOutreach({
-        brandId: "brand-1",
-        brandUrl: "https://example.com",
+      expect(body.inputs).toEqual({
         campaignId: "campaign-1",
         clerkOrgId: "org_test",
-        targetAudience: null,
-        targetOutcome: null,
-        valueForTarget: null,
       });
-
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(body.inputs.targetAudience).toBe("");
-      expect(body.inputs.targetOutcome).toBe("");
-      expect(body.inputs.valueForTarget).toBe("");
     });
 
     it("should not throw when execution fails", async () => {
@@ -203,8 +220,6 @@ describe("Workflow module", () => {
       const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
       await expect(
         executeColdEmailOutreach({
-          brandId: "brand-1",
-          brandUrl: "https://example.com",
           campaignId: "campaign-1",
           clerkOrgId: "org_test",
         })


### PR DESCRIPTION
## Summary
- Rewrites the cold email outreach workflow from batch processing to a sequential 1-lead-per-run pipeline via Windmill DAG (start-run → email-generate → email-send → end-run)
- Adds gate checks (budget 4 windows, volume, stale cleanup, consecutive failures, running run) with fail-closed semantics and auto-stop on total budget/maxLeads/3 consecutive failures
- Adds internal endpoints (`/internal/start-run`, `/internal/end-run`) that consolidate pipeline orchestration: campaign lookup, brand profile (best-effort), lead fetch, run lifecycle, and back-to-back re-trigger

## Test plan
- [x] 16 unit tests for gate check logic (budget, volume, stale cleanup, consecutive failures)
- [x] 18 unit tests for DAG structure, input mappings, deploy, and execute
- [x] 14 integration tests for internal start-run and end-run endpoints
- [x] 4 integration tests for workflow activation on campaign PATCH
- [x] All 96 tests passing, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)