### PR TITLE
chore: add verbose debug logging for prod debugging

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -258,12 +258,17 @@ export async function executeCampaignWorkflow(
   const url = process.env.WINDMILL_SERVICE_URL;
   const apiKey = process.env.WINDMILL_SERVICE_API_KEY;
 
+  console.log(`[Workflow] executeCampaignWorkflow called: type=${type}, campaignId=${inputs.campaignId}, clerkOrgId=${inputs.clerkOrgId}`);
+
   if (!url || !apiKey) {
-    console.warn("[Campaign Service] WINDMILL_SERVICE_URL or WINDMILL_SERVICE_API_KEY not set, skipping workflow execution");
+    console.warn("[Workflow] WINDMILL_SERVICE_URL or WINDMILL_SERVICE_API_KEY not set, skipping workflow execution");
     return;
   }
 
-  const res = await fetch(`${url}/workflows/by-name/${type}/execute`, {
+  const executeUrl = `${url}/workflows/by-name/${type}/execute`;
+  console.log(`[Workflow] POST ${executeUrl}`);
+
+  const res = await fetch(executeUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -281,12 +286,12 @@ export async function executeCampaignWorkflow(
 
   if (!res.ok) {
     const body = await res.text();
-    console.error(`[Campaign Service] Workflow execution failed (${res.status}):`, body);
+    console.error(`[Workflow] Execution failed (${res.status}): ${body}`);
     return;
   }
 
   const data = await res.json() as { id?: string; status?: string };
-  console.log(`[Campaign Service] Workflow ${type} started: run=${data.id}, status=${data.status}`);
+  console.log(`[Workflow] ${type} started successfully: windmillRunId=${data.id}, status=${data.status}`);
 }
 
 export { buildColdEmailDag };

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -329,6 +329,7 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
 
     // Trigger workflow on activation, routed by campaign type
     if (req.body.status === "activate") {
+      console.log(`[Campaign Service] Activation triggered: campaignId=${updated.id}, type=${updated.type}, clerkOrgId=${req.clerkOrgId}`);
       executeCampaignWorkflow(updated.type, {
         campaignId: updated.id,
         clerkOrgId: req.clerkOrgId!,

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -65,7 +65,9 @@ async function ensurePromptRegistered(clerkOrgId: string): Promise<void> {
 router.post("/internal/start-run", requireApiKey, async (req, res) => {
   try {
     const { campaignId, clerkOrgId } = req.body;
+    console.log(`[Start Run] Received request: campaignId=${campaignId}, clerkOrgId=${clerkOrgId}`);
     if (!campaignId || !clerkOrgId) {
+      console.warn("[Start Run] Missing required fields");
       return res.status(400).json({ error: "campaignId and clerkOrgId are required" });
     }
 
@@ -74,6 +76,7 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
       where: eq(orgs.clerkOrgId, clerkOrgId),
     });
     if (!org) {
+      console.warn(`[Start Run] Org not found: ${clerkOrgId}`);
       return res.status(404).json({ error: "Organization not found" });
     }
 
@@ -81,16 +84,21 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
       where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
     });
     if (!campaign) {
+      console.warn(`[Start Run] Campaign not found: ${campaignId} (orgId=${org.id})`);
       return res.status(404).json({ error: "Campaign not found" });
     }
+    console.log(`[Start Run] Campaign found: name=${campaign.name}, type=${campaign.type}, status=${campaign.status}, brandUrl=${campaign.brandUrl}`);
     if (!campaign.brandUrl) {
+      console.warn(`[Start Run] Campaign ${campaignId} has no brandUrl`);
       return res.status(400).json({ error: "Campaign has no brandUrl" });
     }
     if (!campaign.brandId) {
+      console.warn(`[Start Run] Campaign ${campaignId} has no brandId`);
       return res.status(400).json({ error: "Campaign has no brandId" });
     }
 
     // Gate checks
+    console.log(`[Start Run] Running gate checks for campaign ${campaignId}...`);
     const gateResult = await runGateChecks({
       campaignId,
       clerkOrgId,
@@ -103,17 +111,21 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
       maxLeads: campaign.maxLeads,
     });
     if (!gateResult.allowed) {
+      console.warn(`[Start Run] Gate check BLOCKED: reason=${gateResult.reason}, autoStopped=${gateResult.autoStopped}`);
       return res.status(409).json({
         error: "Gate check failed",
         reason: gateResult.reason,
         autoStopped: gateResult.autoStopped || false,
       });
     }
+    console.log(`[Start Run] Gate checks PASSED for campaign ${campaignId}`);
 
     // Register prompt template (best-effort, cached per org)
+    console.log(`[Start Run] Ensuring prompt registered for org ${clerkOrgId} (cached=${promptRegisteredOrgs.has(clerkOrgId)})`);
     await ensurePromptRegistered(clerkOrgId);
 
     // Create run in runs-service
+    console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId}...`);
     const run = await createRun({
       clerkOrgId,
       appId: APP_ID,
@@ -123,6 +135,7 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
       brandId: campaign.brandId,
       clerkUserId: campaign.createdByUserId || undefined,
     });
+    console.log(`[Start Run] Run created: runId=${run.id}`);
 
     // Fetch brand sales profile (best-effort)
     const brandDomain = extractDomain(campaign.brandUrl);
@@ -135,6 +148,7 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
       const brandUrl = process.env.BRAND_SERVICE_URL;
       const brandApiKey = process.env.BRAND_SERVICE_API_KEY;
       if (brandUrl && brandApiKey) {
+        console.log(`[Start Run] Fetching brand profile from ${brandUrl}/sales-profile...`);
         const profileRes = await fetch(`${brandUrl}/sales-profile`, {
           method: "POST",
           headers: {
@@ -152,6 +166,7 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
         });
         if (profileRes.ok) {
           const profile = await profileRes.json() as Record<string, unknown>;
+          console.log(`[Start Run] Brand profile OK: companyName=${profile.companyName}`);
           clientData = {
             companyName: (profile.companyName as string) || brandDomain,
             brandUrl: campaign.brandUrl,
@@ -166,7 +181,11 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
             callToAction: profile.callToAction,
             additionalContext: profile.additionalContext,
           };
+        } else {
+          console.warn(`[Start Run] Brand profile failed (${profileRes.status}), using fallback: companyName=${brandDomain}`);
         }
+      } else {
+        console.warn("[Start Run] BRAND_SERVICE_URL or BRAND_SERVICE_API_KEY not set, using fallback clientData");
       }
     } catch (err) {
       console.warn("[Start Run] Brand profile fetch failed (best-effort):", err);
@@ -176,12 +195,14 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
     const leadServiceUrl = process.env.LEAD_SERVICE_URL;
     const leadApiKey = process.env.LEAD_SERVICE_API_KEY;
     if (!leadServiceUrl || !leadApiKey) {
+      console.error("[Start Run] LEAD_SERVICE_URL or LEAD_SERVICE_API_KEY not set — failing run");
       await updateRun(run.id, "failed");
       return res.status(500).json({ error: "Lead service not configured" });
     }
 
     let lead: { externalId: string; data: Record<string, unknown> } | null = null;
     try {
+      console.log(`[Start Run] Fetching next lead from ${leadServiceUrl}/buffer/next for campaign ${campaignId}...`);
       const leadRes = await fetch(`${leadServiceUrl}/buffer/next`, {
         method: "POST",
         headers: {
@@ -202,8 +223,10 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
       }
 
       const leadData = await leadRes.json() as { found?: boolean; lead?: { externalId: string; data: Record<string, unknown> } };
+      console.log(`[Start Run] Lead response: found=${leadData.found}, hasLead=${!!leadData.lead}, email=${leadData.lead?.data?.email || "none"}`);
       if (!leadData.found || !leadData.lead || !leadData.lead.data?.email) {
         // No lead found or no email → fail run immediately
+        console.warn(`[Start Run] No lead available — failing run ${run.id} and returning 204`);
         await updateRun(run.id, "failed");
         return res.status(204).send();
       }
@@ -213,6 +236,8 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
       await updateRun(run.id, "failed");
       return res.status(204).send();
     }
+
+    console.log(`[Start Run] SUCCESS — runId=${run.id}, leadEmail=${lead.data.email}, leadExternalId=${lead.externalId}`);
 
     // Return all data for the downstream DAG nodes
     res.json({
@@ -231,7 +256,7 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
       clientData,
     });
   } catch (error) {
-    console.error("[Start Run] Error:", error);
+    console.error("[Start Run] Unhandled error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -245,13 +270,16 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
 router.post("/internal/end-run", requireApiKey, async (req, res) => {
   try {
     const { runId, campaignId, clerkOrgId, success } = req.body;
+    console.log(`[End Run] Received request: runId=${runId}, campaignId=${campaignId}, clerkOrgId=${clerkOrgId}, success=${success}`);
     if (!runId || !campaignId || !clerkOrgId) {
+      console.warn("[End Run] Missing required fields");
       return res.status(400).json({ error: "runId, campaignId, and clerkOrgId are required" });
     }
 
     // Determine run status:
     // success === true → completed; anything else → failed
     const status = success === true ? "completed" : "failed";
+    console.log(`[End Run] Updating run ${runId} to status=${status}`);
     await updateRun(runId, status);
 
     // Respond immediately, then re-trigger asynchronously
@@ -262,14 +290,22 @@ router.post("/internal/end-run", requireApiKey, async (req, res) => {
       const org = await db.query.orgs.findFirst({
         where: eq(orgs.clerkOrgId, clerkOrgId),
       });
-      if (!org) return;
+      if (!org) {
+        console.warn(`[End Run] Org not found for re-trigger: ${clerkOrgId}`);
+        return;
+      }
 
       const campaign = await db.query.campaigns.findFirst({
         where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
       });
-      if (campaign?.status !== "ongoing") return;
+      console.log(`[End Run] Campaign status for re-trigger: ${campaign?.status || "NOT FOUND"}, type=${campaign?.type || "N/A"}`);
+      if (campaign?.status !== "ongoing") {
+        console.log(`[End Run] Campaign ${campaignId} is not ongoing — skipping re-trigger`);
+        return;
+      }
 
       // Fire-and-forget: start-run in the next workflow execution will do gate checks
+      console.log(`[End Run] Re-triggering workflow type=${campaign.type} for campaign ${campaignId}`);
       executeCampaignWorkflow(campaign.type, { campaignId, clerkOrgId }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });
@@ -277,7 +313,7 @@ router.post("/internal/end-run", requireApiKey, async (req, res) => {
       console.error(`[End Run] Re-trigger check failed:`, err);
     }
   } catch (error) {
-    console.error("[End Run] Error:", error);
+    console.error("[End Run] Unhandled error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });


### PR DESCRIPTION
## Summary
- Adds detailed `console.log`/`warn`/`error` at every step of `POST /internal/start-run` (org lookup, campaign lookup, gate checks, prompt registration, run creation, brand profile fetch, lead fetch, success/failure)
- Adds logging to `POST /internal/end-run` (run status update, re-trigger decision with campaign status/type)
- Adds logging to campaign activation trigger in `PATCH /campaigns/:id`
- Adds logging to `executeCampaignWorkflow` (URL, type, result)

## Test plan
- [x] All 98 tests pass
- [x] Build succeeds
- [ ] Deploy and verify logs appear in Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)