### PR TITLE
refactor: extract gate-check into DAG node + remove /internal prefix

### DIFF
--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -12,6 +12,12 @@ import {
   BatchBudgetUsageBody,
   RunStatusUpdate,
   ErrorResponse,
+  GateCheckBody,
+  GateCheckResponse,
+  StartRunBody,
+  StartRunResponse,
+  EndRunBody,
+  EndRunResponse,
 } from "../src/schemas.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -262,6 +268,50 @@ registry.registerPath({
       },
     },
     400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+// === PIPELINE (called by DAG via windmill) ===
+
+registry.registerPath({
+  method: "post",
+  path: "/gate-check",
+  tags: ["Pipeline"],
+  summary: "Check if a campaign can run a new iteration",
+  description: "Validates budget limits (daily/weekly/monthly/total), volume limits (maxLeads), campaign status, and consecutive failures. Auto-stops the campaign if total budget or maxLeads is exceeded. Called as the first DAG node.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: { body: { content: { "application/json": { schema: GateCheckBody } } } },
+  responses: {
+    200: { description: "Gate check result", content: { "application/json": { schema: GateCheckResponse } } },
+    404: { description: "Campaign or org not found", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/start-run",
+  tags: ["Pipeline"],
+  summary: "Create a run and return campaign data for downstream nodes",
+  description: "Creates a new run in runs-service and returns all campaign data needed by downstream DAG nodes (brand-profile, fetch-lead, email-generate, etc.).",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: { body: { content: { "application/json": { schema: StartRunBody } } } },
+  responses: {
+    200: { description: "Run created, campaign data returned", content: { "application/json": { schema: StartRunResponse } } },
+    400: { description: "Missing brandUrl or brandId", content: { "application/json": { schema: ErrorResponse } } },
+    404: { description: "Campaign or org not found", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/end-run",
+  tags: ["Pipeline"],
+  summary: "Finalize run and re-trigger workflow if campaign is ongoing",
+  description: "Finds any running runs for the campaign and marks them as completed or failed. Then re-triggers the workflow if the campaign is still ongoing. Does not require runId — finds running runs via runs-service.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: { body: { content: { "application/json": { schema: EndRunBody } } } },
+  responses: {
+    200: { description: "Run finalized", content: { "application/json": { schema: EndRunResponse } } },
   },
 });
 

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -76,31 +76,49 @@ const APP_ID = "mcpfactory";
  * Build the cold-email-outreach DAG.
  *
  * Pipeline:
- *   start-run → brand-profile ↘
- *                                → email-generate → email-send → end-run
- *            → fetch-lead     ↗
+ *   gate-check → start-run → brand-profile ↘
+ *                                            → email-generate → email-send → end-run
+ *                          → fetch-lead    ↗
  *
- * - start-run:      gate checks + create run (campaign-service internal)
+ * - gate-check:     validate budget/volume/status limits (campaign-service)
+ * - start-run:      create run + return campaign data (campaign-service)
  * - brand-profile:  fetch brand sales profile (brand-service)
  * - fetch-lead:     pull next lead from buffer (lead-service, NO RETRY)
  * - email-generate: generate email via AI (emailgeneration-service, NO RETRY)
  * - email-send:     send email (email-gateway-service, NO RETRY, validate success)
- * - end-run:        finalize run + re-trigger (campaign-service internal)
+ * - end-run:        finalize run as completed + re-trigger (campaign-service)
+ * - end-run-error:  finalize run as failed + re-trigger (campaign-service, onError handler)
  *
  * brand-profile and fetch-lead run in parallel after start-run.
- * On DAG error: end-run is called with success=false via onError handler.
+ * On DAG error: end-run-error is called with success=false via onError handler.
  */
 function buildColdEmailDag() {
   return {
     nodes: [
-      // Step 1: Gate checks + create run + return campaign data
+      // Step 0: Validate budget, volume, status limits
+      {
+        id: "gate-check",
+        type: "http.call",
+        retries: 0, // Don't retry budget/volume checks (wasteful, next loop will retry)
+        config: {
+          service: "campaign",
+          method: "POST",
+          path: "/gate-check",
+          validateResponse: { field: "allowed", equals: true },
+        },
+        inputMapping: {
+          "body.campaignId": "$ref:flow_input.campaignId",
+          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+        },
+      },
+      // Step 1: Create run + return campaign data
       {
         id: "start-run",
         type: "http.call",
         config: {
           service: "campaign",
           method: "POST",
-          path: "/internal/start-run",
+          path: "/start-run",
         },
         inputMapping: {
           "body.campaignId": "$ref:flow_input.campaignId",
@@ -230,26 +248,43 @@ function buildColdEmailDag() {
           "body.metadata.emailGenerationId": "$ref:email-generate.output.id",
         },
       },
-      // Step 5: Finalize run + re-trigger
+      // Step 5: Finalize run as completed + re-trigger
       {
         id: "end-run",
         type: "http.call",
         config: {
           service: "campaign",
           method: "POST",
-          path: "/internal/end-run",
+          path: "/end-run",
           body: {
             success: true,
           },
         },
         inputMapping: {
-          "body.runId": "$ref:start-run.output.runId",
-          "body.campaignId": "$ref:start-run.output.campaignId",
-          "body.clerkOrgId": "$ref:start-run.output.clerkOrgId",
+          "body.campaignId": "$ref:flow_input.campaignId",
+          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+        },
+      },
+      // Error handler: finalize run as failed + re-trigger
+      {
+        id: "end-run-error",
+        type: "http.call",
+        config: {
+          service: "campaign",
+          method: "POST",
+          path: "/end-run",
+          body: {
+            success: false,
+          },
+        },
+        inputMapping: {
+          "body.campaignId": "$ref:flow_input.campaignId",
+          "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
         },
       },
     ],
     edges: [
+      { from: "gate-check", to: "start-run" },
       { from: "start-run", to: "brand-profile" },
       { from: "start-run", to: "fetch-lead" },
       { from: "brand-profile", to: "email-generate" },
@@ -257,8 +292,8 @@ function buildColdEmailDag() {
       { from: "email-generate", to: "email-send" },
       { from: "email-send", to: "end-run" },
     ],
-    // Error handler: call end-run with success=false when any node fails.
-    onError: "end-run",
+    // Error handler: call end-run-error with success=false when any node fails.
+    onError: "end-run-error",
   };
 }
 

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -3,10 +3,12 @@ import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { campaigns, orgs } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
-import { createRun, updateRun } from "@mcpfactory/runs-client";
+import { validateBody } from "../middleware/validate.js";
+import { createRun, listRuns, updateRun } from "@mcpfactory/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
 import { executeCampaignWorkflow } from "../lib/workflows.js";
 import { extractDomain } from "../lib/domain.js";
+import { GateCheckBody, StartRunBody, EndRunBody } from "../schemas.js";
 
 const router = Router();
 const APP_ID = "mcpfactory";
@@ -49,31 +51,91 @@ async function ensurePromptRegistered(clerkOrgId: string): Promise<void> {
 }
 
 /**
- * POST /internal/start-run
+ * POST /gate-check
  *
- * Performs gate checks, creates a run, and returns campaign data
- * for downstream DAG nodes (brand-profile, fetch-lead, etc.).
+ * Checks whether a campaign is allowed to run a new iteration.
+ * Validates budget limits, volume limits, consecutive failures,
+ * and campaign status.
  *
- * Brand profile and lead fetching are handled by separate DAG nodes,
- * NOT by this endpoint.
+ * Called as the first DAG node. Returns { allowed: true } to proceed
+ * or { allowed: false, reason } to stop. Windmill uses validateResponse
+ * to treat allowed=false as a node error → triggers onError handler.
+ *
+ * Returns:
+ *   200 — gate check result (allowed or blocked)
+ *   404 — campaign/org not found
+ *   500 — internal error
+ */
+router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (req, res) => {
+  try {
+    const { campaignId, clerkOrgId } = req.body;
+    console.log(`[Gate Check] Received request: campaignId=${campaignId}, clerkOrgId=${clerkOrgId}`);
+
+    const org = await db.query.orgs.findFirst({
+      where: eq(orgs.clerkOrgId, clerkOrgId),
+    });
+    if (!org) {
+      console.warn(`[Gate Check] Org not found: ${clerkOrgId}`);
+      return res.status(404).json({ error: "Organization not found" });
+    }
+
+    const campaign = await db.query.campaigns.findFirst({
+      where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
+    });
+    if (!campaign) {
+      console.warn(`[Gate Check] Campaign not found: ${campaignId}`);
+      return res.status(404).json({ error: "Campaign not found" });
+    }
+
+    console.log(`[Gate Check] Running checks for campaign ${campaignId} (status=${campaign.status})...`);
+    const result = await runGateChecks({
+      campaignId,
+      clerkOrgId,
+      brandId: campaign.brandId || "",
+      status: campaign.status,
+      maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
+      maxBudgetWeeklyUsd: campaign.maxBudgetWeeklyUsd,
+      maxBudgetMonthlyUsd: campaign.maxBudgetMonthlyUsd,
+      maxBudgetTotalUsd: campaign.maxBudgetTotalUsd,
+      maxLeads: campaign.maxLeads,
+    });
+
+    if (!result.allowed) {
+      console.warn(`[Gate Check] BLOCKED: reason=${result.reason}, autoStopped=${result.autoStopped}`);
+    } else {
+      console.log(`[Gate Check] PASSED for campaign ${campaignId}`);
+    }
+
+    res.json({
+      allowed: result.allowed,
+      ...(result.reason && { reason: result.reason }),
+      ...(result.autoStopped && { autoStopped: result.autoStopped }),
+    });
+  } catch (error) {
+    console.error("[Gate Check] Unhandled error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * POST /start-run
+ *
+ * Creates a run and returns campaign data for downstream DAG nodes
+ * (brand-profile, fetch-lead, etc.).
+ *
+ * Gate checks are handled by the /gate-check DAG node upstream.
  *
  * Returns:
  *   200 — run started, campaign data returned
- *   400 — bad request
+ *   400 — bad request (missing brandUrl/brandId)
  *   404 — campaign/org not found
- *   409 — gate check blocked
  *   500 — internal error
  */
-router.post("/internal/start-run", requireApiKey, async (req, res) => {
+router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req, res) => {
   try {
     const { campaignId, clerkOrgId } = req.body;
     console.log(`[Start Run] Received request: campaignId=${campaignId}, clerkOrgId=${clerkOrgId}`);
-    if (!campaignId || !clerkOrgId) {
-      console.warn("[Start Run] Missing required fields");
-      return res.status(400).json({ error: "campaignId and clerkOrgId are required" });
-    }
 
-    // Look up org + campaign
     const org = await db.query.orgs.findFirst({
       where: eq(orgs.clerkOrgId, clerkOrgId),
     });
@@ -98,29 +160,6 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
       console.warn(`[Start Run] Campaign ${campaignId} has no brandId`);
       return res.status(400).json({ error: "Campaign has no brandId" });
     }
-
-    // Gate checks
-    console.log(`[Start Run] Running gate checks for campaign ${campaignId}...`);
-    const gateResult = await runGateChecks({
-      campaignId,
-      clerkOrgId,
-      brandId: campaign.brandId,
-      status: campaign.status,
-      maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
-      maxBudgetWeeklyUsd: campaign.maxBudgetWeeklyUsd,
-      maxBudgetMonthlyUsd: campaign.maxBudgetMonthlyUsd,
-      maxBudgetTotalUsd: campaign.maxBudgetTotalUsd,
-      maxLeads: campaign.maxLeads,
-    });
-    if (!gateResult.allowed) {
-      console.warn(`[Start Run] Gate check BLOCKED: reason=${gateResult.reason}, autoStopped=${gateResult.autoStopped}`);
-      return res.status(409).json({
-        error: "Gate check failed",
-        reason: gateResult.reason,
-        autoStopped: gateResult.autoStopped || false,
-      });
-    }
-    console.log(`[Start Run] Gate checks PASSED for campaign ${campaignId}`);
 
     // Register prompt template (best-effort, cached per org)
     console.log(`[Start Run] Ensuring prompt registered for org ${clerkOrgId} (cached=${promptRegisteredOrgs.has(clerkOrgId)})`);
@@ -175,25 +214,44 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
 });
 
 /**
- * POST /internal/end-run
+ * POST /end-run
  *
- * Marks a run as completed or failed, then re-triggers the workflow
- * if the campaign is still ongoing.
+ * Marks the running run as completed or failed, then re-triggers the
+ * workflow if the campaign is still ongoing.
+ *
+ * Does NOT require runId — finds the running run via runs-service.
+ * This lets it handle both the happy path (email-send → end-run) and
+ * the error path (onError → end-run-error) including cases where
+ * no run was created (gate-check blocked).
  */
-router.post("/internal/end-run", requireApiKey, async (req, res) => {
+router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res) => {
   try {
-    const { runId, campaignId, clerkOrgId, success } = req.body;
-    console.log(`[End Run] Received request: runId=${runId}, campaignId=${campaignId}, clerkOrgId=${clerkOrgId}, success=${success}`);
-    if (!runId || !campaignId || !clerkOrgId) {
-      console.warn("[End Run] Missing required fields");
-      return res.status(400).json({ error: "runId, campaignId, and clerkOrgId are required" });
-    }
+    const { campaignId, clerkOrgId, success } = req.body;
+    console.log(`[End Run] Received request: campaignId=${campaignId}, clerkOrgId=${clerkOrgId}, success=${success}`);
 
-    // Determine run status:
-    // success === true → completed; anything else → failed
     const status = success === true ? "completed" : "failed";
-    console.log(`[End Run] Updating run ${runId} to status=${status}`);
-    await updateRun(runId, status);
+
+    // Find and update running runs for this campaign
+    try {
+      const { runs } = await listRuns({
+        clerkOrgId,
+        appId: APP_ID,
+        serviceName: "campaign-service",
+        taskName: campaignId,
+      });
+
+      const runningRuns = runs.filter((r) => r.status === "running");
+      if (runningRuns.length > 0) {
+        for (const run of runningRuns) {
+          console.log(`[End Run] Updating run ${run.id} to status=${status}`);
+          await updateRun(run.id, status);
+        }
+      } else {
+        console.log(`[End Run] No running runs found for campaign ${campaignId} — skipping run update`);
+      }
+    } catch (err) {
+      console.error(`[End Run] Failed to update runs:`, err);
+    }
 
     // Respond immediately, then re-trigger asynchronously
     res.json({ status });
@@ -217,7 +275,7 @@ router.post("/internal/end-run", requireApiKey, async (req, res) => {
         return;
       }
 
-      // Fire-and-forget: start-run in the next workflow execution will do gate checks
+      // Fire-and-forget: gate-check in the next workflow execution will validate limits
       console.log(`[End Run] Re-triggering workflow type=${campaign.type} for campaign ${campaignId}`);
       executeCampaignWorkflow(campaign.type, { campaignId, clerkOrgId }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -139,10 +139,15 @@ router.post("/internal/start-run", requireApiKey, async (req, res) => {
     });
     console.log(`[Start Run] Run created: runId=${run.id}`);
 
-    // Build searchParams from campaign targetAudience so the fetch-lead
-    // DAG node can pass them to lead-service for Apollo auto-fill.
-    const searchParams = campaign.targetAudience
-      ? { qKeywords: campaign.targetAudience }
+    // Pass all user context as unstructured searchParams so lead-service's
+    // LLM can transform them into structured Apollo search params.
+    const hasSearchContext = campaign.targetAudience || campaign.targetOutcome || campaign.valueForTarget;
+    const searchParams = hasSearchContext
+      ? {
+          targetAudience: campaign.targetAudience,
+          targetOutcome: campaign.targetOutcome,
+          valueForTarget: campaign.valueForTarget,
+        }
       : null;
 
     const brandDomain = extractDomain(campaign.brandUrl);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -114,3 +114,45 @@ export const BatchBudgetUsageBody = z.object({
 export const RunStatusUpdate = z.object({
   status: z.enum(["completed", "failed"]),
 }).openapi("RunStatusUpdate");
+
+// --- Pipeline endpoints (called by DAG) ---
+
+export const GateCheckBody = z.object({
+  campaignId: z.string().uuid("campaignId must be a valid UUID"),
+  clerkOrgId: z.string().min(1, "clerkOrgId is required"),
+}).openapi("GateCheckBody");
+
+export const GateCheckResponse = z.object({
+  allowed: z.boolean(),
+  reason: z.string().optional(),
+  autoStopped: z.boolean().optional(),
+}).openapi("GateCheckResponse");
+
+export const StartRunBody = z.object({
+  campaignId: z.string().uuid("campaignId must be a valid UUID"),
+  clerkOrgId: z.string().min(1, "clerkOrgId is required"),
+}).openapi("StartRunBody");
+
+export const StartRunResponse = z.object({
+  runId: z.string().uuid(),
+  campaignId: z.string().uuid(),
+  clerkOrgId: z.string(),
+  brandId: z.string().uuid(),
+  brandUrl: z.string(),
+  brandDomain: z.string(),
+  appId: z.string(),
+  clerkUserId: z.string().nullable(),
+  targetOutcome: z.string().nullable(),
+  valueForTarget: z.string().nullable(),
+  searchParams: z.record(z.string(), z.unknown()).nullable(),
+}).openapi("StartRunResponse");
+
+export const EndRunBody = z.object({
+  campaignId: z.string().uuid("campaignId must be a valid UUID"),
+  clerkOrgId: z.string().min(1, "clerkOrgId is required"),
+  success: z.boolean(),
+}).openapi("EndRunBody");
+
+export const EndRunResponse = z.object({
+  status: z.string(),
+}).openapi("EndRunResponse");

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -47,7 +47,7 @@ import { cleanTestData, closeDb, insertTestOrg, insertTestCampaign } from "../he
 
 const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 
-describe("Internal routes", () => {
+describe("Pipeline routes", () => {
   let org: { id: string; clerkOrgId: string };
   const brandId = crypto.randomUUID();
 
@@ -73,26 +73,30 @@ describe("Internal routes", () => {
     await closeDb();
   });
 
-  describe("POST /internal/start-run", () => {
-    it("should return 400 if campaignId or clerkOrgId is missing", async () => {
-      await request(app)
-        .post("/internal/start-run")
-        .set("x-api-key", API_KEY)
-        .send({ campaignId: "some-id" })
-        .expect(400);
+  // === POST /gate-check ===
 
+  describe("POST /gate-check", () => {
+    it("should return 400 if campaignId is missing", async () => {
       await request(app)
-        .post("/internal/start-run")
+        .post("/gate-check")
         .set("x-api-key", API_KEY)
         .send({ clerkOrgId: "some-org" })
         .expect(400);
     });
 
+    it("should return 400 if clerkOrgId is missing", async () => {
+      await request(app)
+        .post("/gate-check")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: crypto.randomUUID() })
+        .expect(400);
+    });
+
     it("should return 404 if org not found", async () => {
       const res = await request(app)
-        .post("/internal/start-run")
+        .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: "fake", clerkOrgId: "nonexistent-org" })
+        .send({ campaignId: crypto.randomUUID(), clerkOrgId: "nonexistent-org" })
         .expect(404);
 
       expect(res.body.error).toBe("Organization not found");
@@ -100,7 +104,124 @@ describe("Internal routes", () => {
 
     it("should return 404 if campaign not found", async () => {
       const res = await request(app)
-        .post("/internal/start-run")
+        .post("/gate-check")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: crypto.randomUUID(), clerkOrgId: org.clerkOrgId })
+        .expect(404);
+
+      expect(res.body.error).toBe("Campaign not found");
+    });
+
+    it("should return allowed: true when gate checks pass", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      const res = await request(app)
+        .post("/gate-check")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(res.body.allowed).toBe(true);
+      expect(res.body.reason).toBeUndefined();
+    });
+
+    it("should return allowed: false with reason when gate checks fail", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      mockGateChecks.mockResolvedValue({
+        allowed: false,
+        reason: "daily budget exceeded",
+      });
+
+      const res = await request(app)
+        .post("/gate-check")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(res.body.allowed).toBe(false);
+      expect(res.body.reason).toBe("daily budget exceeded");
+    });
+
+    it("should return autoStopped flag when campaign is auto-stopped", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      mockGateChecks.mockResolvedValue({
+        allowed: false,
+        reason: "Total budget exceeded",
+        autoStopped: true,
+      });
+
+      const res = await request(app)
+        .post("/gate-check")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(res.body.allowed).toBe(false);
+      expect(res.body.autoStopped).toBe(true);
+    });
+
+    it("should pass campaign data to runGateChecks", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+        maxBudgetDailyUsd: "50.00",
+        maxLeads: 100,
+      });
+
+      await request(app)
+        .post("/gate-check")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(mockGateChecks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+          brandId,
+          status: "ongoing",
+          maxBudgetDailyUsd: "50.00",
+          maxLeads: 100,
+        }),
+      );
+    });
+  });
+
+  // === POST /start-run ===
+
+  describe("POST /start-run", () => {
+    it("should return 400 if campaignId is missing", async () => {
+      await request(app)
+        .post("/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ clerkOrgId: "some-org" })
+        .expect(400);
+    });
+
+    it("should return 404 if org not found", async () => {
+      const res = await request(app)
+        .post("/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: crypto.randomUUID(), clerkOrgId: "nonexistent-org" })
+        .expect(404);
+
+      expect(res.body.error).toBe("Organization not found");
+    });
+
+    it("should return 404 if campaign not found", async () => {
+      const res = await request(app)
+        .post("/start-run")
         .set("x-api-key", API_KEY)
         .send({ campaignId: crypto.randomUUID(), clerkOrgId: org.clerkOrgId })
         .expect(404);
@@ -115,7 +236,7 @@ describe("Internal routes", () => {
       });
 
       const res = await request(app)
-        .post("/internal/start-run")
+        .post("/start-run")
         .set("x-api-key", API_KEY)
         .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
         .expect(400);
@@ -130,33 +251,12 @@ describe("Internal routes", () => {
       });
 
       const res = await request(app)
-        .post("/internal/start-run")
+        .post("/start-run")
         .set("x-api-key", API_KEY)
         .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
         .expect(400);
 
       expect(res.body.error).toBe("Campaign has no brandId");
-    });
-
-    it("should return 409 when gate check fails", async () => {
-      const campaign = await insertTestCampaign(org.id, {
-        brandUrl: "https://example.com",
-        brandId,
-      });
-
-      mockGateChecks.mockResolvedValue({
-        allowed: false,
-        reason: "daily budget exceeded",
-      });
-
-      const res = await request(app)
-        .post("/internal/start-run")
-        .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
-        .expect(409);
-
-      expect(res.body.error).toBe("Gate check failed");
-      expect(res.body.reason).toBe("daily budget exceeded");
     });
 
     it("should return 200 with campaign data and runId", async () => {
@@ -169,7 +269,7 @@ describe("Internal routes", () => {
       });
 
       const res = await request(app)
-        .post("/internal/start-run")
+        .post("/start-run")
         .set("x-api-key", API_KEY)
         .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
         .expect(200);
@@ -183,9 +283,6 @@ describe("Internal routes", () => {
       expect(res.body.appId).toBe("mcpfactory");
       expect(res.body.targetOutcome).toBe("Book demos");
       expect(res.body.valueForTarget).toBe("Analytics platform");
-      // No lead or clientData — those are fetched by separate DAG nodes
-      expect(res.body.lead).toBeUndefined();
-      expect(res.body.clientData).toBeUndefined();
     });
 
     it("should pass all user context as unstructured searchParams", async () => {
@@ -198,7 +295,7 @@ describe("Internal routes", () => {
       });
 
       const res = await request(app)
-        .post("/internal/start-run")
+        .post("/start-run")
         .set("x-api-key", API_KEY)
         .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
         .expect(200);
@@ -217,7 +314,7 @@ describe("Internal routes", () => {
       });
 
       const res = await request(app)
-        .post("/internal/start-run")
+        .post("/start-run")
         .set("x-api-key", API_KEY)
         .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
         .expect(200);
@@ -232,7 +329,7 @@ describe("Internal routes", () => {
       });
 
       const res = await request(app)
-        .post("/internal/start-run")
+        .post("/start-run")
         .set("x-api-key", API_KEY)
         .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
         .expect(200);
@@ -240,28 +337,50 @@ describe("Internal routes", () => {
       expect(res.body.brandDomain).toBe("example.com");
       expect(res.body.brandUrl).toBe("https://www.example.com/path");
     });
-  });
 
-  describe("POST /internal/end-run", () => {
-    it("should return 400 if required fields are missing", async () => {
-      await request(app)
-        .post("/internal/end-run")
-        .set("x-api-key", API_KEY)
-        .send({ runId: "run-1", campaignId: "camp-1" })
-        .expect(400);
-    });
-
-    it("should mark run as completed when success is true", async () => {
+    it("should NOT call gate checks (gate check is a separate DAG node)", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",
         brandId,
       });
 
+      await request(app)
+        .post("/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(mockGateChecks).not.toHaveBeenCalled();
+    });
+  });
+
+  // === POST /end-run ===
+
+  describe("POST /end-run", () => {
+    it("should return 400 if required fields are missing", async () => {
+      await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: crypto.randomUUID(), clerkOrgId: "org-1" })
+        .expect(400);
+    });
+
+    it("should find and mark running run as completed when success is true", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      mockListRuns.mockResolvedValue({
+        runs: [
+          { id: "run-123", status: "running", startedAt: new Date().toISOString() },
+        ],
+      });
+
       const res = await request(app)
-        .post("/internal/end-run")
+        .post("/end-run")
         .set("x-api-key", API_KEY)
         .send({
-          runId: "run-123",
           campaignId: campaign.id,
           clerkOrgId: org.clerkOrgId,
           success: true,
@@ -272,17 +391,22 @@ describe("Internal routes", () => {
       expect(mockUpdateRun).toHaveBeenCalledWith("run-123", "completed");
     });
 
-    it("should mark run as failed when success is false", async () => {
+    it("should find and mark running run as failed when success is false", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",
         brandId,
       });
 
+      mockListRuns.mockResolvedValue({
+        runs: [
+          { id: "run-456", status: "running", startedAt: new Date().toISOString() },
+        ],
+      });
+
       const res = await request(app)
-        .post("/internal/end-run")
+        .post("/end-run")
         .set("x-api-key", API_KEY)
         .send({
-          runId: "run-456",
           campaignId: campaign.id,
           clerkOrgId: org.clerkOrgId,
           success: false,
@@ -293,6 +417,28 @@ describe("Internal routes", () => {
       expect(mockUpdateRun).toHaveBeenCalledWith("run-456", "failed");
     });
 
+    it("should skip run update when no running runs exist (gate-check blocked)", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      mockListRuns.mockResolvedValue({ runs: [] });
+
+      const res = await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+          success: false,
+        })
+        .expect(200);
+
+      expect(res.body.status).toBe("failed");
+      expect(mockUpdateRun).not.toHaveBeenCalled();
+    });
+
     it("should re-trigger workflow if campaign is still ongoing", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",
@@ -301,10 +447,9 @@ describe("Internal routes", () => {
       });
 
       await request(app)
-        .post("/internal/end-run")
+        .post("/end-run")
         .set("x-api-key", API_KEY)
         .send({
-          runId: "run-789",
           campaignId: campaign.id,
           clerkOrgId: org.clerkOrgId,
           success: true,
@@ -331,10 +476,9 @@ describe("Internal routes", () => {
       });
 
       await request(app)
-        .post("/internal/end-run")
+        .post("/end-run")
         .set("x-api-key", API_KEY)
         .send({
-          runId: "run-stopped",
           campaignId: campaign.id,
           clerkOrgId: org.clerkOrgId,
           success: true,

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -188,11 +188,13 @@ describe("Internal routes", () => {
       expect(res.body.clientData).toBeUndefined();
     });
 
-    it("should include searchParams when targetAudience is set", async () => {
+    it("should pass all user context as unstructured searchParams", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",
         brandId,
-        targetAudience: "CTOs at SaaS startups",
+        targetAudience: "VPs of Sales at B2B SaaS companies",
+        targetOutcome: "Book demo meetings",
+        valueForTarget: "Reduce outbound prospecting time by 80%",
       });
 
       const res = await request(app)
@@ -201,10 +203,14 @@ describe("Internal routes", () => {
         .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
         .expect(200);
 
-      expect(res.body.searchParams).toEqual({ qKeywords: "CTOs at SaaS startups" });
+      expect(res.body.searchParams).toEqual({
+        targetAudience: "VPs of Sales at B2B SaaS companies",
+        targetOutcome: "Book demo meetings",
+        valueForTarget: "Reduce outbound prospecting time by 80%",
+      });
     });
 
-    it("should have null searchParams when targetAudience is absent", async () => {
+    it("should have null searchParams when no user context is set", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",
         brandId,

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -22,30 +22,33 @@ describe("Workflow module", () => {
   });
 
   describe("buildColdEmailDag", () => {
-    it("should produce a valid DAG with 6 nodes and 6 edges", () => {
+    it("should produce a valid DAG with 8 nodes and 7 edges", () => {
       const dag = buildColdEmailDag();
       expect(dag.nodes).toBeDefined();
       expect(dag.edges).toBeDefined();
-      expect(dag.nodes.length).toBe(6);
-      expect(dag.edges.length).toBe(6);
+      expect(dag.nodes.length).toBe(8);
+      expect(dag.edges.length).toBe(7);
     });
 
     it("should have the correct node IDs", () => {
       const dag = buildColdEmailDag();
       const nodeIds = dag.nodes.map((n) => n.id);
       expect(nodeIds).toEqual([
+        "gate-check",
         "start-run",
         "brand-profile",
         "fetch-lead",
         "email-generate",
         "email-send",
         "end-run",
+        "end-run-error",
       ]);
     });
 
-    it("should have correct edges with parallel fan-out after start-run", () => {
+    it("should have correct edges with gate-check first and parallel fan-out after start-run", () => {
       const dag = buildColdEmailDag();
       expect(dag.edges).toEqual([
+        { from: "gate-check", to: "start-run" },
         { from: "start-run", to: "brand-profile" },
         { from: "start-run", to: "fetch-lead" },
         { from: "brand-profile", to: "email-generate" },
@@ -71,17 +74,19 @@ describe("Workflow module", () => {
       for (const node of dag.nodes) {
         serviceMap[node.id] = node.config.service as string;
       }
+      expect(serviceMap["gate-check"]).toBe("campaign");
       expect(serviceMap["start-run"]).toBe("campaign");
       expect(serviceMap["brand-profile"]).toBe("brand");
       expect(serviceMap["fetch-lead"]).toBe("lead");
       expect(serviceMap["email-generate"]).toBe("emailgeneration");
       expect(serviceMap["email-send"]).toBe("email-gateway");
       expect(serviceMap["end-run"]).toBe("campaign");
+      expect(serviceMap["end-run-error"]).toBe("campaign");
     });
 
-    it("should set retries: 0 at top-level on non-idempotent nodes", () => {
+    it("should set retries: 0 at top-level on non-retryable nodes", () => {
       const dag = buildColdEmailDag();
-      const noRetryNodes = ["fetch-lead", "email-generate", "email-send"];
+      const noRetryNodes = ["gate-check", "fetch-lead", "email-generate", "email-send"];
       for (const nodeId of noRetryNodes) {
         const node = dag.nodes.find((n) => n.id === nodeId);
         // retries must be top-level on the node, NOT inside config
@@ -90,10 +95,19 @@ describe("Workflow module", () => {
       }
     });
 
-    it("should NOT set retries: 0 on start-run (idempotent after extracting lead fetch)", () => {
+    it("should NOT set retries: 0 on start-run (idempotent)", () => {
       const dag = buildColdEmailDag();
       const startRun = dag.nodes.find((n) => n.id === "start-run");
       expect(startRun?.retries).toBeUndefined();
+    });
+
+    it("should have validateResponse on gate-check to catch allowed: false", () => {
+      const dag = buildColdEmailDag();
+      const gateCheck = dag.nodes.find((n) => n.id === "gate-check");
+      expect(gateCheck?.config.validateResponse).toEqual({
+        field: "allowed",
+        equals: true,
+      });
     });
 
     it("should have validateResponse on email-send to catch success: false", () => {
@@ -114,15 +128,42 @@ describe("Workflow module", () => {
       });
     });
 
-    it("should have onError handler pointing to end-run", () => {
+    it("should have onError handler pointing to end-run-error (not end-run)", () => {
       const dag = buildColdEmailDag();
-      expect(dag.onError).toBe("end-run");
+      expect(dag.onError).toBe("end-run-error");
     });
 
-    it("should set success: true in end-run body (overridden to false by onError)", () => {
+    it("should set success: true in end-run body and success: false in end-run-error body", () => {
       const dag = buildColdEmailDag();
       const endRun = dag.nodes.find((n) => n.id === "end-run");
+      const endRunError = dag.nodes.find((n) => n.id === "end-run-error");
       expect(endRun?.config.body).toEqual({ success: true });
+      expect(endRunError?.config.body).toEqual({ success: false });
+    });
+
+    it("should use /gate-check path (no /internal prefix)", () => {
+      const dag = buildColdEmailDag();
+      const gateCheck = dag.nodes.find((n) => n.id === "gate-check");
+      expect(gateCheck?.config.path).toBe("/gate-check");
+    });
+
+    it("should use /start-run and /end-run paths (no /internal prefix)", () => {
+      const dag = buildColdEmailDag();
+      const startRun = dag.nodes.find((n) => n.id === "start-run");
+      const endRun = dag.nodes.find((n) => n.id === "end-run");
+      const endRunError = dag.nodes.find((n) => n.id === "end-run-error");
+      expect(startRun?.config.path).toBe("/start-run");
+      expect(endRun?.config.path).toBe("/end-run");
+      expect(endRunError?.config.path).toBe("/end-run");
+    });
+
+    it("should configure gate-check node with flow_input mapping", () => {
+      const dag = buildColdEmailDag();
+      const gateCheck = dag.nodes.find((n) => n.id === "gate-check");
+      expect(gateCheck?.inputMapping).toEqual({
+        "body.campaignId": "$ref:flow_input.campaignId",
+        "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+      });
     });
 
     it("should configure brand-profile node with keyType and correct inputMapping", () => {
@@ -186,10 +227,31 @@ describe("Workflow module", () => {
       expect(mapping["body.htmlBody"]).toBe("$ref:email-generate.output.bodyHtml");
     });
 
-    it("should use flow_input for start-run inputs", () => {
+    it("should use flow_input for gate-check and start-run inputs", () => {
       const dag = buildColdEmailDag();
+      const gateCheck = dag.nodes.find((n) => n.id === "gate-check");
       const startRun = dag.nodes.find((n) => n.id === "start-run");
+      expect(gateCheck?.inputMapping).toEqual({
+        "body.campaignId": "$ref:flow_input.campaignId",
+        "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+      });
       expect(startRun?.inputMapping).toEqual({
+        "body.campaignId": "$ref:flow_input.campaignId",
+        "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+      });
+    });
+
+    it("should use flow_input for end-run and end-run-error (not start-run.output)", () => {
+      const dag = buildColdEmailDag();
+      const endRun = dag.nodes.find((n) => n.id === "end-run");
+      const endRunError = dag.nodes.find((n) => n.id === "end-run-error");
+
+      // Both should use flow_input, NOT $ref:start-run.output
+      expect(endRun?.inputMapping).toEqual({
+        "body.campaignId": "$ref:flow_input.campaignId",
+        "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+      });
+      expect(endRunError?.inputMapping).toEqual({
         "body.campaignId": "$ref:flow_input.campaignId",
         "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
       });
@@ -216,8 +278,8 @@ describe("Workflow module", () => {
       expect(body.appId).toBe("mcpfactory");
       expect(body.workflows).toHaveLength(1);
       expect(body.workflows[0].name).toBe("cold-email-outreach");
-      expect(body.workflows[0].dag.nodes).toHaveLength(6);
-      expect(body.workflows[0].dag.onError).toBe("end-run");
+      expect(body.workflows[0].dag.nodes).toHaveLength(8);
+      expect(body.workflows[0].dag.onError).toBe("end-run-error");
     });
 
     it("should not throw when windmill env vars are missing", async () => {


### PR DESCRIPTION
## Summary

- **New `POST /gate-check` endpoint** — separate DAG node that validates budget limits (daily/weekly/monthly/total), volume limits (maxLeads), campaign status, and consecutive failures before starting a run. Uses `validateResponse: { field: "allowed", equals: true }` to stop the pipeline when limits are exceeded.
- **Removed `/internal` prefix** — `POST /start-run` and `POST /end-run` are now public endpoints with Zod validation and OpenAPI documentation.
- **End-run is self-sufficient** — finds running runs via runs-service instead of requiring `runId` from `$ref:start-run.output`. This prevents crashes when gate-check blocks (no run was created).
- **New `end-run-error` node** — dedicated onError handler with `success: false`. Fixes pre-existing bug where onError called end-run with `success: true`.
- **DAG: 8 nodes, 7 edges** — `gate-check → start-run → brand-profile+fetch-lead → email-generate → email-send → end-run`, `onError: end-run-error`

## Test plan

- [x] 119 tests passing (gate-check endpoint tests, renamed route tests, updated DAG structure tests)
- [ ] Deploy and verify gate-check blocks when budget/volume exceeded
- [ ] Verify end-run handles missing running runs gracefully (gate-check blocked case)
- [ ] Verify end-run-error correctly marks runs as failed on DAG errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)