### PR TITLE
feat: dynamic appId + email sequence DAG support

### DIFF
--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -3,13 +3,13 @@ import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 
-const APP_ID = "mcpfactory";
 const STALE_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
 const MAX_CONSECUTIVE_FAILURES = 3;
 
 export interface GateCheckInput {
   campaignId: string;
   clerkOrgId: string;
+  appId: string;
   brandId: string;
   status: string;
   maxBudgetDailyUsd: string | null;
@@ -34,7 +34,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   // Fetch all runs for this campaign
   const { runs } = await listRuns({
     clerkOrgId: campaign.clerkOrgId,
-    appId: APP_ID,
+    appId: campaign.appId,
     serviceName: "campaign-service",
     taskName: campaign.campaignId,
   });
@@ -108,7 +108,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   if (campaign.maxLeads != null) {
     let totalServed: number;
     try {
-      const leadStats = await fetchLeadStats(campaign.clerkOrgId, campaign.campaignId, campaign.brandId);
+      const leadStats = await fetchLeadStats(campaign.clerkOrgId, campaign.campaignId, campaign.brandId, campaign.appId);
       const completedCount = finishedRuns.filter((r: Run) => r.status === "completed").length;
       totalServed = Math.max(leadStats.totalServed, completedCount);
     } catch (err: unknown) {
@@ -153,6 +153,7 @@ async function fetchLeadStats(
   clerkOrgId: string,
   campaignId: string,
   brandId: string,
+  appId: string,
 ): Promise<{ totalServed: number }> {
   const url = process.env.LEAD_SERVICE_URL;
   const apiKey = process.env.LEAD_SERVICE_API_KEY;
@@ -162,7 +163,7 @@ async function fetchLeadStats(
   const res = await fetch(`${url}/stats?${params}`, {
     headers: {
       "x-api-key": apiKey,
-      "x-app-id": APP_ID,
+      "x-app-id": appId,
       "x-org-id": clerkOrgId,
     },
   });

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -100,7 +100,7 @@ export const COLD_EMAIL_VARIABLES = [
   "urgency", "scarcity", "riskReversal", "socialProof",
 ];
 
-const APP_ID = "mcpfactory";
+const DEFAULT_APP_ID = process.env.APP_ID || "mcpfactory";
 
 /**
  * Build the cold-email-outreach DAG.
@@ -309,7 +309,7 @@ function buildColdEmailDag() {
           "body.recipientLastName": "$ref:fetch-lead.output.lead.data.lastName",
           "body.recipientCompany": "$ref:fetch-lead.output.lead.data.organizationName",
           "body.subject": "$ref:email-generate.output.subject",
-          "body.htmlBody": "$ref:email-generate.output.bodyHtml",
+          "body.sequence": "$ref:email-generate.output.sequence",
           "body.metadata.emailGenerationId": "$ref:email-generate.output.id",
         },
       },
@@ -379,7 +379,7 @@ export async function deployWorkflows(): Promise<void> {
       "x-api-key": apiKey,
     },
     body: JSON.stringify({
-      appId: APP_ID,
+      appId: DEFAULT_APP_ID,
       workflows: [
         {
           name: "cold-email-outreach",
@@ -402,12 +402,12 @@ export async function deployWorkflows(): Promise<void> {
 
 export async function executeCampaignWorkflow(
   type: string,
-  inputs: { campaignId: string; clerkOrgId: string },
+  inputs: { campaignId: string; clerkOrgId: string; appId: string },
 ): Promise<void> {
   const url = process.env.WINDMILL_SERVICE_URL;
   const apiKey = process.env.WINDMILL_SERVICE_API_KEY;
 
-  console.log(`[Workflow] executeCampaignWorkflow called: type=${type}, campaignId=${inputs.campaignId}, clerkOrgId=${inputs.clerkOrgId}`);
+  console.log(`[Workflow] executeCampaignWorkflow called: type=${type}, campaignId=${inputs.campaignId}, clerkOrgId=${inputs.clerkOrgId}, appId=${inputs.appId}`);
 
   if (!url || !apiKey) {
     console.warn("[Workflow] WINDMILL_SERVICE_URL or WINDMILL_SERVICE_API_KEY not set, skipping workflow execution");
@@ -424,7 +424,7 @@ export async function executeCampaignWorkflow(
       "x-api-key": apiKey,
     },
     body: JSON.stringify({
-      appId: APP_ID,
+      appId: inputs.appId,
       orgId: inputs.clerkOrgId,
       inputs: {
         campaignId: inputs.campaignId,

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -64,6 +64,7 @@ router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBu
     const campaignRows = await db
       .select({
         id: campaigns.id,
+        appId: campaigns.appId,
         status: campaigns.status,
         maxLeads: campaigns.maxLeads,
         maxBudgetTotalUsd: campaigns.maxBudgetTotalUsd,
@@ -90,7 +91,7 @@ router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBu
         try {
           const runResult = await listRuns({
             clerkOrgId: row.clerkOrgId,
-            appId: "mcpfactory",
+            appId: row.appId || "",
             serviceName: "campaign-service",
             taskName: campaignId,
           });
@@ -305,6 +306,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     executeCampaignWorkflow(campaign.type, {
       campaignId: campaign.id,
       clerkOrgId: req.clerkOrgId!,
+      appId: campaign.appId || "",
     }).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
@@ -357,6 +359,7 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
       executeCampaignWorkflow(updated.type, {
         campaignId: updated.id,
         clerkOrgId: req.clerkOrgId!,
+        appId: updated.appId || "",
       }).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -11,13 +11,13 @@ import { extractDomain } from "../lib/domain.js";
 import { GateCheckBody, StartRunBody, EndRunBody } from "../schemas.js";
 
 const router = Router();
-const APP_ID = "mcpfactory";
 
-// In-memory cache: skip prompt registration if already done for this org
-const promptRegisteredOrgs = new Set<string>();
+// In-memory cache: skip prompt registration if already done for this org+app
+const promptRegisteredKeys = new Set<string>();
 
-async function ensurePromptRegistered(clerkOrgId: string): Promise<void> {
-  if (promptRegisteredOrgs.has(clerkOrgId)) return;
+async function ensurePromptRegistered(appId: string, clerkOrgId: string): Promise<void> {
+  const cacheKey = `${appId}:${clerkOrgId}`;
+  if (promptRegisteredKeys.has(cacheKey)) return;
 
   const url = process.env.EMAILGENERATION_SERVICE_URL;
   const apiKey = process.env.EMAILGENERATION_SERVICE_API_KEY;
@@ -33,7 +33,7 @@ async function ensurePromptRegistered(clerkOrgId: string): Promise<void> {
         "x-clerk-org-id": clerkOrgId,
       },
       body: JSON.stringify({
-        appId: APP_ID,
+        appId,
         type: "cold-email",
         prompt: COLD_EMAIL_PROMPT,
         variables: COLD_EMAIL_VARIABLES,
@@ -41,7 +41,7 @@ async function ensurePromptRegistered(clerkOrgId: string): Promise<void> {
     });
 
     if (res.ok) {
-      promptRegisteredOrgs.add(clerkOrgId);
+      promptRegisteredKeys.add(cacheKey);
     } else {
       console.warn(`[Start Run] Prompt registration failed (${res.status})`);
     }
@@ -91,6 +91,7 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
     const result = await runGateChecks({
       campaignId,
       clerkOrgId,
+      appId: campaign.appId || "",
       brandId: campaign.brandId || "",
       status: campaign.status,
       maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
@@ -161,15 +162,17 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
       return res.status(400).json({ error: "Campaign has no brandId" });
     }
 
-    // Register prompt template (best-effort, cached per org)
-    console.log(`[Start Run] Ensuring prompt registered for org ${clerkOrgId} (cached=${promptRegisteredOrgs.has(clerkOrgId)})`);
-    await ensurePromptRegistered(clerkOrgId);
+    // Register prompt template (best-effort, cached per app+org)
+    const appId = campaign.appId || "";
+    const cacheKey = `${appId}:${clerkOrgId}`;
+    console.log(`[Start Run] Ensuring prompt registered for app=${appId} org=${clerkOrgId} (cached=${promptRegisteredKeys.has(cacheKey)})`);
+    await ensurePromptRegistered(appId, clerkOrgId);
 
     // Create run in runs-service (parentRunId links to api-service's parent run)
     console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId} (parentRunId=${campaign.parentRunId || "none"})...`);
     const run = await createRun({
       clerkOrgId,
-      appId: APP_ID,
+      appId,
       serviceName: "campaign-service",
       taskName: campaignId,
       campaignId,
@@ -202,7 +205,7 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
       brandId: campaign.brandId,
       brandUrl: campaign.brandUrl,
       brandDomain,
-      appId: campaign.appId || APP_ID,
+      appId,
       clerkUserId: campaign.createdByUserId,
       targetOutcome: campaign.targetOutcome,
       valueForTarget: campaign.valueForTarget,
@@ -237,11 +240,22 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
 
     const status = success === true ? "completed" : "failed";
 
+    // Fetch campaign to get appId
+    const org = await db.query.orgs.findFirst({
+      where: eq(orgs.clerkOrgId, clerkOrgId),
+    });
+    const campaign = org
+      ? await db.query.campaigns.findFirst({
+          where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
+        })
+      : undefined;
+    const appId = campaign?.appId || "";
+
     // Find and update running runs for this campaign
     try {
       const { runs } = await listRuns({
         clerkOrgId,
-        appId: APP_ID,
+        appId,
         serviceName: "campaign-service",
         taskName: campaignId,
       });
@@ -265,9 +279,6 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
     // No leads found → auto-stop campaign, no re-trigger
     if (success === true && leadFound === false) {
       try {
-        const org = await db.query.orgs.findFirst({
-          where: eq(orgs.clerkOrgId, clerkOrgId),
-        });
         if (org) {
           await db.update(campaigns)
             .set({ status: "stopped" })
@@ -282,26 +293,24 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
 
     // Re-trigger if campaign is still ongoing
     try {
-      const org = await db.query.orgs.findFirst({
-        where: eq(orgs.clerkOrgId, clerkOrgId),
-      });
       if (!org) {
         console.warn(`[End Run] Org not found for re-trigger: ${clerkOrgId}`);
         return;
       }
 
-      const campaign = await db.query.campaigns.findFirst({
+      // Re-fetch campaign for fresh status (may have been auto-stopped by gate-check)
+      const freshCampaign = await db.query.campaigns.findFirst({
         where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
       });
-      console.log(`[End Run] Campaign status for re-trigger: ${campaign?.status || "NOT FOUND"}, type=${campaign?.type || "N/A"}`);
-      if (campaign?.status !== "ongoing") {
+      console.log(`[End Run] Campaign status for re-trigger: ${freshCampaign?.status || "NOT FOUND"}, type=${freshCampaign?.type || "N/A"}`);
+      if (freshCampaign?.status !== "ongoing") {
         console.log(`[End Run] Campaign ${campaignId} is not ongoing — skipping re-trigger`);
         return;
       }
 
       // Fire-and-forget: gate-check in the next workflow execution will validate limits
-      console.log(`[End Run] Re-triggering workflow type=${campaign.type} for campaign ${campaignId}`);
-      executeCampaignWorkflow(campaign.type, { campaignId, clerkOrgId }).catch((err) => {
+      console.log(`[End Run] Re-triggering workflow type=${freshCampaign.type} for campaign ${campaignId}`);
+      executeCampaignWorkflow(freshCampaign.type, { campaignId, clerkOrgId, appId }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });
     } catch (err) {

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -36,7 +36,7 @@ router.get("/campaigns/:campaignId/runs/list", requireApiKey, async (req, res) =
 
     const result = await listRuns({
       clerkOrgId: org.clerkOrgId,
-      appId: "mcpfactory",
+      appId: campaign.appId || "",
       serviceName: "campaign-service",
       taskName: campaignId,
     });
@@ -70,7 +70,7 @@ router.get("/campaigns/:campaignId/runs", requireApiKey, serviceAuth, async (req
 
     const result = await listRuns({
       clerkOrgId: req.clerkOrgId!,
-      appId: "mcpfactory",
+      appId: campaign.appId || "",
       serviceName: "campaign-service",
       taskName: campaignId,
     });
@@ -136,7 +136,7 @@ router.post("/campaigns/:campaignId/runs", requireApiKey, async (req, res) => {
 
     const run = await createRun({
       clerkOrgId: org.clerkOrgId,
-      appId: "mcpfactory",
+      appId: campaign.appId || "",
       serviceName: "campaign-service",
       taskName: campaignId,
       brandId: campaign.brandId ?? undefined,

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -48,6 +48,7 @@ function makeCampaign(overrides: Partial<GateCheckInput> = {}): GateCheckInput {
   return {
     campaignId: "campaign-1",
     clerkOrgId: "org-1",
+    appId: "mcpfactory",
     brandId: "brand-1",
     status: "ongoing",
     maxBudgetDailyUsd: "10.00",

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -300,7 +300,7 @@ describe("Workflow module", () => {
       expect(mapping["body.recipientLastName"]).toBe("$ref:fetch-lead.output.lead.data.lastName");
       expect(mapping["body.recipientCompany"]).toBe("$ref:fetch-lead.output.lead.data.organizationName");
       expect(mapping["body.subject"]).toBe("$ref:email-generate.output.subject");
-      expect(mapping["body.htmlBody"]).toBe("$ref:email-generate.output.bodyHtml");
+      expect(mapping["body.sequence"]).toBe("$ref:email-generate.output.sequence");
     });
 
     it("should use flow_input for gate-check and start-run inputs", () => {
@@ -394,6 +394,7 @@ describe("Workflow module", () => {
       await executeCampaignWorkflow("cold-email-outreach", {
         campaignId: "campaign-1",
         clerkOrgId: "org_test",
+        appId: "mcpfactory",
       });
 
       expect(mockFetch).toHaveBeenCalledOnce();
@@ -420,6 +421,7 @@ describe("Workflow module", () => {
       await executeCampaignWorkflow("journalist-pitch", {
         campaignId: "campaign-2",
         clerkOrgId: "org_test",
+        appId: "mcpfactory",
       });
 
       const [url] = mockFetch.mock.calls[0];
@@ -438,6 +440,7 @@ describe("Workflow module", () => {
         executeCampaignWorkflow("cold-email-outreach", {
           campaignId: "campaign-1",
           clerkOrgId: "org_test",
+          appId: "mcpfactory",
         })
       ).resolves.not.toThrow();
     });


### PR DESCRIPTION
## Summary
- Replace all hardcoded `APP_ID = "mcpfactory"` with `campaign.appId` read from DB across gate-check, start-run, end-run, runs routes, and campaigns routes
- `executeCampaignWorkflow` now receives `appId` as a parameter instead of using hardcoded constant
- DAG `email-send` node passes `sequence` array (from email-generation's new 3-step format) instead of single `htmlBody`
- Prompt registration cache key now includes `appId` for multi-app correctness

## Test plan
- [x] All 55 unit tests pass
- [ ] Integration tests (require DB) — verify in CI
- [ ] Deploy and confirm DAG deploys correctly with new sequence mapping
- [ ] Verify gate-check works with campaign.appId in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)