### PR TITLE
feat: conditional branching for graceful no-leads handling

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -76,21 +76,30 @@ const APP_ID = "mcpfactory";
  * Build the cold-email-outreach DAG.
  *
  * Pipeline:
- *   gate-check → start-run → brand-profile ↘
- *                                            → email-generate → email-send → end-run
- *                          → fetch-lead    ↗
+ *   gate-check → start-run → fetch-lead → check-lead ──────────┐
+ *                                           │ (found=true)      │ (found=false)
+ *                                           ↓                   │
+ *                                     brand-profile             │
+ *                                           ↓                   │
+ *                                     email-generate            │
+ *                                           ↓                   │
+ *                                     email-send                │
+ *                                           ↓                   ↓
+ *                                           end-run (always)
  *
  * - gate-check:     validate budget/volume/status limits (campaign-service)
  * - start-run:      create run + return campaign data (campaign-service)
- * - brand-profile:  fetch brand sales profile (brand-service)
  * - fetch-lead:     pull next lead from buffer (lead-service, NO RETRY)
+ * - check-lead:     condition node — branches on found=true/false
+ * - brand-profile:  fetch brand sales profile (brand-service, only when lead found)
  * - email-generate: generate email via AI (emailgeneration-service, NO RETRY)
  * - email-send:     send email (email-gateway-service, NO RETRY, validate success)
- * - end-run:        finalize run as completed + re-trigger (campaign-service)
- * - end-run-error:  finalize run as failed + re-trigger (campaign-service, onError handler)
+ * - end-run:        finalize run (always called, receives leadFound flag)
+ * - end-run-error:  finalize run as failed (onError handler for real errors)
  *
- * brand-profile and fetch-lead run in parallel after start-run.
- * On DAG error: end-run-error is called with success=false via onError handler.
+ * end-run always executes: when leadFound=true it re-triggers, when leadFound=false
+ * it auto-stops the campaign (no leads = no point retrying).
+ * On real DAG error: end-run-error is called with success=false via onError handler.
  */
 function buildColdEmailDag() {
   return {
@@ -125,7 +134,34 @@ function buildColdEmailDag() {
           "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
         },
       },
-      // Step 2a: Fetch brand sales profile (parallel with fetch-lead)
+      // Step 2: Pull next lead from buffer
+      {
+        id: "fetch-lead",
+        type: "http.call",
+        retries: 0, // Non-idempotent: consumes from buffer
+        config: {
+          service: "lead",
+          method: "POST",
+          path: "/buffer/next",
+          body: {
+            keySource: "byok",
+          },
+        },
+        inputMapping: {
+          "headers.x-app-id": "$ref:start-run.output.appId",
+          "headers.x-org-id": "$ref:start-run.output.clerkOrgId",
+          "body.campaignId": "$ref:start-run.output.campaignId",
+          "body.brandId": "$ref:start-run.output.brandId",
+          "body.parentRunId": "$ref:start-run.output.runId",
+          "body.searchParams": "$ref:start-run.output.searchParams",
+        },
+      },
+      // Step 3: Condition — branch on found=true/false
+      {
+        id: "check-lead",
+        type: "condition",
+      },
+      // Step 4a: Fetch brand sales profile (only when lead found)
       {
         id: "brand-profile",
         type: "http.call",
@@ -145,30 +181,7 @@ function buildColdEmailDag() {
           "body.parentRunId": "$ref:start-run.output.runId",
         },
       },
-      // Step 2b: Pull next lead from buffer (parallel with brand-profile)
-      {
-        id: "fetch-lead",
-        type: "http.call",
-        retries: 0, // Non-idempotent: consumes from buffer
-        config: {
-          service: "lead",
-          method: "POST",
-          path: "/buffer/next",
-          body: {
-            keySource: "byok",
-          },
-          validateResponse: { field: "found", equals: true },
-        },
-        inputMapping: {
-          "headers.x-app-id": "$ref:start-run.output.appId",
-          "headers.x-org-id": "$ref:start-run.output.clerkOrgId",
-          "body.campaignId": "$ref:start-run.output.campaignId",
-          "body.brandId": "$ref:start-run.output.brandId",
-          "body.parentRunId": "$ref:start-run.output.runId",
-          "body.searchParams": "$ref:start-run.output.searchParams",
-        },
-      },
-      // Step 3: Generate email (non-idempotent, NO RETRY)
+      // Step 4b: Generate email (non-idempotent, NO RETRY)
       {
         id: "email-generate",
         type: "http.call",
@@ -217,7 +230,7 @@ function buildColdEmailDag() {
           "body.valueForTarget": "$ref:start-run.output.valueForTarget",
         },
       },
-      // Step 4: Send email (non-idempotent, NO RETRY)
+      // Step 5: Send email (non-idempotent, NO RETRY)
       {
         id: "email-send",
         type: "http.call",
@@ -251,7 +264,7 @@ function buildColdEmailDag() {
           "body.metadata.emailGenerationId": "$ref:email-generate.output.id",
         },
       },
-      // Step 5: Finalize run as completed + re-trigger
+      // Step 6: Finalize run (always called — receives leadFound flag)
       {
         id: "end-run",
         type: "http.call",
@@ -266,6 +279,7 @@ function buildColdEmailDag() {
         inputMapping: {
           "body.campaignId": "$ref:flow_input.campaignId",
           "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+          "body.leadFound": "$ref:fetch-lead.output.found",
         },
       },
       // Error handler: finalize run as failed + re-trigger
@@ -288,14 +302,14 @@ function buildColdEmailDag() {
     ],
     edges: [
       { from: "gate-check", to: "start-run" },
-      { from: "start-run", to: "brand-profile" },
       { from: "start-run", to: "fetch-lead" },
+      { from: "fetch-lead", to: "check-lead" },
+      { from: "check-lead", to: "brand-profile", condition: "results.fetch_lead.found == true" },
       { from: "brand-profile", to: "email-generate" },
-      { from: "fetch-lead", to: "email-generate" },
       { from: "email-generate", to: "email-send" },
-      { from: "email-send", to: "end-run" },
+      { from: "check-lead", to: "end-run" },
     ],
-    // Error handler: call end-run-error with success=false when any node fails.
+    // Error handler: call end-run-error with success=false when any real node fails.
     onError: "end-run-error",
   };
 }

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -226,8 +226,8 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
  */
 router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res) => {
   try {
-    const { campaignId, clerkOrgId, success } = req.body;
-    console.log(`[End Run] Received request: campaignId=${campaignId}, clerkOrgId=${clerkOrgId}, success=${success}`);
+    const { campaignId, clerkOrgId, success, leadFound } = req.body;
+    console.log(`[End Run] Received request: campaignId=${campaignId}, clerkOrgId=${clerkOrgId}, success=${success}, leadFound=${leadFound}`);
 
     const status = success === true ? "completed" : "failed";
 
@@ -253,8 +253,26 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
       console.error(`[End Run] Failed to update runs:`, err);
     }
 
-    // Respond immediately, then re-trigger asynchronously
+    // Respond immediately, then handle re-trigger asynchronously
     res.json({ status });
+
+    // No leads found → auto-stop campaign, no re-trigger
+    if (success === true && leadFound === false) {
+      try {
+        const org = await db.query.orgs.findFirst({
+          where: eq(orgs.clerkOrgId, clerkOrgId),
+        });
+        if (org) {
+          await db.update(campaigns)
+            .set({ status: "stopped" })
+            .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)));
+          console.log(`[End Run] No leads found — auto-stopped campaign ${campaignId}`);
+        }
+      } catch (err) {
+        console.error(`[End Run] Failed to auto-stop campaign:`, err);
+      }
+      return;
+    }
 
     // Re-trigger if campaign is still ongoing
     try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -151,6 +151,7 @@ export const EndRunBody = z.object({
   campaignId: z.string().uuid("campaignId must be a valid UUID"),
   clerkOrgId: z.string().min(1, "clerkOrgId is required"),
   success: z.boolean(),
+  leadFound: z.boolean().optional(),
 }).openapi("EndRunBody");
 
 export const EndRunResponse = z.object({

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -489,5 +489,75 @@ describe("Pipeline routes", () => {
 
       expect(mockExecute).not.toHaveBeenCalled();
     });
+
+    it("should auto-stop campaign and NOT re-trigger when leadFound is false", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+        status: "ongoing",
+      });
+
+      mockListRuns.mockResolvedValue({
+        runs: [
+          { id: "run-789", status: "running", startedAt: new Date().toISOString() },
+        ],
+      });
+
+      const res = await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+          success: true,
+          leadFound: false,
+        })
+        .expect(200);
+
+      expect(res.body.status).toBe("completed");
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-789", "completed");
+
+      // Wait for async auto-stop
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Should NOT re-trigger
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it("should re-trigger normally when leadFound is true", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+        status: "ongoing",
+      });
+
+      mockListRuns.mockResolvedValue({
+        runs: [
+          { id: "run-101", status: "running", startedAt: new Date().toISOString() },
+        ],
+      });
+
+      await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+          success: true,
+          leadFound: true,
+        })
+        .expect(200);
+
+      // Wait for async re-trigger
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        "cold-email-outreach",
+        {
+          campaignId: campaign.id,
+          clerkOrgId: org.clerkOrgId,
+        },
+      );
+    });
   });
 });

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -22,11 +22,11 @@ describe("Workflow module", () => {
   });
 
   describe("buildColdEmailDag", () => {
-    it("should produce a valid DAG with 8 nodes and 7 edges", () => {
+    it("should produce a valid DAG with 9 nodes and 7 edges", () => {
       const dag = buildColdEmailDag();
       expect(dag.nodes).toBeDefined();
       expect(dag.edges).toBeDefined();
-      expect(dag.nodes.length).toBe(8);
+      expect(dag.nodes.length).toBe(9);
       expect(dag.edges.length).toBe(7);
     });
 
@@ -36,8 +36,9 @@ describe("Workflow module", () => {
       expect(nodeIds).toEqual([
         "gate-check",
         "start-run",
-        "brand-profile",
         "fetch-lead",
+        "check-lead",
+        "brand-profile",
         "email-generate",
         "email-send",
         "end-run",
@@ -45,26 +46,36 @@ describe("Workflow module", () => {
       ]);
     });
 
-    it("should have correct edges with gate-check first and parallel fan-out after start-run", () => {
+    it("should have correct edges with conditional branching after check-lead", () => {
       const dag = buildColdEmailDag();
       expect(dag.edges).toEqual([
         { from: "gate-check", to: "start-run" },
-        { from: "start-run", to: "brand-profile" },
         { from: "start-run", to: "fetch-lead" },
+        { from: "fetch-lead", to: "check-lead" },
+        { from: "check-lead", to: "brand-profile", condition: "results.fetch_lead.found == true" },
         { from: "brand-profile", to: "email-generate" },
-        { from: "fetch-lead", to: "email-generate" },
         { from: "email-generate", to: "email-send" },
-        { from: "email-send", to: "end-run" },
+        { from: "check-lead", to: "end-run" },
       ]);
     });
 
-    it("should use http.call type for all nodes", () => {
+    it("should have check-lead as a condition node (not http.call)", () => {
+      const dag = buildColdEmailDag();
+      const checkLead = dag.nodes.find((n) => n.id === "check-lead");
+      expect(checkLead?.type).toBe("condition");
+    });
+
+    it("should use http.call type for all non-condition nodes", () => {
       const dag = buildColdEmailDag();
       for (const node of dag.nodes) {
-        expect(node.type).toBe("http.call");
-        expect(node.config.service).toBeDefined();
-        expect(node.config.method).toBeDefined();
-        expect(node.config.path).toBeDefined();
+        if (node.id === "check-lead") {
+          expect(node.type).toBe("condition");
+        } else {
+          expect(node.type).toBe("http.call");
+          expect(node.config.service).toBeDefined();
+          expect(node.config.method).toBeDefined();
+          expect(node.config.path).toBeDefined();
+        }
       }
     });
 
@@ -72,7 +83,9 @@ describe("Workflow module", () => {
       const dag = buildColdEmailDag();
       const serviceMap: Record<string, string> = {};
       for (const node of dag.nodes) {
-        serviceMap[node.id] = node.config.service as string;
+        if (node.config?.service) {
+          serviceMap[node.id] = node.config.service as string;
+        }
       }
       expect(serviceMap["gate-check"]).toBe("campaign");
       expect(serviceMap["start-run"]).toBe("campaign");
@@ -119,13 +132,23 @@ describe("Workflow module", () => {
       });
     });
 
-    it("should have validateResponse on fetch-lead to catch found: false", () => {
+    it("should NOT have validateResponse on fetch-lead (handled by check-lead condition)", () => {
       const dag = buildColdEmailDag();
       const fetchLead = dag.nodes.find((n) => n.id === "fetch-lead");
-      expect(fetchLead?.config.validateResponse).toEqual({
-        field: "found",
-        equals: true,
-      });
+      expect(fetchLead?.config.validateResponse).toBeUndefined();
+    });
+
+    it("should have conditional edge from check-lead to brand-profile (found=true branch)", () => {
+      const dag = buildColdEmailDag();
+      const conditionalEdge = dag.edges.find((e) => e.from === "check-lead" && e.to === "brand-profile");
+      expect(conditionalEdge?.condition).toBe("results.fetch_lead.found == true");
+    });
+
+    it("should have unconditional edge from check-lead to end-run (always runs)", () => {
+      const dag = buildColdEmailDag();
+      const endRunEdge = dag.edges.find((e) => e.from === "check-lead" && e.to === "end-run");
+      expect(endRunEdge).toBeDefined();
+      expect(endRunEdge?.condition).toBeUndefined();
     });
 
     it("should have onError handler pointing to end-run-error (not end-run)", () => {
@@ -139,6 +162,12 @@ describe("Workflow module", () => {
       const endRunError = dag.nodes.find((n) => n.id === "end-run-error");
       expect(endRun?.config.body).toEqual({ success: true });
       expect(endRunError?.config.body).toEqual({ success: false });
+    });
+
+    it("should pass leadFound flag to end-run via inputMapping", () => {
+      const dag = buildColdEmailDag();
+      const endRun = dag.nodes.find((n) => n.id === "end-run");
+      expect(endRun?.inputMapping?.["body.leadFound"]).toBe("$ref:fetch-lead.output.found");
     });
 
     it("should use /gate-check path (no /internal prefix)", () => {
@@ -252,11 +281,13 @@ describe("Workflow module", () => {
       const endRun = dag.nodes.find((n) => n.id === "end-run");
       const endRunError = dag.nodes.find((n) => n.id === "end-run-error");
 
-      // Both should use flow_input, NOT $ref:start-run.output
+      // end-run also includes leadFound from fetch-lead
       expect(endRun?.inputMapping).toEqual({
         "body.campaignId": "$ref:flow_input.campaignId",
         "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+        "body.leadFound": "$ref:fetch-lead.output.found",
       });
+      // end-run-error only has flow_input (real errors, no leadFound context)
       expect(endRunError?.inputMapping).toEqual({
         "body.campaignId": "$ref:flow_input.campaignId",
         "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
@@ -284,7 +315,7 @@ describe("Workflow module", () => {
       expect(body.appId).toBe("mcpfactory");
       expect(body.workflows).toHaveLength(1);
       expect(body.workflows[0].name).toBe("cold-email-outreach");
-      expect(body.workflows[0].dag.nodes).toHaveLength(8);
+      expect(body.workflows[0].dag.nodes).toHaveLength(9);
       expect(body.workflows[0].dag.onError).toBe("end-run-error");
     });
 


### PR DESCRIPTION
## Summary
- Adds `check-lead` condition node after `fetch-lead` in the DAG, using windmill's new native branching (PR #33)
- When `found=true`: continues to brand-profile → email-generate → email-send → end-run (normal flow)
- When `found=false`: skips directly to end-run with `leadFound=false` → auto-stops campaign (no error, no retry loop)
- `end-run` now receives `leadFound` flag to distinguish "no leads" from "email sent"

## What this fixes
Previously, 0 leads caused `validateResponse` to throw → 3 ERROR loops → auto-stop. Now it's a clean, single graceful stop.

## Test plan
- [x] 125 tests pass (unit + integration)
- [x] New tests for `leadFound=false` auto-stop behavior
- [x] New tests for conditional branching DAG structure
- [ ] Deploy and verify with a campaign that has 0 leads — expect clean stop, no error logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)