### PR TITLE
feat: pass workflow dimensions and displayName to deploy

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -102,6 +102,34 @@ export const COLD_EMAIL_VARIABLES = [
 
 const DEFAULT_APP_ID = process.env.APP_ID || "mcpfactory";
 
+/** Evocative words used as human-readable workflow signature names. */
+export const SIGNATURE_WORDS = [
+  "Aurora", "Beacon", "Cascade", "Denali", "Eclipse",
+  "Falcon", "Glacier", "Horizon", "Ignite", "Jasper",
+  "Kinetic", "Lunar", "Meridian", "Nova", "Obsidian",
+  "Phoenix", "Quasar", "Radiant", "Sequoia", "Tempest",
+  "Utopia", "Vertex", "Wildfire", "Xenon", "Zenith",
+  "Alpine", "Blaze", "Cosmos", "Drift", "Ember",
+  "Forge", "Genesis", "Haven", "Impulse", "Jubilee",
+  "Kestrel", "Latitude", "Monarch", "Nebula", "Onyx",
+  "Prism", "Quest", "Riviera", "Solstice", "Titan",
+  "Umbra", "Vortex", "Whisper", "Zephyr", "Apex",
+];
+
+/**
+ * Generate a deterministic displayName from a DAG definition.
+ * Same DAG → same name; changed DAG → (likely) different name.
+ */
+export function generateDisplayName(dag: unknown): string {
+  const json = JSON.stringify(dag);
+  // djb2 hash
+  let hash = 5381;
+  for (let i = 0; i < json.length; i++) {
+    hash = ((hash << 5) + hash + json.charCodeAt(i)) | 0;
+  }
+  return SIGNATURE_WORDS[Math.abs(hash) % SIGNATURE_WORDS.length];
+}
+
 // Confirmed workflow names from workflow-service deploy response.
 // Workflow-service is the authority on names — we use its confirmed name
 // rather than assuming campaign.type = workflow name.
@@ -404,7 +432,11 @@ export async function deployWorkflows(): Promise<void> {
       workflows: [
         {
           name: "cold-email-outreach",
+          displayName: generateDisplayName(buildColdEmailDag()),
           description: "Cold email pipeline: gate checks → lead → generate → send → re-trigger (1 lead per run)",
+          category: "sales",
+          channel: "email",
+          audienceType: "cold-outreach",
           dag: buildColdEmailDag(),
         },
       ],

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { buildColdEmailDag, COLD_EMAIL_PROMPT, COLD_EMAIL_VARIABLES, getConfirmedWorkflowName } from "../../src/lib/workflows.js";
+import { buildColdEmailDag, COLD_EMAIL_PROMPT, COLD_EMAIL_VARIABLES, getConfirmedWorkflowName, generateDisplayName, SIGNATURE_WORDS } from "../../src/lib/workflows.js";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -340,8 +340,32 @@ describe("Workflow module", () => {
     });
   });
 
+  describe("generateDisplayName", () => {
+    it("should return a word from SIGNATURE_WORDS", () => {
+      const dag = buildColdEmailDag();
+      const name = generateDisplayName(dag);
+      expect(SIGNATURE_WORDS).toContain(name);
+    });
+
+    it("should be deterministic (same DAG → same name)", () => {
+      const dag = buildColdEmailDag();
+      const name1 = generateDisplayName(dag);
+      const name2 = generateDisplayName(dag);
+      expect(name1).toBe(name2);
+    });
+
+    it("should change when the DAG changes", () => {
+      const dag1 = buildColdEmailDag();
+      const dag2 = { ...buildColdEmailDag(), extra: "modified" };
+      const name1 = generateDisplayName(dag1);
+      const name2 = generateDisplayName(dag2);
+      // Not guaranteed to differ for all inputs, but very likely for any meaningful change
+      expect(name1).not.toBe(name2);
+    });
+  });
+
   describe("deployWorkflows", () => {
-    it("should call PUT /workflows/deploy with correct payload", async () => {
+    it("should call PUT /workflows/deploy with correct payload including dimensions and displayName", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ workflows: [{ name: "cold-email-outreach", action: "created" }] }),
@@ -359,9 +383,15 @@ describe("Workflow module", () => {
       const body = JSON.parse(opts.body);
       expect(body.appId).toBe("mcpfactory");
       expect(body.workflows).toHaveLength(1);
-      expect(body.workflows[0].name).toBe("cold-email-outreach");
-      expect(body.workflows[0].dag.nodes).toHaveLength(9);
-      expect(body.workflows[0].dag.onError).toBe("end-run-error");
+
+      const wf = body.workflows[0];
+      expect(wf.name).toBe("cold-email-outreach");
+      expect(wf.category).toBe("sales");
+      expect(wf.channel).toBe("email");
+      expect(wf.audienceType).toBe("cold-outreach");
+      expect(SIGNATURE_WORDS).toContain(wf.displayName);
+      expect(wf.dag.nodes).toHaveLength(9);
+      expect(wf.dag.onError).toBe("end-run-error");
     });
 
     it("should not throw when workflow-service env vars are missing", async () => {


### PR DESCRIPTION
## Summary
- Sends `category: "sales"`, `channel: "email"`, `audienceType: "cold-outreach"` when deploying the `cold-email-outreach` workflow to workflow-service
- Generates a deterministic `displayName` (from a predefined word list, hashed from the DAG structure) so each workflow version gets a memorable human-readable name
- Adds tests for `generateDisplayName` determinism and deploy payload verification

## Context
workflow-service already accepts these fields on `PUT /workflows/deploy` but campaign-service wasn't sending them. This enables the performance page to group stats by workflow dimensions.

### Re: workflowName propagation to runs
Investigated the 2231/2266 runs with `workflow_name = NULL`. This is **not a campaign-service issue** — campaign-service correctly:
1. Creates the parent run with `workflowName` set
2. Returns `workflowName` in the `/start-run` response
3. Propagates it to all downstream DAG nodes via `$ref:start-run.output.workflowName`

The gap is in **downstream services** (lead-service, brand-service, content-generation-service, email-gateway-service) — they receive `workflowName` in their request body but don't forward it when creating their own child runs in runs-service.

## Test plan
- [x] `generateDisplayName` returns a word from `SIGNATURE_WORDS`
- [x] `generateDisplayName` is deterministic (same DAG → same name)
- [x] `generateDisplayName` changes when DAG changes
- [x] Deploy payload includes `category`, `channel`, `audienceType`, and `displayName`
- [x] All 44 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)