### PR TITLE
fix: add keyMode to email-generate DAG node

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -196,6 +196,7 @@ function buildColdEmailDag() {
           "body.brandId": "$ref:start-run.output.brandId",
           "body.campaignId": "$ref:start-run.output.campaignId",
           "body.runId": "$ref:start-run.output.runId",
+          "body.keyMode": "$ref:start-run.output.keySource",
           "body.apolloEnrichmentId": "$ref:fetch-lead.output.lead.externalId",
           // Template variables — must be nested under body.variables (emailgeneration expects z.record)
           // Lead fields from fetch-lead (flat camelCase per Apollo spec)

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -238,6 +238,7 @@ describe("Workflow module", () => {
       expect(mapping["body.runId"]).toBe("$ref:start-run.output.runId");
       expect(mapping["body.brandId"]).toBe("$ref:start-run.output.brandId");
       expect(mapping["body.campaignId"]).toBe("$ref:start-run.output.campaignId");
+      expect(mapping["body.keyMode"]).toBe("$ref:start-run.output.keySource");
       expect(mapping["body.apolloEnrichmentId"]).toBe("$ref:fetch-lead.output.lead.externalId");
 
       // Template variables MUST be nested under body.variables (emailgeneration expects z.record)


### PR DESCRIPTION
## Summary
- emailgeneration-service added a required `keyMode` field (`"byok"` | `"app"`) to `POST /generate`
- Maps `body.keyMode` from `start-run.output.keySource` in the `email-generate` DAG node (same pattern as `fetch-lead` and `brand-profile`)
- Adds test assertion for the new mapping

## Test plan
- [x] Unit tests pass (34/34 in workflows.test.ts)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)