### PR TITLE
feat: require parentRunId for run cost tree tracking

### DIFF
--- a/drizzle/0015_unique_joystick.sql
+++ b/drizzle/0015_unique_joystick.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "campaigns" ADD COLUMN "parent_run_id" uuid;

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,386 @@
+{
+  "id": "74574f37-871e-4757-bfa8-f053578586a2",
+  "prevId": "b8b1b716-bcf6-4186-b97e-babe797c7a29",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cold-email-outreach'"
+        },
+        "brand_url": {
+          "name": "brand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_outcome": {
+          "name": "target_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_for_target": {
+          "name": "value_for_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_daily_usd": {
+          "name": "max_budget_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_weekly_usd": {
+          "name": "max_budget_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_monthly_usd": {
+          "name": "max_budget_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_total_usd": {
+          "name": "max_budget_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_leads": {
+          "name": "max_leads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'byok'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ongoing'"
+        },
+        "to_resume_at": {
+          "name": "to_resume_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_frequency": {
+          "name": "notify_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_channel": {
+          "name": "notify_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_destination": {
+          "name": "notify_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_campaigns_org": {
+          "name": "idx_campaigns_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_campaigns_app_id": {
+          "name": "idx_campaigns_app_id",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaigns_org_id_orgs_id_fk": {
+          "name": "campaigns_org_id_orgs_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_created_by_user_id_users_id_fk": {
+          "name": "campaigns_created_by_user_id_users_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_clerk_id": {
+          "name": "idx_orgs_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_clerk_id": {
+          "name": "idx_users_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1771408508723,
       "tag": "0014_flimsy_scalphunter",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1771468877702,
+      "tag": "0015_unique_joystick",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -51,6 +51,9 @@ export const campaigns = pgTable(
     // Nullable initially, populated when brand is created/found in brand-service
     brandId: uuid("brand_id"),
 
+    // Parent run ID from api-service — root of the cost tree for this campaign's runs
+    parentRunId: uuid("parent_run_id"),
+
     // App ID from external app/product service
     // Nullable, populated when campaign is associated with an app
     appId: text("app_id"),

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -242,6 +242,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     const {
       name,
       type,
+      parentRunId,
       brandUrl,
       brandId,
       appId,
@@ -270,6 +271,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         createdByUserId: req.userId ?? null,
         name,
         type,
+        parentRunId,
         appId,
         brandUrl: normalizedBrandUrl,
         brandId,
@@ -322,6 +324,11 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
 
     if (!existing) {
       return res.status(404).json({ error: "Campaign not found" });
+    }
+
+    // Activating requires a parentRunId (api-service creates a parent run first)
+    if (req.body.status === "activate" && !req.body.parentRunId) {
+      return res.status(400).json({ error: "parentRunId is required when activating a campaign" });
     }
 
     const statusMap: Record<string, string> = { activate: "ongoing", stop: "stopped" };

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -165,8 +165,8 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
     console.log(`[Start Run] Ensuring prompt registered for org ${clerkOrgId} (cached=${promptRegisteredOrgs.has(clerkOrgId)})`);
     await ensurePromptRegistered(clerkOrgId);
 
-    // Create run in runs-service
-    console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId}...`);
+    // Create run in runs-service (parentRunId links to api-service's parent run)
+    console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId} (parentRunId=${campaign.parentRunId || "none"})...`);
     const run = await createRun({
       clerkOrgId,
       appId: APP_ID,
@@ -175,6 +175,7 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
       campaignId,
       brandId: campaign.brandId,
       clerkUserId: campaign.createdByUserId || undefined,
+      parentRunId: campaign.parentRunId || undefined,
     });
     console.log(`[Start Run] Run created: runId=${run.id}`);
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -17,6 +17,7 @@ export const CampaignSchema = z.object({
   type: z.string(),
   brandUrl: z.string().nullable(),
   brandId: z.string().uuid().nullable(),
+  parentRunId: z.string().uuid().nullable(),
   appId: z.string().nullable(),
   targetAudience: z.string().nullable(),
   targetOutcome: z.string().nullable(),
@@ -44,6 +45,7 @@ export const CreateCampaignBody = z.object({
   name: z.string().min(1, "Campaign name is required"),
   type: z.string().min(1, "type is required"),
   clerkOrgId: z.string().min(1, "clerkOrgId is required"),
+  parentRunId: z.string().uuid("parentRunId must be a valid UUID"),
   brandUrl: z.string().min(1, "brandUrl is required"),
   brandId: z.string().uuid("brandId must be a valid UUID"),
   appId: z.string().min(1, "appId is required"),
@@ -65,6 +67,7 @@ export const CreateCampaignBody = z.object({
 
 export const UpdateCampaignBody = z.object({
   name: z.string().optional(),
+  parentRunId: z.string().uuid("parentRunId must be a valid UUID").optional(),
   brandUrl: z.string().optional(),
   brandId: z.string().uuid().optional(),
   targetAudience: z.string().optional(),

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -45,6 +45,7 @@ export async function insertTestCampaign(
     name?: string;
     type?: string;
     status?: string;
+    parentRunId?: string;
     brandUrl?: string;
     brandId?: string;
     appId?: string;
@@ -65,6 +66,7 @@ export async function insertTestCampaign(
       name: data.name || `Test Campaign ${Date.now()}`,
       type: data.type || "cold-email-outreach",
       status: data.status || "ongoing",
+      parentRunId: data.parentRunId || null,
       brandUrl: data.brandUrl || null,
       brandId: data.brandId || null,
       appId: data.appId || null,

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -19,11 +19,13 @@ describe("Campaign CRUD", () => {
     name: "Test Campaign",
     type: "cold-email-outreach",
     clerkOrgId: "org_test_crud",
+    parentRunId: crypto.randomUUID(),
     brandUrl: "https://example.com",
     brandId: crypto.randomUUID(),
     appId: "mcpfactory",
     targetOutcome: "Book sales demos",
     valueForTarget: "Access to enterprise analytics at startup pricing",
+    keySource: "byok" as const,
   };
 
   describe("POST /campaigns", () => {
@@ -50,6 +52,41 @@ describe("Campaign CRUD", () => {
         .set("x-api-key", API_KEY)
         .set("x-clerk-org-id", "org_test_crud")
         .send(body)
+        .expect(400);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it("should store parentRunId on the campaign", async () => {
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send(validBody)
+        .expect(201);
+
+      expect(res.body.campaign.parentRunId).toBe(validBody.parentRunId);
+    });
+
+    it("should reject when parentRunId is missing", async () => {
+      const { parentRunId, ...body } = validBody;
+
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send(body)
+        .expect(400);
+
+      expect(res.body.error).toBeDefined();
+    });
+
+    it("should reject when parentRunId is not a valid UUID", async () => {
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send({ ...validBody, parentRunId: "not-a-uuid" })
         .expect(400);
 
       expect(res.body.error).toBeDefined();
@@ -203,6 +240,66 @@ describe("Campaign CRUD", () => {
   });
 
   describe("PATCH /campaigns/:id", () => {
+    it("should reject activate without parentRunId", async () => {
+      const createRes = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send(validBody)
+        .expect(201);
+
+      const campaignId = createRes.body.campaign.id;
+
+      // Stop first
+      await request(app)
+        .patch(`/campaigns/${campaignId}`)
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send({ status: "stop" })
+        .expect(200);
+
+      // Activate without parentRunId → 400
+      const res = await request(app)
+        .patch(`/campaigns/${campaignId}`)
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send({ status: "activate" })
+        .expect(400);
+
+      expect(res.body.error).toBe("parentRunId is required when activating a campaign");
+    });
+
+    it("should accept activate with parentRunId and update stored value", async () => {
+      const createRes = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send(validBody)
+        .expect(201);
+
+      const campaignId = createRes.body.campaign.id;
+
+      // Stop first
+      await request(app)
+        .patch(`/campaigns/${campaignId}`)
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send({ status: "stop" })
+        .expect(200);
+
+      // Activate with new parentRunId
+      const newParentRunId = crypto.randomUUID();
+      const activateRes = await request(app)
+        .patch(`/campaigns/${campaignId}`)
+        .set("x-api-key", API_KEY)
+        .set("x-clerk-org-id", "org_test_crud")
+        .send({ status: "activate", parentRunId: newParentRunId })
+        .expect(200);
+
+      expect(activateRes.body.campaign.parentRunId).toBe(newParentRunId);
+      expect(activateRes.body.campaign.status).toBe("ongoing");
+    });
+
     it("should update targetAudience", async () => {
       // Create campaign first
       const createRes = await request(app)

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -338,6 +338,42 @@ describe("Pipeline routes", () => {
       expect(res.body.brandUrl).toBe("https://www.example.com/path");
     });
 
+    it("should pass parentRunId to createRun when campaign has one", async () => {
+      const parentRunId = crypto.randomUUID();
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+        parentRunId,
+      });
+
+      await request(app)
+        .post("/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(mockCreateRun).toHaveBeenCalledWith(
+        expect.objectContaining({ parentRunId }),
+      );
+    });
+
+    it("should NOT pass parentRunId to createRun when campaign has none", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      await request(app)
+        .post("/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .expect(200);
+
+      expect(mockCreateRun).toHaveBeenCalledWith(
+        expect.not.objectContaining({ parentRunId: expect.any(String) }),
+      );
+    });
+
     it("should NOT call gate checks (gate check is a separate DAG node)", async () => {
       const campaign = await insertTestCampaign(org.id, {
         brandUrl: "https://example.com",

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -34,12 +34,14 @@ const validBody = {
   name: "Activation Test Campaign",
   type: "cold-email-outreach",
   clerkOrgId: "org_activation_test",
+  parentRunId: crypto.randomUUID(),
   brandUrl: "https://example.com",
   brandId: crypto.randomUUID(),
   appId: "mcpfactory",
   targetOutcome: "Book sales demos",
   valueForTarget: "Enterprise analytics at startup pricing",
   targetAudience: "CTOs at SaaS companies",
+  keySource: "byok" as const,
 };
 
 describe("Workflow trigger", () => {
@@ -116,12 +118,12 @@ describe("Workflow trigger", () => {
       vi.clearAllMocks();
       mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
 
-      // Activate
+      // Activate (requires parentRunId)
       const activateRes = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
         .set("x-clerk-org-id", "org_activation_test")
-        .send({ status: "activate" })
+        .send({ status: "activate", parentRunId: crypto.randomUUID() })
         .expect(200);
 
       expect(activateRes.body.campaign.status).toBe("ongoing");
@@ -217,7 +219,7 @@ describe("Workflow trigger", () => {
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
         .set("x-clerk-org-id", "org_activation_test")
-        .send({ status: "activate" })
+        .send({ status: "activate", parentRunId: crypto.randomUUID() })
         .expect(200);
 
       expect(activateRes.body.campaign.status).toBe("ongoing");


### PR DESCRIPTION
## Summary
- API-service now creates a parent run before calling campaign-service and passes its ID as `parentRunId`
- `parentRunId` is stored on the campaign and passed to `createRun()` in `/start-run`, enabling cost tree aggregation via `descendantRuns`
- Breaking change: `parentRunId` (UUID) is now **required** on `POST /campaigns` and on `PATCH /campaigns/:id` when activating

## Changes
- `src/db/schema.ts`: new `parent_run_id` column (nullable UUID)
- `src/schemas.ts`: `parentRunId` required in `CreateCampaignBody`, optional in `UpdateCampaignBody`
- `src/routes/campaigns.ts`: store `parentRunId` on create; validate it on activate
- `src/routes/internal.ts`: pass `campaign.parentRunId` to `createRun()` in `/start-run`
- Migration `drizzle/0015_unique_joystick.sql`
- Tests: 134 passing (new parentRunId validation + propagation tests)

## Test plan
- [x] `POST /campaigns` rejects missing parentRunId (400)
- [x] `POST /campaigns` rejects invalid UUID parentRunId (400)
- [x] `POST /campaigns` stores parentRunId on created campaign
- [x] `PATCH /campaigns/:id` with `status: "activate"` rejects without parentRunId (400)
- [x] `PATCH /campaigns/:id` with `status: "activate"` + parentRunId updates stored value
- [x] `/start-run` passes stored parentRunId to `createRun()`
- [x] `/start-run` works without parentRunId (legacy campaigns)
- [x] All 134 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)