### PR TITLE
fix: move retries to top-level on DAG nodes

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -91,11 +91,11 @@ function buildColdEmailDag() {
       {
         id: "start-run",
         type: "http.call",
+        retries: 0, // Contains non-idempotent lead fetch
         config: {
           service: "campaign",
           method: "POST",
           path: "/internal/start-run",
-          retries: 0, // Contains non-idempotent lead fetch
         },
         inputMapping: {
           "body.campaignId": "$ref:flow_input.campaignId",
@@ -106,11 +106,11 @@ function buildColdEmailDag() {
       {
         id: "email-generate",
         type: "http.call",
+        retries: 0, // Non-idempotent generation
         config: {
           service: "emailgeneration",
           method: "POST",
           path: "/generate",
-          retries: 0,
           body: {
             type: "cold-email",
           },
@@ -155,11 +155,11 @@ function buildColdEmailDag() {
       {
         id: "email-send",
         type: "http.call",
+        retries: 0, // Non-idempotent send
         config: {
           service: "email-gateway",
           method: "POST",
           path: "/send",
-          retries: 0,
           body: {
             type: "broadcast",
             tag: "cold-email",

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -67,12 +67,14 @@ describe("Workflow module", () => {
       expect(serviceMap["end-run"]).toBe("campaign");
     });
 
-    it("should set retries: 0 on non-idempotent nodes", () => {
+    it("should set retries: 0 at top-level on non-idempotent nodes", () => {
       const dag = buildColdEmailDag();
       const noRetryNodes = ["start-run", "email-generate", "email-send"];
       for (const nodeId of noRetryNodes) {
         const node = dag.nodes.find((n) => n.id === nodeId);
-        expect(node?.config.retries).toBe(0);
+        // retries must be top-level on the node, NOT inside config
+        expect(node?.retries).toBe(0);
+        expect(node?.config.retries).toBeUndefined();
       }
     });
 


### PR DESCRIPTION
## Summary
- Moved `retries: 0` from inside `config` to top-level on `start-run`, `email-generate`, and `email-send` DAG nodes
- Windmill reads `retries` as a node-level field per the `DAGNode` schema — putting it inside `config` just passed it as a script parameter (ignored), so all nodes were retrying 3 times (default)
- This caused non-idempotent operations (lead fetch, email generation, email send) to be retried, risking duplicates

## Test plan
- [x] Updated test to assert `retries` is top-level AND not inside `config`
- [x] All 100 tests pass
- [x] Build succeeds
- [ ] Deploy and verify nodes don't retry on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)