### PR TITLE
fix: add error message + OpenAPI description for keySource

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -57,7 +57,7 @@ export const CreateCampaignBody = z.object({
   maxLeads: z.number().int().optional(),
   startDate: z.string().optional(),
   endDate: z.string().optional(),
-  keySource: z.enum(["byok", "app"]),
+  keySource: z.enum(["byok", "app"], { error: "keySource is required and must be \"byok\" or \"app\"" }).openapi({ description: "How downstream services resolve API keys. \"byok\" = org's own keys via key-service, \"app\" = platform keys." }),
   notifyFrequency: z.string().optional(),
   notifyChannel: z.string().optional(),
   notifyDestination: z.string().optional(),


### PR DESCRIPTION
## Summary
- Adds clear Zod error message: `keySource is required and must be "byok" or "app"` (instead of generic "Required")
- Adds OpenAPI description on `CreateCampaignBody.keySource` explaining what each value means

## Test plan
- [x] 54 unit tests pass
- [x] Build succeeds
- [x] OpenAPI spec shows description on keySource field

🤖 Generated with [Claude Code](https://claude.com/claude-code)