### PR TITLE
fix: pass searchParams to lead-service for Apollo auto-fill

### DIFF
--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -202,7 +202,12 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
 
     let lead: { externalId: string; data: Record<string, unknown> } | null = null;
     try {
-      console.log(`[Start Run] Fetching next lead from ${leadServiceUrl}/buffer/next for campaign ${campaignId}...`);
+      // Build searchParams from campaign targetAudience so lead-service
+      // can auto-fill from Apollo when the buffer is empty.
+      const searchParams = campaign.targetAudience
+        ? { qKeywords: campaign.targetAudience }
+        : undefined;
+      console.log(`[Start Run] Fetching next lead from ${leadServiceUrl}/buffer/next for campaign ${campaignId} (searchParams=${searchParams ? "yes" : "none"})...`);
       const leadRes = await fetch(`${leadServiceUrl}/buffer/next`, {
         method: "POST",
         headers: {
@@ -215,6 +220,7 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
           campaignId,
           brandId: campaign.brandId,
           parentRunId: run.id,
+          ...(searchParams && { searchParams }),
         }),
       });
 

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -245,6 +245,95 @@ describe("Internal routes", () => {
       expect(res.body.clientData.companyOverview).toBe("A great company");
     });
 
+    it("should pass searchParams with targetAudience to lead service", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+        appId: "mcpfactory",
+        targetAudience: "CTOs at SaaS startups",
+        targetOutcome: "Book demos",
+        valueForTarget: "Analytics",
+      });
+
+      let capturedLeadBody: Record<string, unknown> | null = null;
+
+      mockFetch.mockImplementation((url: string, opts?: { body?: string }) => {
+        if (url.includes("/prompts")) {
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+        }
+        if (url.includes("/sales-profile")) {
+          return Promise.resolve({ ok: false, status: 500 });
+        }
+        if (url.includes("/buffer/next")) {
+          capturedLeadBody = opts?.body ? JSON.parse(opts.body) : null;
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              found: true,
+              lead: {
+                externalId: "lead-ext-sp",
+                data: { first_name: "Test", email: "test@example.com" },
+              },
+            }),
+          });
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      });
+
+      await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(capturedLeadBody).toBeDefined();
+      expect(capturedLeadBody!.searchParams).toEqual({ qKeywords: "CTOs at SaaS startups" });
+    });
+
+    it("should NOT pass searchParams when targetAudience is null", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+        appId: "mcpfactory",
+        targetOutcome: "Book demos",
+        valueForTarget: "Analytics",
+      });
+
+      let capturedLeadBody: Record<string, unknown> | null = null;
+
+      mockFetch.mockImplementation((url: string, opts?: { body?: string }) => {
+        if (url.includes("/prompts")) {
+          return Promise.resolve({ ok: true, json: async () => ({}) });
+        }
+        if (url.includes("/sales-profile")) {
+          return Promise.resolve({ ok: false, status: 500 });
+        }
+        if (url.includes("/buffer/next")) {
+          capturedLeadBody = opts?.body ? JSON.parse(opts.body) : null;
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              found: true,
+              lead: {
+                externalId: "lead-ext-no-sp",
+                data: { first_name: "Test", email: "test2@example.com" },
+              },
+            }),
+          });
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      });
+
+      await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(capturedLeadBody).toBeDefined();
+      expect(capturedLeadBody!.searchParams).toBeUndefined();
+    });
+
     it("should use fallback clientData when brand profile fails", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://www.example.com",


### PR DESCRIPTION
## Summary
- When a campaign has `targetAudience`, pass it as `searchParams: { qKeywords }` to lead-service `/buffer/next`
- This enables lead-service to auto-populate from Apollo search when the lead buffer is empty
- Without this, newly created campaigns with empty buffers would always return "no lead found"

## Test plan
- [x] Added test: searchParams with targetAudience is passed to lead service
- [x] Added test: searchParams is NOT passed when targetAudience is null
- [x] All 102 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)