### PR TITLE
fix: use correct Apollo field names (flat camelCase)

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -6,7 +6,10 @@ export const COLD_EMAIL_PROMPT = `You are an expert sales copywriter. Write a pe
 - Email: {{leadEmail}}
 - LinkedIn: {{leadLinkedinUrl}}
 - Company: {{leadCompanyName}}
-- Company Details: {{leadCompanyOrganization}}
+- Domain: {{leadCompanyDomain}}
+- Industry: {{leadCompanyIndustry}}
+- Company Size: {{leadCompanySize}}
+- Revenue: {{leadCompanyRevenueUsd}}
 
 ## Sender / Our Company
 - Company: {{clientCompanyName}}
@@ -58,7 +61,8 @@ SUBJECT: [subject line]
 
 export const COLD_EMAIL_VARIABLES = [
   "leadFirstName", "leadLastName", "leadTitle", "leadEmail",
-  "leadLinkedinUrl", "leadCompanyName", "leadCompanyOrganization",
+  "leadLinkedinUrl", "leadCompanyName", "leadCompanyDomain",
+  "leadCompanyIndustry", "leadCompanySize", "leadCompanyRevenueUsd",
   "clientCompanyName", "clientBrandUrl", "clientCompanyOverview",
   "clientValueProposition", "clientTargetAudience", "clientCustomerPainPoints",
   "clientKeyFeatures", "clientProductDifferentiators", "clientCompetitors",
@@ -181,14 +185,17 @@ function buildColdEmailDag() {
           "body.campaignId": "$ref:start-run.output.campaignId",
           "body.runId": "$ref:start-run.output.runId",
           "body.apolloEnrichmentId": "$ref:fetch-lead.output.lead.externalId",
-          // Lead fields from fetch-lead
-          "body.leadFirstName": "$ref:fetch-lead.output.lead.data.first_name",
-          "body.leadLastName": "$ref:fetch-lead.output.lead.data.last_name",
+          // Lead fields from fetch-lead (flat camelCase per Apollo spec)
+          "body.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+          "body.leadLastName": "$ref:fetch-lead.output.lead.data.lastName",
           "body.leadTitle": "$ref:fetch-lead.output.lead.data.title",
           "body.leadEmail": "$ref:fetch-lead.output.lead.data.email",
-          "body.leadLinkedinUrl": "$ref:fetch-lead.output.lead.data.linkedin_url",
-          "body.leadCompanyName": "$ref:fetch-lead.output.lead.data.organization_name",
-          "body.leadCompanyOrganization": "$ref:fetch-lead.output.lead.data.organization",
+          "body.leadLinkedinUrl": "$ref:fetch-lead.output.lead.data.linkedinUrl",
+          "body.leadCompanyName": "$ref:fetch-lead.output.lead.data.organizationName",
+          "body.leadCompanyDomain": "$ref:fetch-lead.output.lead.data.organizationDomain",
+          "body.leadCompanyIndustry": "$ref:fetch-lead.output.lead.data.organizationIndustry",
+          "body.leadCompanySize": "$ref:fetch-lead.output.lead.data.organizationSize",
+          "body.leadCompanyRevenueUsd": "$ref:fetch-lead.output.lead.data.organizationRevenueUsd",
           // Client/brand fields from brand-profile
           "body.clientCompanyName": "$ref:start-run.output.brandDomain",
           "body.clientBrandUrl": "$ref:start-run.output.brandUrl",
@@ -233,9 +240,9 @@ function buildColdEmailDag() {
           "body.campaignId": "$ref:start-run.output.campaignId",
           "body.runId": "$ref:start-run.output.runId",
           "body.to": "$ref:fetch-lead.output.lead.data.email",
-          "body.recipientFirstName": "$ref:fetch-lead.output.lead.data.first_name",
-          "body.recipientLastName": "$ref:fetch-lead.output.lead.data.last_name",
-          "body.recipientCompany": "$ref:fetch-lead.output.lead.data.organization_name",
+          "body.recipientFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+          "body.recipientLastName": "$ref:fetch-lead.output.lead.data.lastName",
+          "body.recipientCompany": "$ref:fetch-lead.output.lead.data.organizationName",
           "body.subject": "$ref:email-generate.output.subject",
           "body.htmlBody": "$ref:email-generate.output.bodyHtml",
           "body.metadata.emailGenerationId": "$ref:email-generate.output.id",

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -196,11 +196,11 @@ describe("Workflow module", () => {
       const emailGen = dag.nodes.find((n) => n.id === "email-generate");
       const mapping = emailGen?.inputMapping || {};
 
-      // Lead fields come from fetch-lead
-      expect(mapping["body.leadFirstName"]).toBe("$ref:fetch-lead.output.lead.data.first_name");
-      expect(mapping["body.leadLastName"]).toBe("$ref:fetch-lead.output.lead.data.last_name");
+      // Lead fields come from fetch-lead (flat camelCase per Apollo spec)
+      expect(mapping["body.leadFirstName"]).toBe("$ref:fetch-lead.output.lead.data.firstName");
+      expect(mapping["body.leadLastName"]).toBe("$ref:fetch-lead.output.lead.data.lastName");
       expect(mapping["body.leadEmail"]).toBe("$ref:fetch-lead.output.lead.data.email");
-      expect(mapping["body.leadCompanyName"]).toBe("$ref:fetch-lead.output.lead.data.organization_name");
+      expect(mapping["body.leadCompanyName"]).toBe("$ref:fetch-lead.output.lead.data.organizationName");
       expect(mapping["body.apolloEnrichmentId"]).toBe("$ref:fetch-lead.output.lead.externalId");
 
       // Brand fields come from brand-profile
@@ -220,9 +220,9 @@ describe("Workflow module", () => {
       const mapping = emailSend?.inputMapping || {};
 
       expect(mapping["body.to"]).toBe("$ref:fetch-lead.output.lead.data.email");
-      expect(mapping["body.recipientFirstName"]).toBe("$ref:fetch-lead.output.lead.data.first_name");
-      expect(mapping["body.recipientLastName"]).toBe("$ref:fetch-lead.output.lead.data.last_name");
-      expect(mapping["body.recipientCompany"]).toBe("$ref:fetch-lead.output.lead.data.organization_name");
+      expect(mapping["body.recipientFirstName"]).toBe("$ref:fetch-lead.output.lead.data.firstName");
+      expect(mapping["body.recipientLastName"]).toBe("$ref:fetch-lead.output.lead.data.lastName");
+      expect(mapping["body.recipientCompany"]).toBe("$ref:fetch-lead.output.lead.data.organizationName");
       expect(mapping["body.subject"]).toBe("$ref:email-generate.output.subject");
       expect(mapping["body.htmlBody"]).toBe("$ref:email-generate.output.bodyHtml");
     });


### PR DESCRIPTION
## Summary
- Fixed all `$ref` paths to use Apollo's flat camelCase field names instead of nested snake_case
- `firstName` not `first_name`, `organizationDomain` not `organization.primary_domain`
- Restored organization enrichment fields (domain, industry, size, revenue) as flat refs
- Updated email-generate and email-send inputMapping + prompt template

## What was wrong
The DAG referenced `lead.data.organization.primary_domain` (nested) instead of `lead.data.organizationDomain` (flat). Apollo service returns flat camelCase — confirmed via API Registry spec.

## Test plan
- [x] All 119 tests pass
- [ ] Deploy and verify email-generate receives correct lead data

🤖 Generated with [Claude Code](https://claude.com/claude-code)