### PR TITLE
feat: add campaign type field for workflow routing

### DIFF
--- a/drizzle/0013_mature_silver_sable.sql
+++ b/drizzle/0013_mature_silver_sable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "campaigns" ADD COLUMN "type" text DEFAULT 'cold-email-outreach' NOT NULL;

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,373 @@
+{
+  "id": "4ea68504-80b0-4001-8381-3b79e00c96c8",
+  "prevId": "a1b2c3d4-0012-4000-b000-000000000012",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cold-email-outreach'"
+        },
+        "brand_url": {
+          "name": "brand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_outcome": {
+          "name": "target_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_for_target": {
+          "name": "value_for_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_daily_usd": {
+          "name": "max_budget_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_weekly_usd": {
+          "name": "max_budget_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_monthly_usd": {
+          "name": "max_budget_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_total_usd": {
+          "name": "max_budget_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_leads": {
+          "name": "max_leads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ongoing'"
+        },
+        "to_resume_at": {
+          "name": "to_resume_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_frequency": {
+          "name": "notify_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_channel": {
+          "name": "notify_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_destination": {
+          "name": "notify_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_campaigns_org": {
+          "name": "idx_campaigns_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_campaigns_app_id": {
+          "name": "idx_campaigns_app_id",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaigns_org_id_orgs_id_fk": {
+          "name": "campaigns_org_id_orgs_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_created_by_user_id_users_id_fk": {
+          "name": "campaigns_created_by_user_id_users_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_clerk_id": {
+          "name": "idx_orgs_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_clerk_id": {
+          "name": "idx_users_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1771400000000,
       "tag": "0012_add_target_outcome_value",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1771328408543,
+      "tag": "0013_mature_silver_sable",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -40,7 +40,10 @@ export const campaigns = pgTable(
       .references(() => users.id),  // Optional - MCP calls don't have user context
     
     name: text("name").notNull(),
-    
+
+    // Campaign type — determines which Windmill DAG to execute
+    type: text("type").notNull().default("cold-email-outreach"),
+
     // Brand URL - used to identify which brand this campaign promotes
     brandUrl: text("brand_url"),
     

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -251,10 +251,10 @@ export async function deployWorkflows(): Promise<void> {
   console.log("[Campaign Service] Workflows deployed:", data.workflows?.map((w) => `${w.name} (${w.action})`).join(", "));
 }
 
-export async function executeColdEmailOutreach(inputs: {
-  campaignId: string;
-  clerkOrgId: string;
-}): Promise<void> {
+export async function executeCampaignWorkflow(
+  type: string,
+  inputs: { campaignId: string; clerkOrgId: string },
+): Promise<void> {
   const url = process.env.WINDMILL_SERVICE_URL;
   const apiKey = process.env.WINDMILL_SERVICE_API_KEY;
 
@@ -263,7 +263,7 @@ export async function executeColdEmailOutreach(inputs: {
     return;
   }
 
-  const res = await fetch(`${url}/workflows/by-name/cold-email-outreach/execute`, {
+  const res = await fetch(`${url}/workflows/by-name/${type}/execute`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -286,7 +286,7 @@ export async function executeColdEmailOutreach(inputs: {
   }
 
   const data = await res.json() as { id?: string; status?: string };
-  console.log(`[Campaign Service] Cold email workflow started: run=${data.id}, status=${data.status}`);
+  console.log(`[Campaign Service] Workflow ${type} started: run=${data.id}, status=${data.status}`);
 }
 
 export { buildColdEmailDag };

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -7,7 +7,7 @@ import { validateBody } from "../middleware/validate.js";
 import { normalizeUrl, extractDomain } from "../lib/domain.js";
 import { listRuns, getRunsBatch, type Run, type RunWithCosts } from "@mcpfactory/runs-client";
 import { CreateCampaignBody, UpdateCampaignBody, StatsFilterBody, BatchBudgetUsageBody } from "../schemas.js";
-import { executeColdEmailOutreach } from "../lib/workflows.js";
+import { executeCampaignWorkflow } from "../lib/workflows.js";
 
 const router = Router();
 
@@ -23,6 +23,7 @@ router.get("/campaigns/list", requireApiKey, async (_req, res) => {
         id: campaigns.id,
         orgId: campaigns.orgId,
         name: campaigns.name,
+        type: campaigns.type,
         status: campaigns.status,
         targetAudience: campaigns.targetAudience,
         targetOutcome: campaigns.targetOutcome,
@@ -240,6 +241,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
   try {
     const {
       name,
+      type,
       brandUrl,
       brandId,
       appId,
@@ -267,6 +269,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         orgId: req.orgId!,
         createdByUserId: req.userId ?? null,
         name,
+        type,
         appId,
         brandUrl: normalizedBrandUrl,
         brandId,
@@ -324,9 +327,9 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
       .where(eq(campaigns.id, id))
       .returning();
 
-    // Trigger cold email workflow on activation
+    // Trigger workflow on activation, routed by campaign type
     if (req.body.status === "activate") {
-      executeColdEmailOutreach({
+      executeCampaignWorkflow(updated.type, {
         campaignId: updated.id,
         clerkOrgId: req.clerkOrgId!,
       }).catch((err) => {

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -5,7 +5,7 @@ import { campaigns, orgs } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
 import { createRun, updateRun } from "@mcpfactory/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
-import { executeColdEmailOutreach } from "../lib/workflows.js";
+import { executeCampaignWorkflow } from "../lib/workflows.js";
 import { extractDomain } from "../lib/domain.js";
 
 const router = Router();
@@ -270,7 +270,7 @@ router.post("/internal/end-run", requireApiKey, async (req, res) => {
       if (campaign?.status !== "ongoing") return;
 
       // Fire-and-forget: start-run in the next workflow execution will do gate checks
-      executeColdEmailOutreach({ campaignId, clerkOrgId }).catch((err) => {
+      executeCampaignWorkflow(campaign.type, { campaignId, clerkOrgId }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });
     } catch (err) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -14,6 +14,7 @@ export const CampaignSchema = z.object({
   orgId: z.string().uuid(),
   createdByUserId: z.string().uuid().nullable(),
   name: z.string(),
+  type: z.string(),
   brandUrl: z.string().nullable(),
   brandId: z.string().uuid().nullable(),
   appId: z.string().nullable(),
@@ -40,6 +41,7 @@ export const CampaignSchema = z.object({
 
 export const CreateCampaignBody = z.object({
   name: z.string().min(1, "Campaign name is required"),
+  type: z.string().min(1, "type is required"),
   clerkOrgId: z.string().min(1, "clerkOrgId is required"),
   brandUrl: z.string().min(1, "brandUrl is required"),
   brandId: z.string().uuid("brandId must be a valid UUID"),

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -43,6 +43,7 @@ export async function insertTestCampaign(
   orgId: string,
   data: {
     name?: string;
+    type?: string;
     status?: string;
     brandUrl?: string;
     brandId?: string;
@@ -62,6 +63,7 @@ export async function insertTestCampaign(
     .values({
       orgId,
       name: data.name || `Test Campaign ${Date.now()}`,
+      type: data.type || "cold-email-outreach",
       status: data.status || "ongoing",
       brandUrl: data.brandUrl || null,
       brandId: data.brandId || null,

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -17,6 +17,7 @@ describe("Campaign CRUD", () => {
 
   const validBody = {
     name: "Test Campaign",
+    type: "cold-email-outreach",
     clerkOrgId: "org_test_crud",
     brandUrl: "https://example.com",
     brandId: crypto.randomUUID(),
@@ -36,8 +37,22 @@ describe("Campaign CRUD", () => {
 
       expect(res.body.campaign).toBeDefined();
       expect(res.body.campaign.name).toBe("Test Campaign");
+      expect(res.body.campaign.type).toBe("cold-email-outreach");
       expect(res.body.campaign.brandId).toBe(validBody.brandId);
       expect(res.body.campaign.appId).toBe("mcpfactory");
+    });
+
+    it("should reject when type is missing", async () => {
+      const { type, ...body } = validBody;
+
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send(body)
+        .expect(400);
+
+      expect(res.body.error).toBeDefined();
     });
 
     it("should reject when brandId is missing", async () => {

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -29,7 +29,7 @@ vi.mock("@mcpfactory/runs-client", () => ({
 }));
 
 vi.mock("../../src/lib/workflows.js", () => ({
-  executeColdEmailOutreach: mockExecute,
+  executeCampaignWorkflow: mockExecute,
   deployWorkflows: vi.fn(),
   COLD_EMAIL_PROMPT: "test prompt {{leadFirstName}}",
   COLD_EMAIL_VARIABLES: ["leadFirstName"],
@@ -358,10 +358,13 @@ describe("Internal routes", () => {
       // Wait for async re-trigger
       await new Promise((r) => setTimeout(r, 100));
 
-      expect(mockExecute).toHaveBeenCalledWith({
-        campaignId: campaign.id,
-        clerkOrgId: org.clerkOrgId,
-      });
+      expect(mockExecute).toHaveBeenCalledWith(
+        "cold-email-outreach",
+        {
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+        },
+      );
     });
 
     it("should NOT re-trigger if campaign is stopped", async () => {

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
 
-const { mockExecuteColdEmailOutreach } = vi.hoisted(() => ({
-  mockExecuteColdEmailOutreach: vi.fn(),
+const { mockExecuteCampaignWorkflow } = vi.hoisted(() => ({
+  mockExecuteCampaignWorkflow: vi.fn(),
 }));
 
 vi.mock("../../src/lib/workflows.js", () => ({
-  executeColdEmailOutreach: mockExecuteColdEmailOutreach,
+  executeCampaignWorkflow: mockExecuteCampaignWorkflow,
   deployWorkflows: vi.fn(),
   COLD_EMAIL_PROMPT: "test prompt",
   COLD_EMAIL_VARIABLES: ["leadFirstName"],
@@ -32,6 +32,7 @@ const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 
 const validBody = {
   name: "Activation Test Campaign",
+  type: "cold-email-outreach",
   clerkOrgId: "org_activation_test",
   brandUrl: "https://example.com",
   brandId: crypto.randomUUID(),
@@ -45,7 +46,7 @@ describe("Workflow activation on PATCH", () => {
   beforeEach(async () => {
     await cleanTestData();
     vi.clearAllMocks();
-    mockExecuteColdEmailOutreach.mockResolvedValue(undefined);
+    mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
   });
 
   afterAll(async () => {
@@ -73,7 +74,7 @@ describe("Workflow activation on PATCH", () => {
       .expect(200);
 
     vi.clearAllMocks();
-    mockExecuteColdEmailOutreach.mockResolvedValue(undefined);
+    mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
 
     // Activate
     const activateRes = await request(app)
@@ -88,11 +89,14 @@ describe("Workflow activation on PATCH", () => {
     // Wait a tick for the fire-and-forget promise
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(mockExecuteColdEmailOutreach).toHaveBeenCalledOnce();
-    expect(mockExecuteColdEmailOutreach).toHaveBeenCalledWith({
-      campaignId,
-      clerkOrgId: "org_activation_test",
-    });
+    expect(mockExecuteCampaignWorkflow).toHaveBeenCalledOnce();
+    expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
+      "cold-email-outreach",
+      {
+        campaignId,
+        clerkOrgId: "org_activation_test",
+      },
+    );
   });
 
   it("should NOT trigger workflow when status is set to stop", async () => {
@@ -114,7 +118,7 @@ describe("Workflow activation on PATCH", () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(mockExecuteColdEmailOutreach).not.toHaveBeenCalled();
+    expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
   });
 
   it("should NOT trigger workflow when updating non-status fields", async () => {
@@ -136,11 +140,11 @@ describe("Workflow activation on PATCH", () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(mockExecuteColdEmailOutreach).not.toHaveBeenCalled();
+    expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
   });
 
   it("should still return 200 even if workflow execution fails", async () => {
-    mockExecuteColdEmailOutreach.mockRejectedValue(new Error("Windmill down"));
+    mockExecuteCampaignWorkflow.mockRejectedValue(new Error("Windmill down"));
 
     const createRes = await request(app)
       .post("/campaigns")

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -183,15 +183,15 @@ describe("Workflow module", () => {
     });
   });
 
-  describe("executeColdEmailOutreach", () => {
-    it("should call POST /workflows/by-name/cold-email-outreach/execute with campaignId and clerkOrgId", async () => {
+  describe("executeCampaignWorkflow", () => {
+    it("should call POST /workflows/by-name/{type}/execute with type, campaignId, and clerkOrgId", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ id: "run-123", status: "queued" }),
       });
 
-      const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
-      await executeColdEmailOutreach({
+      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
+      await executeCampaignWorkflow("cold-email-outreach", {
         campaignId: "campaign-1",
         clerkOrgId: "org_test",
       });
@@ -210,6 +210,22 @@ describe("Workflow module", () => {
       });
     });
 
+    it("should use type parameter in workflow URL", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-456", status: "queued" }),
+      });
+
+      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
+      await executeCampaignWorkflow("journalist-pitch", {
+        campaignId: "campaign-2",
+        clerkOrgId: "org_test",
+      });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://windmill.test.local/workflows/by-name/journalist-pitch/execute");
+    });
+
     it("should not throw when execution fails", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -217,9 +233,9 @@ describe("Workflow module", () => {
         text: async () => "Workflow not found",
       });
 
-      const { executeColdEmailOutreach } = await import("../../src/lib/workflows.js");
+      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
       await expect(
-        executeColdEmailOutreach({
+        executeCampaignWorkflow("cold-email-outreach", {
           campaignId: "campaign-1",
           clerkOrgId: "org_test",
         })


### PR DESCRIPTION
## Summary
- Adds mandatory `type` field to campaigns that determines which Windmill DAG to execute on activation
- Generalizes `executeColdEmailOutreach` → `executeCampaignWorkflow(type, inputs)` so future campaign types (journalist-pitch, linkedin-dm, etc.) route to the correct workflow automatically
- Includes DB migration, Zod schema update, and OpenAPI response field

## Test plan
- [x] New test: rejects campaign creation when `type` is missing (400)
- [x] New test: `type` is returned in campaign response
- [x] New test: workflow URL uses type parameter (`/workflows/by-name/journalist-pitch/execute`)
- [x] Updated activation tests verify `executeCampaignWorkflow("cold-email-outreach", ...)` call signature
- [x] Updated end-run re-trigger tests verify type-based routing
- [x] All 98 tests passing, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)