### PR TITLE
feat: make keySource dynamic on campaigns

### DIFF
--- a/drizzle/0014_flimsy_scalphunter.sql
+++ b/drizzle/0014_flimsy_scalphunter.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "campaigns" ADD COLUMN "key_source" text DEFAULT 'byok' NOT NULL;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,380 @@
+{
+  "id": "b8b1b716-bcf6-4186-b97e-babe797c7a29",
+  "prevId": "4ea68504-80b0-4001-8381-3b79e00c96c8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cold-email-outreach'"
+        },
+        "brand_url": {
+          "name": "brand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_outcome": {
+          "name": "target_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_for_target": {
+          "name": "value_for_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_daily_usd": {
+          "name": "max_budget_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_weekly_usd": {
+          "name": "max_budget_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_monthly_usd": {
+          "name": "max_budget_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_total_usd": {
+          "name": "max_budget_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_leads": {
+          "name": "max_leads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'byok'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ongoing'"
+        },
+        "to_resume_at": {
+          "name": "to_resume_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_frequency": {
+          "name": "notify_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_channel": {
+          "name": "notify_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_destination": {
+          "name": "notify_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_campaigns_org": {
+          "name": "idx_campaigns_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_campaigns_app_id": {
+          "name": "idx_campaigns_app_id",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaigns_org_id_orgs_id_fk": {
+          "name": "campaigns_org_id_orgs_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_created_by_user_id_users_id_fk": {
+          "name": "campaigns_created_by_user_id_users_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_clerk_id": {
+          "name": "idx_orgs_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_clerk_id": {
+          "name": "idx_users_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1771328408543,
       "tag": "0013_mature_silver_sable",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1771408508723,
+      "tag": "0014_flimsy_scalphunter",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -77,6 +77,9 @@ export const campaigns = pgTable(
     startDate: date("start_date"),
     endDate: date("end_date"),
     
+    // Key source: how downstream services resolve API keys ('byok' = org's own keys, 'app' = platform keys)
+    keySource: text("key_source").notNull().default("byok"),
+
     // Status: 'ongoing' or 'stopped'
     status: text("status").notNull().default("ongoing"),
     toResumeAt: timestamp("to_resume_at", { withTimezone: true }),

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -143,9 +143,6 @@ function buildColdEmailDag() {
           service: "lead",
           method: "POST",
           path: "/buffer/next",
-          body: {
-            keySource: "byok",
-          },
         },
         inputMapping: {
           "headers.x-app-id": "$ref:start-run.output.appId",
@@ -154,6 +151,7 @@ function buildColdEmailDag() {
           "body.brandId": "$ref:start-run.output.brandId",
           "body.parentRunId": "$ref:start-run.output.runId",
           "body.searchParams": "$ref:start-run.output.searchParams",
+          "body.keySource": "$ref:start-run.output.keySource",
         },
       },
       // Step 3: Condition — branch on found=true/false
@@ -169,9 +167,6 @@ function buildColdEmailDag() {
           service: "brand",
           method: "POST",
           path: "/sales-profile",
-          body: {
-            keyType: "byok",
-          },
         },
         inputMapping: {
           "body.appId": "$ref:start-run.output.appId",
@@ -179,6 +174,7 @@ function buildColdEmailDag() {
           "body.url": "$ref:start-run.output.brandUrl",
           "body.clerkUserId": "$ref:start-run.output.clerkUserId",
           "body.parentRunId": "$ref:start-run.output.runId",
+          "body.keyType": "$ref:start-run.output.keySource",
         },
       },
       // Step 4b: Generate email (non-idempotent, NO RETRY)

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -206,6 +206,7 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
       targetOutcome: campaign.targetOutcome,
       valueForTarget: campaign.valueForTarget,
       searchParams,
+      keySource: campaign.keySource,
     });
   } catch (error) {
     console.error("[Start Run] Unhandled error:", error);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -28,6 +28,7 @@ export const CampaignSchema = z.object({
   maxLeads: z.number().int().nullable(),
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
+  keySource: z.string(),
   status: z.string(),
   toResumeAt: z.string().nullable(),
   notifyFrequency: z.string().nullable(),
@@ -56,6 +57,7 @@ export const CreateCampaignBody = z.object({
   maxLeads: z.number().int().optional(),
   startDate: z.string().optional(),
   endDate: z.string().optional(),
+  keySource: z.enum(["byok", "app"]),
   notifyFrequency: z.string().optional(),
   notifyChannel: z.string().optional(),
   notifyDestination: z.string().optional(),
@@ -76,6 +78,7 @@ export const UpdateCampaignBody = z.object({
   startDate: z.string().optional(),
   endDate: z.string().optional(),
   status: z.enum(["activate", "stop"]).optional(),
+  keySource: z.enum(["byok", "app"]).optional(),
   notifyFrequency: z.string().optional(),
   notifyChannel: z.string().optional(),
   notifyDestination: z.string().optional(),
@@ -145,6 +148,7 @@ export const StartRunResponse = z.object({
   targetOutcome: z.string().nullable(),
   valueForTarget: z.string().nullable(),
   searchParams: z.record(z.string(), z.unknown()).nullable(),
+  keySource: z.enum(["byok", "app"]),
 }).openapi("StartRunResponse");
 
 export const EndRunBody = z.object({

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -195,23 +195,25 @@ describe("Workflow module", () => {
       });
     });
 
-    it("should configure brand-profile node with keyType and correct inputMapping", () => {
+    it("should configure brand-profile node with dynamic keyType from start-run", () => {
       const dag = buildColdEmailDag();
       const brandProfile = dag.nodes.find((n) => n.id === "brand-profile");
-      expect(brandProfile?.config.body).toEqual({ keyType: "byok" });
+      expect(brandProfile?.config.body).toBeUndefined();
       expect(brandProfile?.inputMapping).toEqual({
         "body.appId": "$ref:start-run.output.appId",
         "body.clerkOrgId": "$ref:start-run.output.clerkOrgId",
         "body.url": "$ref:start-run.output.brandUrl",
         "body.clerkUserId": "$ref:start-run.output.clerkUserId",
         "body.parentRunId": "$ref:start-run.output.runId",
+        "body.keyType": "$ref:start-run.output.keySource",
       });
     });
 
-    it("should configure fetch-lead node with keySource: byok in body", () => {
+    it("should configure fetch-lead node with dynamic keySource from start-run", () => {
       const dag = buildColdEmailDag();
       const fetchLead = dag.nodes.find((n) => n.id === "fetch-lead");
-      expect(fetchLead?.config.body).toEqual({ keySource: "byok" });
+      expect(fetchLead?.config.body).toBeUndefined();
+      expect(fetchLead?.inputMapping?.["body.keySource"]).toBe("$ref:start-run.output.keySource");
     });
 
     it("should configure fetch-lead node with custom headers and searchParams", () => {


### PR DESCRIPTION
## Summary
- Adds `keySource` column to campaigns table (`"byok" | "app"`, defaults to `"byok"` for existing rows)
- Makes `keySource` required on campaign creation, optional on update
- `/start-run` now returns `keySource` from the campaign
- DAG nodes `fetch-lead` and `brand-profile` use `inputMapping` to forward `keySource` from `start-run.output` instead of hardcoding `"byok"`
- Includes Drizzle migration `0014_flimsy_scalphunter.sql`

## Context
Lead-service PRs #58 + #59 made `keySource` a required field on `POST /buffer/next`. Rather than hardcode `"byok"`, we store the value on the campaign so callers control how downstream services resolve API keys.

## Test plan
- [x] All 50 unit tests pass
- [x] Build succeeds
- [x] Migration generated (`ALTER TABLE campaigns ADD COLUMN key_source text DEFAULT 'byok' NOT NULL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)