### PR TITLE
docs: add read-only-by-default rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
+## CRITICAL RULE — Read-only by default
+
+When the user shares logs, errors, or bug reports: **ONLY diagnose and explain**. NEVER write code, create branches, open PRs, or make any changes unless the user explicitly asks you to implement a fix. The user often shares the same logs with multiple agents in parallel just for analysis — acting on them without permission wastes time and creates mess to clean up.
+
+**Before making ANY structural or architectural change** (new endpoints, new DAG nodes, new services, schema changes, workflow changes): stop and ask the user for approval first. Never assume the fix belongs in this repo — the root cause may be in another service.
+
 # Project: campaign-service
 
 Campaign CRUD and orchestration service for MCP Factory. Manages campaign lifecycle, budget tracking, and run coordination.


### PR DESCRIPTION
## Summary
- Adds a critical rule to CLAUDE.md: when logs/errors are shared, only diagnose and explain — never implement changes without explicit approval
- Structural or architectural changes (new endpoints, DAG nodes, schema changes) require user sign-off first

## Test plan
- [ ] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)