### PR TITLE
fix: pass all user context as unstructured searchParams

### DIFF
--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -139,10 +139,15 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
     });
     console.log(`[Start Run] Run created: runId=${run.id}`);
 
-    // Build searchParams from campaign targetAudience so the fetch-lead
-    // DAG node can pass them to lead-service for Apollo auto-fill.
-    const searchParams = campaign.targetAudience
-      ? { qKeywords: campaign.targetAudience }
+    // Pass all user context as unstructured searchParams so lead-service's
+    // LLM can transform them into structured Apollo search params.
+    const hasSearchContext = campaign.targetAudience || campaign.targetOutcome || campaign.valueForTarget;
+    const searchParams = hasSearchContext
+      ? {
+          targetAudience: campaign.targetAudience,
+          targetOutcome: campaign.targetOutcome,
+          valueForTarget: campaign.valueForTarget,
+        }
       : null;
 
     const brandDomain = extractDomain(campaign.brandUrl);

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -188,11 +188,13 @@ describe("Internal routes", () => {
       expect(res.body.clientData).toBeUndefined();
     });
 
-    it("should include searchParams when targetAudience is set", async () => {
+    it("should pass all user context as unstructured searchParams", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",
         brandId,
-        targetAudience: "CTOs at SaaS startups",
+        targetAudience: "VPs of Sales at B2B SaaS companies",
+        targetOutcome: "Book demo meetings",
+        valueForTarget: "Reduce outbound prospecting time by 80%",
       });
 
       const res = await request(app)
@@ -201,10 +203,14 @@ describe("Internal routes", () => {
         .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
         .expect(200);
 
-      expect(res.body.searchParams).toEqual({ qKeywords: "CTOs at SaaS startups" });
+      expect(res.body.searchParams).toEqual({
+        targetAudience: "VPs of Sales at B2B SaaS companies",
+        targetOutcome: "Book demo meetings",
+        valueForTarget: "Reduce outbound prospecting time by 80%",
+      });
     });
 
-    it("should have null searchParams when targetAudience is absent", async () => {
+    it("should have null searchParams when no user context is set", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",
         brandId,


### PR DESCRIPTION
## Summary
- Stop pre-structuring searchParams as `{ qKeywords: targetAudience }` — lead-service has an LLM that transforms unstructured input into Apollo params
- Pass ALL user context: `targetAudience`, `targetOutcome`, `valueForTarget` as raw data
- More context = better lead search quality

Before:
```json
{ "searchParams": { "qKeywords": "CTOs at SaaS startups" } }
```

After:
```json
{
  "searchParams": {
    "targetAudience": "VPs of Sales at B2B SaaS companies",
    "targetOutcome": "Book demo meetings",
    "valueForTarget": "Reduce outbound prospecting time by 80%"
  }
}
```

## Test plan
- [x] Updated test to verify all three fields are passed
- [x] All 105 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)