### PR TITLE
refactor: extract brand-service and lead-service into DAG nodes

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -75,23 +75,28 @@ const APP_ID = "mcpfactory";
 /**
  * Build the cold-email-outreach DAG.
  *
- * Pipeline: start-run → email-generate → email-send → end-run
+ * Pipeline:
+ *   start-run → brand-profile ↘
+ *                                → email-generate → email-send → end-run
+ *            → fetch-lead     ↗
  *
- * - start-run: gate checks + create run + campaign/brand/lead fetch (campaign-service internal)
+ * - start-run:      gate checks + create run (campaign-service internal)
+ * - brand-profile:  fetch brand sales profile (brand-service)
+ * - fetch-lead:     pull next lead from buffer (lead-service, NO RETRY)
  * - email-generate: generate email via AI (emailgeneration-service, NO RETRY)
- * - email-send: send email (email-gateway-service, NO RETRY, validate success field)
- * - end-run: finalize run + re-trigger (campaign-service internal)
+ * - email-send:     send email (email-gateway-service, NO RETRY, validate success)
+ * - end-run:        finalize run + re-trigger (campaign-service internal)
  *
+ * brand-profile and fetch-lead run in parallel after start-run.
  * On DAG error: end-run is called with success=false via onError handler.
  */
 function buildColdEmailDag() {
   return {
     nodes: [
-      // Step 1–4: Gate checks + create run + fetch campaign + brand profile + lead
+      // Step 1: Gate checks + create run + return campaign data
       {
         id: "start-run",
         type: "http.call",
-        retries: 0, // Contains non-idempotent lead fetch
         config: {
           service: "campaign",
           method: "POST",
@@ -102,7 +107,47 @@ function buildColdEmailDag() {
           "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
         },
       },
-      // Step 5: Generate email (non-idempotent, NO RETRY)
+      // Step 2a: Fetch brand sales profile (parallel with fetch-lead)
+      {
+        id: "brand-profile",
+        type: "http.call",
+        config: {
+          service: "brand",
+          method: "POST",
+          path: "/sales-profile",
+          body: {
+            keyType: "byok",
+          },
+        },
+        inputMapping: {
+          "body.appId": "$ref:start-run.output.appId",
+          "body.clerkOrgId": "$ref:start-run.output.clerkOrgId",
+          "body.url": "$ref:start-run.output.brandUrl",
+          "body.clerkUserId": "$ref:start-run.output.clerkUserId",
+          "body.parentRunId": "$ref:start-run.output.runId",
+        },
+      },
+      // Step 2b: Pull next lead from buffer (parallel with brand-profile)
+      {
+        id: "fetch-lead",
+        type: "http.call",
+        retries: 0, // Non-idempotent: consumes from buffer
+        config: {
+          service: "lead",
+          method: "POST",
+          path: "/buffer/next",
+          validateResponse: { field: "found", equals: true },
+        },
+        inputMapping: {
+          "headers.x-app-id": "$ref:start-run.output.appId",
+          "headers.x-org-id": "$ref:start-run.output.clerkOrgId",
+          "body.campaignId": "$ref:start-run.output.campaignId",
+          "body.brandId": "$ref:start-run.output.brandId",
+          "body.parentRunId": "$ref:start-run.output.runId",
+          "body.searchParams": "$ref:start-run.output.searchParams",
+        },
+      },
+      // Step 3: Generate email (non-idempotent, NO RETRY)
       {
         id: "email-generate",
         type: "http.call",
@@ -121,37 +166,37 @@ function buildColdEmailDag() {
           "body.brandId": "$ref:start-run.output.brandId",
           "body.campaignId": "$ref:start-run.output.campaignId",
           "body.runId": "$ref:start-run.output.runId",
-          "body.apolloEnrichmentId": "$ref:start-run.output.lead.externalId",
-          // Lead fields
-          "body.leadFirstName": "$ref:start-run.output.lead.data.first_name",
-          "body.leadLastName": "$ref:start-run.output.lead.data.last_name",
-          "body.leadTitle": "$ref:start-run.output.lead.data.title",
-          "body.leadEmail": "$ref:start-run.output.lead.data.email",
-          "body.leadLinkedinUrl": "$ref:start-run.output.lead.data.linkedin_url",
-          "body.leadCompanyName": "$ref:start-run.output.lead.data.organization_name",
-          "body.leadCompanyDomain": "$ref:start-run.output.lead.data.organization.primary_domain",
-          "body.leadCompanyIndustry": "$ref:start-run.output.lead.data.organization.industry",
-          "body.leadCompanySize": "$ref:start-run.output.lead.data.organization.estimated_num_employees",
-          "body.leadCompanyRevenueUsd": "$ref:start-run.output.lead.data.organization.annual_revenue_printed",
-          // Client/brand fields
-          "body.clientCompanyName": "$ref:start-run.output.clientData.companyName",
-          "body.clientBrandUrl": "$ref:start-run.output.clientData.brandUrl",
-          "body.clientCompanyOverview": "$ref:start-run.output.clientData.companyOverview",
-          "body.clientValueProposition": "$ref:start-run.output.clientData.valueProposition",
-          "body.clientTargetAudience": "$ref:start-run.output.clientData.targetAudience",
-          "body.clientCustomerPainPoints": "$ref:start-run.output.clientData.customerPainPoints",
-          "body.clientKeyFeatures": "$ref:start-run.output.clientData.keyFeatures",
-          "body.clientProductDifferentiators": "$ref:start-run.output.clientData.productDifferentiators",
-          "body.clientCompetitors": "$ref:start-run.output.clientData.competitors",
-          "body.clientSocialProof": "$ref:start-run.output.clientData.socialProof",
-          "body.clientCallToAction": "$ref:start-run.output.clientData.callToAction",
-          "body.clientAdditionalContext": "$ref:start-run.output.clientData.additionalContext",
-          // Campaign fields
+          "body.apolloEnrichmentId": "$ref:fetch-lead.output.lead.externalId",
+          // Lead fields from fetch-lead
+          "body.leadFirstName": "$ref:fetch-lead.output.lead.data.first_name",
+          "body.leadLastName": "$ref:fetch-lead.output.lead.data.last_name",
+          "body.leadTitle": "$ref:fetch-lead.output.lead.data.title",
+          "body.leadEmail": "$ref:fetch-lead.output.lead.data.email",
+          "body.leadLinkedinUrl": "$ref:fetch-lead.output.lead.data.linkedin_url",
+          "body.leadCompanyName": "$ref:fetch-lead.output.lead.data.organization_name",
+          "body.leadCompanyDomain": "$ref:fetch-lead.output.lead.data.organization.primary_domain",
+          "body.leadCompanyIndustry": "$ref:fetch-lead.output.lead.data.organization.industry",
+          "body.leadCompanySize": "$ref:fetch-lead.output.lead.data.organization.estimated_num_employees",
+          "body.leadCompanyRevenueUsd": "$ref:fetch-lead.output.lead.data.organization.annual_revenue_printed",
+          // Client/brand fields from brand-profile
+          "body.clientCompanyName": "$ref:start-run.output.brandDomain",
+          "body.clientBrandUrl": "$ref:start-run.output.brandUrl",
+          "body.clientCompanyOverview": "$ref:brand-profile.output.profile.companyOverview",
+          "body.clientValueProposition": "$ref:brand-profile.output.profile.valueProposition",
+          "body.clientTargetAudience": "$ref:brand-profile.output.profile.targetAudience",
+          "body.clientCustomerPainPoints": "$ref:brand-profile.output.profile.customerPainPoints",
+          "body.clientKeyFeatures": "$ref:brand-profile.output.profile.keyFeatures",
+          "body.clientProductDifferentiators": "$ref:brand-profile.output.profile.productDifferentiators",
+          "body.clientCompetitors": "$ref:brand-profile.output.profile.competitors",
+          "body.clientSocialProof": "$ref:brand-profile.output.profile.socialProof",
+          "body.clientCallToAction": "$ref:brand-profile.output.profile.callToAction",
+          "body.clientAdditionalContext": "$ref:brand-profile.output.profile.additionalContext",
+          // Campaign fields from start-run
           "body.targetOutcome": "$ref:start-run.output.targetOutcome",
           "body.valueForTarget": "$ref:start-run.output.valueForTarget",
         },
       },
-      // Step 6: Send email (non-idempotent, NO RETRY)
+      // Step 4: Send email (non-idempotent, NO RETRY)
       {
         id: "email-send",
         type: "http.call",
@@ -176,16 +221,16 @@ function buildColdEmailDag() {
           "body.brandId": "$ref:start-run.output.brandId",
           "body.campaignId": "$ref:start-run.output.campaignId",
           "body.runId": "$ref:start-run.output.runId",
-          "body.to": "$ref:start-run.output.lead.data.email",
-          "body.recipientFirstName": "$ref:start-run.output.lead.data.first_name",
-          "body.recipientLastName": "$ref:start-run.output.lead.data.last_name",
-          "body.recipientCompany": "$ref:start-run.output.lead.data.organization_name",
+          "body.to": "$ref:fetch-lead.output.lead.data.email",
+          "body.recipientFirstName": "$ref:fetch-lead.output.lead.data.first_name",
+          "body.recipientLastName": "$ref:fetch-lead.output.lead.data.last_name",
+          "body.recipientCompany": "$ref:fetch-lead.output.lead.data.organization_name",
           "body.subject": "$ref:email-generate.output.subject",
           "body.htmlBody": "$ref:email-generate.output.bodyHtml",
           "body.metadata.emailGenerationId": "$ref:email-generate.output.id",
         },
       },
-      // Step 7: Finalize run + re-trigger
+      // Step 5: Finalize run + re-trigger
       {
         id: "end-run",
         type: "http.call",
@@ -205,7 +250,10 @@ function buildColdEmailDag() {
       },
     ],
     edges: [
-      { from: "start-run", to: "email-generate" },
+      { from: "start-run", to: "brand-profile" },
+      { from: "start-run", to: "fetch-lead" },
+      { from: "brand-profile", to: "email-generate" },
+      { from: "fetch-lead", to: "email-generate" },
       { from: "email-generate", to: "email-send" },
       { from: "email-send", to: "end-run" },
     ],

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -51,12 +51,14 @@ async function ensurePromptRegistered(clerkOrgId: string): Promise<void> {
 /**
  * POST /internal/start-run
  *
- * Performs gate checks, creates a run, fetches campaign + brand profile + next lead.
- * Returns all data needed for the email pipeline, or an error status.
+ * Performs gate checks, creates a run, and returns campaign data
+ * for downstream DAG nodes (brand-profile, fetch-lead, etc.).
+ *
+ * Brand profile and lead fetching are handled by separate DAG nodes,
+ * NOT by this endpoint.
  *
  * Returns:
- *   200 — run started, lead found
- *   204 — no lead found (run created then immediately failed)
+ *   200 — run started, campaign data returned
  *   400 — bad request
  *   404 — campaign/org not found
  *   409 — gate check blocked
@@ -137,129 +139,29 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
     });
     console.log(`[Start Run] Run created: runId=${run.id}`);
 
-    // Fetch brand sales profile (best-effort)
+    // Build searchParams from campaign targetAudience so the fetch-lead
+    // DAG node can pass them to lead-service for Apollo auto-fill.
+    const searchParams = campaign.targetAudience
+      ? { qKeywords: campaign.targetAudience }
+      : null;
+
     const brandDomain = extractDomain(campaign.brandUrl);
-    let clientData: Record<string, unknown> = {
-      companyName: brandDomain,
-      brandUrl: campaign.brandUrl,
-    };
 
-    try {
-      const brandUrl = process.env.BRAND_SERVICE_URL;
-      const brandApiKey = process.env.BRAND_SERVICE_API_KEY;
-      if (brandUrl && brandApiKey) {
-        console.log(`[Start Run] Fetching brand profile from ${brandUrl}/sales-profile...`);
-        const profileRes = await fetch(`${brandUrl}/sales-profile`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": brandApiKey,
-          },
-          body: JSON.stringify({
-            appId: campaign.appId || APP_ID,
-            clerkOrgId,
-            url: campaign.brandUrl,
-            clerkUserId: campaign.createdByUserId || "system",
-            keyType: "byok",
-            parentRunId: run.id,
-          }),
-        });
-        if (profileRes.ok) {
-          const profile = await profileRes.json() as Record<string, unknown>;
-          console.log(`[Start Run] Brand profile OK: companyName=${profile.companyName}`);
-          clientData = {
-            companyName: (profile.companyName as string) || brandDomain,
-            brandUrl: campaign.brandUrl,
-            companyOverview: profile.companyOverview,
-            valueProposition: profile.valueProposition,
-            targetAudience: profile.targetAudience,
-            customerPainPoints: Array.isArray(profile.customerPainPoints) && profile.customerPainPoints.length ? profile.customerPainPoints : undefined,
-            keyFeatures: Array.isArray(profile.keyFeatures) && profile.keyFeatures.length ? profile.keyFeatures : undefined,
-            productDifferentiators: Array.isArray(profile.productDifferentiators) && profile.productDifferentiators.length ? profile.productDifferentiators : undefined,
-            competitors: Array.isArray(profile.competitors) && profile.competitors.length ? profile.competitors : undefined,
-            socialProof: profile.socialProof,
-            callToAction: profile.callToAction,
-            additionalContext: profile.additionalContext,
-          };
-        } else {
-          console.warn(`[Start Run] Brand profile failed (${profileRes.status}), using fallback: companyName=${brandDomain}`);
-        }
-      } else {
-        console.warn("[Start Run] BRAND_SERVICE_URL or BRAND_SERVICE_API_KEY not set, using fallback clientData");
-      }
-    } catch (err) {
-      console.warn("[Start Run] Brand profile fetch failed (best-effort):", err);
-    }
+    console.log(`[Start Run] SUCCESS — runId=${run.id}, brandDomain=${brandDomain}, searchParams=${searchParams ? "yes" : "none"}`);
 
-    // Fetch next lead from lead-service (non-idempotent, no retry)
-    const leadServiceUrl = process.env.LEAD_SERVICE_URL;
-    const leadApiKey = process.env.LEAD_SERVICE_API_KEY;
-    if (!leadServiceUrl || !leadApiKey) {
-      console.error("[Start Run] LEAD_SERVICE_URL or LEAD_SERVICE_API_KEY not set — failing run");
-      await updateRun(run.id, "failed");
-      return res.status(500).json({ error: "Lead service not configured" });
-    }
-
-    let lead: { externalId: string; data: Record<string, unknown> } | null = null;
-    try {
-      // Build searchParams from campaign targetAudience so lead-service
-      // can auto-fill from Apollo when the buffer is empty.
-      const searchParams = campaign.targetAudience
-        ? { qKeywords: campaign.targetAudience }
-        : undefined;
-      console.log(`[Start Run] Fetching next lead from ${leadServiceUrl}/buffer/next for campaign ${campaignId} (searchParams=${searchParams ? "yes" : "none"})...`);
-      const leadRes = await fetch(`${leadServiceUrl}/buffer/next`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": leadApiKey,
-          "x-app-id": APP_ID,
-          "x-org-id": clerkOrgId,
-        },
-        body: JSON.stringify({
-          campaignId,
-          brandId: campaign.brandId,
-          parentRunId: run.id,
-          ...(searchParams && { searchParams }),
-        }),
-      });
-
-      if (!leadRes.ok) {
-        throw new Error(`Lead service returned ${leadRes.status}`);
-      }
-
-      const leadData = await leadRes.json() as { found?: boolean; lead?: { externalId: string; data: Record<string, unknown> } };
-      console.log(`[Start Run] Lead response: found=${leadData.found}, hasLead=${!!leadData.lead}, email=${leadData.lead?.data?.email || "none"}`);
-      if (!leadData.found || !leadData.lead || !leadData.lead.data?.email) {
-        // No lead found or no email → fail run immediately
-        console.warn(`[Start Run] No lead available — failing run ${run.id} and returning 204`);
-        await updateRun(run.id, "failed");
-        return res.status(204).send();
-      }
-      lead = leadData.lead;
-    } catch (err) {
-      console.error("[Start Run] Lead fetch failed:", err);
-      await updateRun(run.id, "failed");
-      return res.status(204).send();
-    }
-
-    console.log(`[Start Run] SUCCESS — runId=${run.id}, leadEmail=${lead.data.email}, leadExternalId=${lead.externalId}`);
-
-    // Return all data for the downstream DAG nodes
+    // Return campaign data for downstream DAG nodes
     res.json({
       runId: run.id,
       campaignId,
       clerkOrgId,
       brandId: campaign.brandId,
+      brandUrl: campaign.brandUrl,
+      brandDomain,
       appId: campaign.appId || APP_ID,
       clerkUserId: campaign.createdByUserId,
       targetOutcome: campaign.targetOutcome,
       valueForTarget: campaign.valueForTarget,
-      lead: {
-        externalId: lead.externalId,
-        data: lead.data,
-      },
-      clientData,
+      searchParams,
     });
   } catch (error) {
     console.error("[Start Run] Unhandled error:", error);

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../src/lib/gate-check.js", () => ({
   runGateChecks: mockGateChecks,
 }));
 
+// Mock fetch for prompt registration (ensurePromptRegistered calls fetch)
 vi.stubGlobal("fetch", mockFetch);
 
 import app from "../../src/index.js";
@@ -63,6 +64,8 @@ describe("Internal routes", () => {
     mockGetRunsBatch.mockResolvedValue(new Map());
     mockGateChecks.mockResolvedValue({ allowed: true });
     mockExecute.mockResolvedValue(undefined);
+    // Default: prompt registration succeeds (best-effort, only fetch call in start-run)
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
   });
 
   afterAll(async () => {
@@ -156,76 +159,13 @@ describe("Internal routes", () => {
       expect(res.body.reason).toBe("daily budget exceeded");
     });
 
-    it("should return 204 when no lead is found", async () => {
-      const campaign = await insertTestCampaign(org.id, {
-        brandUrl: "https://example.com",
-        brandId,
-      });
-
-      // Mock prompt registration
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-      // Mock brand profile (skip)
-      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
-      // Mock lead fetch — no lead found
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ found: false }),
-      });
-
-      await request(app)
-        .post("/internal/start-run")
-        .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
-        .expect(204);
-
-      // Run should be created then immediately failed
-      expect(mockCreateRun).toHaveBeenCalledOnce();
-      expect(mockUpdateRun).toHaveBeenCalledWith("run-123", "failed");
-    });
-
-    it("should return 200 with full pipeline data when lead is found", async () => {
+    it("should return 200 with campaign data and runId", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",
         brandId,
         appId: "mcpfactory",
         targetOutcome: "Book demos",
         valueForTarget: "Analytics platform",
-      });
-
-      // Use URL-based mock to avoid cache ordering issues
-      mockFetch.mockImplementation((url: string) => {
-        if (url.includes("/prompts")) {
-          return Promise.resolve({ ok: true, json: async () => ({}) });
-        }
-        if (url.includes("/sales-profile")) {
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({
-              companyName: "Example Inc",
-              companyOverview: "A great company",
-              valueProposition: "We make things better",
-            }),
-          });
-        }
-        if (url.includes("/buffer/next")) {
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({
-              found: true,
-              lead: {
-                externalId: "lead-ext-1",
-                data: {
-                  first_name: "John",
-                  last_name: "Doe",
-                  title: "CTO",
-                  email: "john@acme.com",
-                  organization_name: "Acme Corp",
-                },
-              },
-            }),
-          });
-        }
-        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
       });
 
       const res = await request(app)
@@ -238,129 +178,21 @@ describe("Internal routes", () => {
       expect(res.body.campaignId).toBe(campaign.id);
       expect(res.body.clerkOrgId).toBe(org.clerkOrgId);
       expect(res.body.brandId).toBe(brandId);
+      expect(res.body.brandUrl).toBe("https://example.com");
+      expect(res.body.brandDomain).toBe("example.com");
+      expect(res.body.appId).toBe("mcpfactory");
       expect(res.body.targetOutcome).toBe("Book demos");
-      expect(res.body.lead.externalId).toBe("lead-ext-1");
-      expect(res.body.lead.data.email).toBe("john@acme.com");
-      expect(res.body.clientData.companyName).toBe("Example Inc");
-      expect(res.body.clientData.companyOverview).toBe("A great company");
+      expect(res.body.valueForTarget).toBe("Analytics platform");
+      // No lead or clientData — those are fetched by separate DAG nodes
+      expect(res.body.lead).toBeUndefined();
+      expect(res.body.clientData).toBeUndefined();
     });
 
-    it("should pass searchParams with targetAudience to lead service", async () => {
+    it("should include searchParams when targetAudience is set", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",
         brandId,
-        appId: "mcpfactory",
         targetAudience: "CTOs at SaaS startups",
-        targetOutcome: "Book demos",
-        valueForTarget: "Analytics",
-      });
-
-      let capturedLeadBody: Record<string, unknown> | null = null;
-
-      mockFetch.mockImplementation((url: string, opts?: { body?: string }) => {
-        if (url.includes("/prompts")) {
-          return Promise.resolve({ ok: true, json: async () => ({}) });
-        }
-        if (url.includes("/sales-profile")) {
-          return Promise.resolve({ ok: false, status: 500 });
-        }
-        if (url.includes("/buffer/next")) {
-          capturedLeadBody = opts?.body ? JSON.parse(opts.body) : null;
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({
-              found: true,
-              lead: {
-                externalId: "lead-ext-sp",
-                data: { first_name: "Test", email: "test@example.com" },
-              },
-            }),
-          });
-        }
-        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
-      });
-
-      await request(app)
-        .post("/internal/start-run")
-        .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
-        .expect(200);
-
-      expect(capturedLeadBody).toBeDefined();
-      expect(capturedLeadBody!.searchParams).toEqual({ qKeywords: "CTOs at SaaS startups" });
-    });
-
-    it("should NOT pass searchParams when targetAudience is null", async () => {
-      const campaign = await insertTestCampaign(org.id, {
-        brandUrl: "https://example.com",
-        brandId,
-        appId: "mcpfactory",
-        targetOutcome: "Book demos",
-        valueForTarget: "Analytics",
-      });
-
-      let capturedLeadBody: Record<string, unknown> | null = null;
-
-      mockFetch.mockImplementation((url: string, opts?: { body?: string }) => {
-        if (url.includes("/prompts")) {
-          return Promise.resolve({ ok: true, json: async () => ({}) });
-        }
-        if (url.includes("/sales-profile")) {
-          return Promise.resolve({ ok: false, status: 500 });
-        }
-        if (url.includes("/buffer/next")) {
-          capturedLeadBody = opts?.body ? JSON.parse(opts.body) : null;
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({
-              found: true,
-              lead: {
-                externalId: "lead-ext-no-sp",
-                data: { first_name: "Test", email: "test2@example.com" },
-              },
-            }),
-          });
-        }
-        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
-      });
-
-      await request(app)
-        .post("/internal/start-run")
-        .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
-        .expect(200);
-
-      expect(capturedLeadBody).toBeDefined();
-      expect(capturedLeadBody!.searchParams).toBeUndefined();
-    });
-
-    it("should use fallback clientData when brand profile fails", async () => {
-      const campaign = await insertTestCampaign(org.id, {
-        brandUrl: "https://www.example.com",
-        brandId,
-      });
-
-      // Use URL-based mock to avoid cache ordering issues
-      mockFetch.mockImplementation((url: string) => {
-        if (url.includes("/prompts")) {
-          return Promise.resolve({ ok: true, json: async () => ({}) });
-        }
-        if (url.includes("/sales-profile")) {
-          return Promise.resolve({ ok: false, status: 500, text: async () => "error" });
-        }
-        if (url.includes("/buffer/next")) {
-          return Promise.resolve({
-            ok: true,
-            json: async () => ({
-              found: true,
-              lead: {
-                externalId: "lead-ext-2",
-                data: { first_name: "Jane", email: "jane@test.com" },
-              },
-            }),
-          });
-        }
-        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
       });
 
       const res = await request(app)
@@ -369,9 +201,38 @@ describe("Internal routes", () => {
         .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
         .expect(200);
 
-      // Should fall back to domain-based clientData
-      expect(res.body.clientData.companyName).toBe("example.com");
-      expect(res.body.clientData.brandUrl).toBe("https://www.example.com");
+      expect(res.body.searchParams).toEqual({ qKeywords: "CTOs at SaaS startups" });
+    });
+
+    it("should have null searchParams when targetAudience is absent", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      const res = await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(res.body.searchParams).toBeNull();
+    });
+
+    it("should extract brandDomain from brandUrl", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://www.example.com/path",
+        brandId,
+      });
+
+      const res = await request(app)
+        .post("/internal/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(res.body.brandDomain).toBe("example.com");
+      expect(res.body.brandUrl).toBe("https://www.example.com/path");
     });
   });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,14 +8,10 @@ process.env.RUNS_SERVICE_API_KEY = "test-api-key";
 process.env.CAMPAIGN_SERVICE_API_KEY = "test-api-key";
 process.env.WINDMILL_SERVICE_URL = "https://windmill.test.local";
 process.env.WINDMILL_SERVICE_API_KEY = "test-windmill-key";
-process.env.BRAND_SERVICE_URL = "https://brand.test.local";
-process.env.BRAND_SERVICE_API_KEY = "test-brand-key";
 process.env.LEAD_SERVICE_URL = "https://lead.test.local";
 process.env.LEAD_SERVICE_API_KEY = "test-lead-key";
 process.env.EMAILGENERATION_SERVICE_URL = "https://emailgen.test.local";
 process.env.EMAILGENERATION_SERVICE_API_KEY = "test-emailgen-key";
-process.env.EMAIL_GATEWAY_SERVICE_URL = "https://email-gateway.test.local";
-process.env.EMAIL_GATEWAY_SERVICE_API_KEY = "test-gateway-key";
 
 beforeAll(() => console.log("Test suite starting..."));
 afterAll(() => console.log("Test suite complete."));

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -22,24 +22,34 @@ describe("Workflow module", () => {
   });
 
   describe("buildColdEmailDag", () => {
-    it("should produce a valid DAG with nodes and edges", () => {
+    it("should produce a valid DAG with 6 nodes and 6 edges", () => {
       const dag = buildColdEmailDag();
       expect(dag.nodes).toBeDefined();
       expect(dag.edges).toBeDefined();
-      expect(dag.nodes.length).toBe(4);
-      expect(dag.edges.length).toBe(3);
+      expect(dag.nodes.length).toBe(6);
+      expect(dag.edges.length).toBe(6);
     });
 
-    it("should have the correct node sequence: start-run → email-generate → email-send → end-run", () => {
+    it("should have the correct node IDs", () => {
       const dag = buildColdEmailDag();
       const nodeIds = dag.nodes.map((n) => n.id);
-      expect(nodeIds).toEqual(["start-run", "email-generate", "email-send", "end-run"]);
+      expect(nodeIds).toEqual([
+        "start-run",
+        "brand-profile",
+        "fetch-lead",
+        "email-generate",
+        "email-send",
+        "end-run",
+      ]);
     });
 
-    it("should have correct edge ordering", () => {
+    it("should have correct edges with parallel fan-out after start-run", () => {
       const dag = buildColdEmailDag();
       expect(dag.edges).toEqual([
-        { from: "start-run", to: "email-generate" },
+        { from: "start-run", to: "brand-profile" },
+        { from: "start-run", to: "fetch-lead" },
+        { from: "brand-profile", to: "email-generate" },
+        { from: "fetch-lead", to: "email-generate" },
         { from: "email-generate", to: "email-send" },
         { from: "email-send", to: "end-run" },
       ]);
@@ -62,6 +72,8 @@ describe("Workflow module", () => {
         serviceMap[node.id] = node.config.service as string;
       }
       expect(serviceMap["start-run"]).toBe("campaign");
+      expect(serviceMap["brand-profile"]).toBe("brand");
+      expect(serviceMap["fetch-lead"]).toBe("lead");
       expect(serviceMap["email-generate"]).toBe("emailgeneration");
       expect(serviceMap["email-send"]).toBe("email-gateway");
       expect(serviceMap["end-run"]).toBe("campaign");
@@ -69,7 +81,7 @@ describe("Workflow module", () => {
 
     it("should set retries: 0 at top-level on non-idempotent nodes", () => {
       const dag = buildColdEmailDag();
-      const noRetryNodes = ["start-run", "email-generate", "email-send"];
+      const noRetryNodes = ["fetch-lead", "email-generate", "email-send"];
       for (const nodeId of noRetryNodes) {
         const node = dag.nodes.find((n) => n.id === nodeId);
         // retries must be top-level on the node, NOT inside config
@@ -78,11 +90,26 @@ describe("Workflow module", () => {
       }
     });
 
+    it("should NOT set retries: 0 on start-run (idempotent after extracting lead fetch)", () => {
+      const dag = buildColdEmailDag();
+      const startRun = dag.nodes.find((n) => n.id === "start-run");
+      expect(startRun?.retries).toBeUndefined();
+    });
+
     it("should have validateResponse on email-send to catch success: false", () => {
       const dag = buildColdEmailDag();
       const emailSend = dag.nodes.find((n) => n.id === "email-send");
       expect(emailSend?.config.validateResponse).toEqual({
         field: "success",
+        equals: true,
+      });
+    });
+
+    it("should have validateResponse on fetch-lead to catch found: false", () => {
+      const dag = buildColdEmailDag();
+      const fetchLead = dag.nodes.find((n) => n.id === "fetch-lead");
+      expect(fetchLead?.config.validateResponse).toEqual({
+        field: "found",
         equals: true,
       });
     });
@@ -98,34 +125,65 @@ describe("Workflow module", () => {
       expect(endRun?.config.body).toEqual({ success: true });
     });
 
-    it("should map all lead data fields from start-run to email-generate", () => {
+    it("should configure brand-profile node with keyType and correct inputMapping", () => {
+      const dag = buildColdEmailDag();
+      const brandProfile = dag.nodes.find((n) => n.id === "brand-profile");
+      expect(brandProfile?.config.body).toEqual({ keyType: "byok" });
+      expect(brandProfile?.inputMapping).toEqual({
+        "body.appId": "$ref:start-run.output.appId",
+        "body.clerkOrgId": "$ref:start-run.output.clerkOrgId",
+        "body.url": "$ref:start-run.output.brandUrl",
+        "body.clerkUserId": "$ref:start-run.output.clerkUserId",
+        "body.parentRunId": "$ref:start-run.output.runId",
+      });
+    });
+
+    it("should configure fetch-lead node with custom headers and searchParams", () => {
+      const dag = buildColdEmailDag();
+      const fetchLead = dag.nodes.find((n) => n.id === "fetch-lead");
+      const mapping = fetchLead?.inputMapping || {};
+      expect(mapping["headers.x-app-id"]).toBe("$ref:start-run.output.appId");
+      expect(mapping["headers.x-org-id"]).toBe("$ref:start-run.output.clerkOrgId");
+      expect(mapping["body.campaignId"]).toBe("$ref:start-run.output.campaignId");
+      expect(mapping["body.brandId"]).toBe("$ref:start-run.output.brandId");
+      expect(mapping["body.parentRunId"]).toBe("$ref:start-run.output.runId");
+      expect(mapping["body.searchParams"]).toBe("$ref:start-run.output.searchParams");
+    });
+
+    it("should map lead data from fetch-lead and brand data from brand-profile to email-generate", () => {
       const dag = buildColdEmailDag();
       const emailGen = dag.nodes.find((n) => n.id === "email-generate");
       const mapping = emailGen?.inputMapping || {};
 
-      // Lead fields
-      expect(mapping["body.leadFirstName"]).toBe("$ref:start-run.output.lead.data.first_name");
-      expect(mapping["body.leadLastName"]).toBe("$ref:start-run.output.lead.data.last_name");
-      expect(mapping["body.leadEmail"]).toBe("$ref:start-run.output.lead.data.email");
-      expect(mapping["body.leadCompanyName"]).toBe("$ref:start-run.output.lead.data.organization_name");
+      // Lead fields come from fetch-lead
+      expect(mapping["body.leadFirstName"]).toBe("$ref:fetch-lead.output.lead.data.first_name");
+      expect(mapping["body.leadLastName"]).toBe("$ref:fetch-lead.output.lead.data.last_name");
+      expect(mapping["body.leadEmail"]).toBe("$ref:fetch-lead.output.lead.data.email");
+      expect(mapping["body.leadCompanyName"]).toBe("$ref:fetch-lead.output.lead.data.organization_name");
+      expect(mapping["body.apolloEnrichmentId"]).toBe("$ref:fetch-lead.output.lead.externalId");
 
-      // Client fields
-      expect(mapping["body.clientCompanyName"]).toBe("$ref:start-run.output.clientData.companyName");
-      expect(mapping["body.clientBrandUrl"]).toBe("$ref:start-run.output.clientData.brandUrl");
+      // Brand fields come from brand-profile
+      expect(mapping["body.clientCompanyName"]).toBe("$ref:start-run.output.brandDomain");
+      expect(mapping["body.clientBrandUrl"]).toBe("$ref:start-run.output.brandUrl");
+      expect(mapping["body.clientCompanyOverview"]).toBe("$ref:brand-profile.output.profile.companyOverview");
+      expect(mapping["body.clientValueProposition"]).toBe("$ref:brand-profile.output.profile.valueProposition");
 
-      // Campaign fields
+      // Campaign fields from start-run
       expect(mapping["body.targetOutcome"]).toBe("$ref:start-run.output.targetOutcome");
       expect(mapping["body.valueForTarget"]).toBe("$ref:start-run.output.valueForTarget");
     });
 
-    it("should pass email-generate output to email-send", () => {
+    it("should map lead data from fetch-lead to email-send", () => {
       const dag = buildColdEmailDag();
       const emailSend = dag.nodes.find((n) => n.id === "email-send");
       const mapping = emailSend?.inputMapping || {};
 
+      expect(mapping["body.to"]).toBe("$ref:fetch-lead.output.lead.data.email");
+      expect(mapping["body.recipientFirstName"]).toBe("$ref:fetch-lead.output.lead.data.first_name");
+      expect(mapping["body.recipientLastName"]).toBe("$ref:fetch-lead.output.lead.data.last_name");
+      expect(mapping["body.recipientCompany"]).toBe("$ref:fetch-lead.output.lead.data.organization_name");
       expect(mapping["body.subject"]).toBe("$ref:email-generate.output.subject");
       expect(mapping["body.htmlBody"]).toBe("$ref:email-generate.output.bodyHtml");
-      expect(mapping["body.metadata.emailGenerationId"]).toBe("$ref:email-generate.output.id");
     });
 
     it("should use flow_input for start-run inputs", () => {
@@ -158,7 +216,7 @@ describe("Workflow module", () => {
       expect(body.appId).toBe("mcpfactory");
       expect(body.workflows).toHaveLength(1);
       expect(body.workflows[0].name).toBe("cold-email-outreach");
-      expect(body.workflows[0].dag.nodes).toHaveLength(4);
+      expect(body.workflows[0].dag.nodes).toHaveLength(6);
       expect(body.workflows[0].dag.onError).toBe("end-run");
     });
 


### PR DESCRIPTION
## Summary
- **Removed** direct brand-service and lead-service calls from `/internal/start-run` — these are now separate DAG nodes (`brand-profile` and `fetch-lead`)
- **start-run** now only does: campaign lookup, gate checks, run creation, and returns campaign data
- `brand-profile` and `fetch-lead` run **in parallel** after start-run, then both feed into `email-generate`
- DAG grows from 4 nodes to 6 nodes, with parallel fan-out:
  ```
  start-run → brand-profile ↘
                              → email-generate → email-send → end-run
           → fetch-lead    ↗
  ```
- Fixes the production bug where start-run returned 204 (no body) causing `results.start_run = null` and crashing all downstream nodes
- `fetch-lead` uses `validateResponse: { field: "found", equals: true }` to properly handle "no lead found" as a DAG error
- campaign-service no longer needs `BRAND_SERVICE_URL`/`BRAND_SERVICE_API_KEY` env vars — windmill resolves them automatically

## Test plan
- [x] All 105 tests pass
- [x] Build succeeds
- [x] Updated DAG structure tests (6 nodes, 6 edges, parallel fan-out)
- [x] Updated start-run tests (new response shape, no lead/clientData)
- [x] Verified brand-profile and fetch-lead node configs and inputMappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)