### PR TITLE
fix: stringify brand-profile vars for email-generate

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -81,6 +81,8 @@ const APP_ID = "mcpfactory";
  *                                           ↓                   │
  *                                     brand-profile             │
  *                                           ↓                   │
+ *                                     prepare-vars              │
+ *                                           ↓                   │
  *                                     email-generate            │
  *                                           ↓                   │
  *                                     email-send                │
@@ -92,6 +94,7 @@ const APP_ID = "mcpfactory";
  * - fetch-lead:     pull next lead from buffer (lead-service, NO RETRY)
  * - check-lead:     condition node — branches on found=true/false
  * - brand-profile:  fetch brand sales profile (brand-service, only when lead found)
+ * - prepare-vars:   stringify brand-profile arrays/objects → flat strings (campaign-service)
  * - email-generate: generate email via AI (emailgeneration-service, NO RETRY)
  * - email-send:     send email (email-gateway-service, NO RETRY, validate success)
  * - end-run:        finalize run (always called, receives leadFound flag)
@@ -177,7 +180,30 @@ function buildColdEmailDag() {
           "body.keyType": "$ref:start-run.output.keySource",
         },
       },
-      // Step 4b: Generate email (non-idempotent, NO RETRY)
+      // Step 4b: Stringify brand-profile fields for email template variables
+      // Brand-service returns arrays/objects; emailgeneration expects Record<string, string>
+      {
+        id: "prepare-vars",
+        type: "http.call",
+        config: {
+          service: "campaign",
+          method: "POST",
+          path: "/prepare-email-vars",
+        },
+        inputMapping: {
+          "body.companyOverview": "$ref:brand-profile.output.profile.companyOverview",
+          "body.valueProposition": "$ref:brand-profile.output.profile.valueProposition",
+          "body.targetAudience": "$ref:brand-profile.output.profile.targetAudience",
+          "body.customerPainPoints": "$ref:brand-profile.output.profile.customerPainPoints",
+          "body.keyFeatures": "$ref:brand-profile.output.profile.keyFeatures",
+          "body.productDifferentiators": "$ref:brand-profile.output.profile.productDifferentiators",
+          "body.competitors": "$ref:brand-profile.output.profile.competitors",
+          "body.socialProof": "$ref:brand-profile.output.profile.socialProof",
+          "body.callToAction": "$ref:brand-profile.output.profile.callToAction",
+          "body.additionalContext": "$ref:brand-profile.output.profile.additionalContext",
+        },
+      },
+      // Step 4c: Generate email (non-idempotent, NO RETRY)
       {
         id: "email-generate",
         type: "http.call",
@@ -209,19 +235,19 @@ function buildColdEmailDag() {
           "body.variables.leadCompanyIndustry": "$ref:fetch-lead.output.lead.data.organizationIndustry",
           "body.variables.leadCompanySize": "$ref:fetch-lead.output.lead.data.organizationSize",
           "body.variables.leadCompanyRevenueUsd": "$ref:fetch-lead.output.lead.data.organizationRevenueUsd",
-          // Client/brand fields from brand-profile
+          // Client/brand fields from prepare-vars (stringified brand-profile output)
           "body.variables.clientCompanyName": "$ref:start-run.output.brandDomain",
           "body.variables.clientBrandUrl": "$ref:start-run.output.brandUrl",
-          "body.variables.clientCompanyOverview": "$ref:brand-profile.output.profile.companyOverview",
-          "body.variables.clientValueProposition": "$ref:brand-profile.output.profile.valueProposition",
-          "body.variables.clientTargetAudience": "$ref:brand-profile.output.profile.targetAudience",
-          "body.variables.clientCustomerPainPoints": "$ref:brand-profile.output.profile.customerPainPoints",
-          "body.variables.clientKeyFeatures": "$ref:brand-profile.output.profile.keyFeatures",
-          "body.variables.clientProductDifferentiators": "$ref:brand-profile.output.profile.productDifferentiators",
-          "body.variables.clientCompetitors": "$ref:brand-profile.output.profile.competitors",
-          "body.variables.clientSocialProof": "$ref:brand-profile.output.profile.socialProof",
-          "body.variables.clientCallToAction": "$ref:brand-profile.output.profile.callToAction",
-          "body.variables.clientAdditionalContext": "$ref:brand-profile.output.profile.additionalContext",
+          "body.variables.clientCompanyOverview": "$ref:prepare-vars.output.companyOverview",
+          "body.variables.clientValueProposition": "$ref:prepare-vars.output.valueProposition",
+          "body.variables.clientTargetAudience": "$ref:prepare-vars.output.targetAudience",
+          "body.variables.clientCustomerPainPoints": "$ref:prepare-vars.output.customerPainPoints",
+          "body.variables.clientKeyFeatures": "$ref:prepare-vars.output.keyFeatures",
+          "body.variables.clientProductDifferentiators": "$ref:prepare-vars.output.productDifferentiators",
+          "body.variables.clientCompetitors": "$ref:prepare-vars.output.competitors",
+          "body.variables.clientSocialProof": "$ref:prepare-vars.output.socialProof",
+          "body.variables.clientCallToAction": "$ref:prepare-vars.output.callToAction",
+          "body.variables.clientAdditionalContext": "$ref:prepare-vars.output.additionalContext",
           // Campaign fields from start-run
           "body.variables.targetOutcome": "$ref:start-run.output.targetOutcome",
           "body.variables.valueForTarget": "$ref:start-run.output.valueForTarget",
@@ -302,7 +328,8 @@ function buildColdEmailDag() {
       { from: "start-run", to: "fetch-lead" },
       { from: "fetch-lead", to: "check-lead" },
       { from: "check-lead", to: "brand-profile", condition: "results.fetch_lead.found == true" },
-      { from: "brand-profile", to: "email-generate" },
+      { from: "brand-profile", to: "prepare-vars" },
+      { from: "prepare-vars", to: "email-generate" },
       { from: "email-generate", to: "email-send" },
       { from: "check-lead", to: "end-run" },
     ],

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -8,7 +8,7 @@ import { createRun, listRuns, updateRun } from "@mcpfactory/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
 import { executeCampaignWorkflow } from "../lib/workflows.js";
 import { extractDomain } from "../lib/domain.js";
-import { GateCheckBody, StartRunBody, EndRunBody } from "../schemas.js";
+import { GateCheckBody, StartRunBody, EndRunBody, PrepareEmailVarsBody } from "../schemas.js";
 
 const router = Router();
 const APP_ID = "mcpfactory";
@@ -307,5 +307,38 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
     res.status(500).json({ error: "Internal server error" });
   }
 });
+
+/**
+ * POST /prepare-email-vars
+ *
+ * Accepts raw brand-profile fields (which may be strings, arrays, or objects)
+ * and returns all values stringified for use as email template variables.
+ *
+ * Called as a DAG node between brand-profile and email-generate to bridge
+ * the type mismatch: brand-service returns arrays/objects for some fields,
+ * but emailgeneration-service expects Record<string, string>.
+ */
+router.post("/prepare-email-vars", requireApiKey, validateBody(PrepareEmailVarsBody), async (req, res) => {
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(req.body as Record<string, unknown>)) {
+    result[key] = stringifyValue(value);
+  }
+
+  res.json(result);
+});
+
+function stringifyValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => (typeof v === "string" ? v : JSON.stringify(v)))
+      .filter(Boolean)
+      .join(", ");
+  }
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
 
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -161,3 +161,9 @@ export const EndRunBody = z.object({
 export const EndRunResponse = z.object({
   status: z.string(),
 }).openapi("EndRunResponse");
+
+// --- Prepare email vars (DAG node: stringify brand-profile fields) ---
+
+export const PrepareEmailVarsBody = z.record(z.string(), z.unknown()).openapi("PrepareEmailVarsBody");
+
+export const PrepareEmailVarsResponse = z.record(z.string(), z.string()).openapi("PrepareEmailVarsResponse");

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -354,6 +354,95 @@ describe("Pipeline routes", () => {
     });
   });
 
+  // === POST /prepare-email-vars ===
+
+  describe("POST /prepare-email-vars", () => {
+    it("should pass through string values unchanged", async () => {
+      const res = await request(app)
+        .post("/prepare-email-vars")
+        .set("x-api-key", API_KEY)
+        .send({
+          companyOverview: "A SaaS company",
+          valueProposition: "Save time",
+        })
+        .expect(200);
+
+      expect(res.body.companyOverview).toBe("A SaaS company");
+      expect(res.body.valueProposition).toBe("Save time");
+    });
+
+    it("should join arrays into comma-separated strings", async () => {
+      const res = await request(app)
+        .post("/prepare-email-vars")
+        .set("x-api-key", API_KEY)
+        .send({
+          customerPainPoints: ["slow onboarding", "high churn"],
+          keyFeatures: ["analytics", "automation", "integrations"],
+          competitors: ["Competitor A", "Competitor B"],
+        })
+        .expect(200);
+
+      expect(res.body.customerPainPoints).toBe("slow onboarding, high churn");
+      expect(res.body.keyFeatures).toBe("analytics, automation, integrations");
+      expect(res.body.competitors).toBe("Competitor A, Competitor B");
+    });
+
+    it("should stringify objects to JSON", async () => {
+      const socialProof = {
+        caseStudies: ["Case A"],
+        testimonials: [{ quote: "Great product", name: "Jane" }],
+        results: ["50% faster"],
+      };
+
+      const res = await request(app)
+        .post("/prepare-email-vars")
+        .set("x-api-key", API_KEY)
+        .send({ socialProof })
+        .expect(200);
+
+      expect(res.body.socialProof).toBe(JSON.stringify(socialProof));
+    });
+
+    it("should convert null and undefined to empty strings", async () => {
+      const res = await request(app)
+        .post("/prepare-email-vars")
+        .set("x-api-key", API_KEY)
+        .send({
+          callToAction: null,
+          additionalContext: "some context",
+        })
+        .expect(200);
+
+      expect(res.body.callToAction).toBe("");
+      expect(res.body.additionalContext).toBe("some context");
+    });
+
+    it("should handle mixed types in a single request", async () => {
+      const res = await request(app)
+        .post("/prepare-email-vars")
+        .set("x-api-key", API_KEY)
+        .send({
+          companyOverview: "A company",
+          customerPainPoints: ["pain1", "pain2"],
+          socialProof: { results: ["10x ROI"] },
+          callToAction: null,
+        })
+        .expect(200);
+
+      expect(res.body.companyOverview).toBe("A company");
+      expect(res.body.customerPainPoints).toBe("pain1, pain2");
+      expect(res.body.socialProof).toBe(JSON.stringify({ results: ["10x ROI"] }));
+      expect(res.body.callToAction).toBe("");
+    });
+
+    it("should require API key", async () => {
+      await request(app)
+        .post("/prepare-email-vars")
+        .send({ companyOverview: "test" })
+        .expect(401);
+    });
+  });
+
   // === POST /end-run ===
 
   describe("POST /end-run", () => {

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -22,12 +22,12 @@ describe("Workflow module", () => {
   });
 
   describe("buildColdEmailDag", () => {
-    it("should produce a valid DAG with 9 nodes and 7 edges", () => {
+    it("should produce a valid DAG with 10 nodes and 8 edges", () => {
       const dag = buildColdEmailDag();
       expect(dag.nodes).toBeDefined();
       expect(dag.edges).toBeDefined();
-      expect(dag.nodes.length).toBe(9);
-      expect(dag.edges.length).toBe(7);
+      expect(dag.nodes.length).toBe(10);
+      expect(dag.edges.length).toBe(8);
     });
 
     it("should have the correct node IDs", () => {
@@ -39,6 +39,7 @@ describe("Workflow module", () => {
         "fetch-lead",
         "check-lead",
         "brand-profile",
+        "prepare-vars",
         "email-generate",
         "email-send",
         "end-run",
@@ -53,7 +54,8 @@ describe("Workflow module", () => {
         { from: "start-run", to: "fetch-lead" },
         { from: "fetch-lead", to: "check-lead" },
         { from: "check-lead", to: "brand-profile", condition: "results.fetch_lead.found == true" },
-        { from: "brand-profile", to: "email-generate" },
+        { from: "brand-profile", to: "prepare-vars" },
+        { from: "prepare-vars", to: "email-generate" },
         { from: "email-generate", to: "email-send" },
         { from: "check-lead", to: "end-run" },
       ]);
@@ -90,6 +92,7 @@ describe("Workflow module", () => {
       expect(serviceMap["gate-check"]).toBe("campaign");
       expect(serviceMap["start-run"]).toBe("campaign");
       expect(serviceMap["brand-profile"]).toBe("brand");
+      expect(serviceMap["prepare-vars"]).toBe("campaign");
       expect(serviceMap["fetch-lead"]).toBe("lead");
       expect(serviceMap["email-generate"]).toBe("emailgeneration");
       expect(serviceMap["email-send"]).toBe("email-gateway");
@@ -195,6 +198,26 @@ describe("Workflow module", () => {
       });
     });
 
+    it("should configure prepare-vars node to stringify brand-profile fields", () => {
+      const dag = buildColdEmailDag();
+      const prepareVars = dag.nodes.find((n) => n.id === "prepare-vars");
+      expect(prepareVars?.type).toBe("http.call");
+      expect(prepareVars?.config.service).toBe("campaign");
+      expect(prepareVars?.config.path).toBe("/prepare-email-vars");
+      expect(prepareVars?.inputMapping).toEqual({
+        "body.companyOverview": "$ref:brand-profile.output.profile.companyOverview",
+        "body.valueProposition": "$ref:brand-profile.output.profile.valueProposition",
+        "body.targetAudience": "$ref:brand-profile.output.profile.targetAudience",
+        "body.customerPainPoints": "$ref:brand-profile.output.profile.customerPainPoints",
+        "body.keyFeatures": "$ref:brand-profile.output.profile.keyFeatures",
+        "body.productDifferentiators": "$ref:brand-profile.output.profile.productDifferentiators",
+        "body.competitors": "$ref:brand-profile.output.profile.competitors",
+        "body.socialProof": "$ref:brand-profile.output.profile.socialProof",
+        "body.callToAction": "$ref:brand-profile.output.profile.callToAction",
+        "body.additionalContext": "$ref:brand-profile.output.profile.additionalContext",
+      });
+    });
+
     it("should configure brand-profile node with dynamic keyType from start-run", () => {
       const dag = buildColdEmailDag();
       const brandProfile = dag.nodes.find((n) => n.id === "brand-profile");
@@ -247,11 +270,11 @@ describe("Workflow module", () => {
       expect(mapping["body.variables.leadEmail"]).toBe("$ref:fetch-lead.output.lead.data.email");
       expect(mapping["body.variables.leadCompanyName"]).toBe("$ref:fetch-lead.output.lead.data.organizationName");
 
-      // Brand fields from brand-profile — nested under variables
+      // Brand fields from prepare-vars (stringified brand-profile output) — nested under variables
       expect(mapping["body.variables.clientCompanyName"]).toBe("$ref:start-run.output.brandDomain");
       expect(mapping["body.variables.clientBrandUrl"]).toBe("$ref:start-run.output.brandUrl");
-      expect(mapping["body.variables.clientCompanyOverview"]).toBe("$ref:brand-profile.output.profile.companyOverview");
-      expect(mapping["body.variables.clientValueProposition"]).toBe("$ref:brand-profile.output.profile.valueProposition");
+      expect(mapping["body.variables.clientCompanyOverview"]).toBe("$ref:prepare-vars.output.companyOverview");
+      expect(mapping["body.variables.clientValueProposition"]).toBe("$ref:prepare-vars.output.valueProposition");
 
       // Campaign fields from start-run — nested under variables
       expect(mapping["body.variables.targetOutcome"]).toBe("$ref:start-run.output.targetOutcome");
@@ -338,7 +361,7 @@ describe("Workflow module", () => {
       expect(body.appId).toBe("mcpfactory");
       expect(body.workflows).toHaveLength(1);
       expect(body.workflows[0].name).toBe("cold-email-outreach");
-      expect(body.workflows[0].dag.nodes).toHaveLength(9);
+      expect(body.workflows[0].dag.nodes).toHaveLength(10);
       expect(body.workflows[0].dag.onError).toBe("end-run-error");
     });
 


### PR DESCRIPTION
## Summary
- Brand-service returns arrays/objects for some sales-profile fields (`customerPainPoints`, `keyFeatures`, `productDifferentiators`, `competitors`, `socialProof`), but emailgeneration-service expects all template variables to be strings (`z.record<string, string>`)
- Adds a `prepare-vars` DAG node between `brand-profile` and `email-generate` that calls a new `POST /prepare-email-vars` endpoint to coerce non-string values (arrays → comma-joined, objects → JSON, nulls → empty strings)
- Fixes the `email_generate` 400 error: `"Invalid input: expected string, received array"`

## Test plan
- [x] Unit tests: DAG structure updated (10 nodes, 8 edges), prepare-vars node config verified
- [x] Integration tests: 6 new tests for `/prepare-email-vars` covering strings, arrays, objects, nulls, mixed types, and auth
- [x] All 56 unit tests pass
- [ ] CI runs full suite with fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)