### PR TITLE
feat: enable AI disclaimer on cold email generation

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -246,6 +246,7 @@ function buildColdEmailDag() {
           path: "/generate",
           body: {
             type: "cold-email",
+            includeAiDisclaimer: true,
           },
         },
         inputMapping: {


### PR DESCRIPTION
## Summary
- Adds `includeAiDisclaimer: true` to the `email-generate` DAG node's static body config
- content-generation-service will append an AI disclaimer at the bottom of every generated cold email
- No DB changes, no new campaign fields — hardcoded in the workflow definition

## Test plan
- [x] Unit tests pass (`pnpm test:unit` — 43 passed)
- [x] Build succeeds (`pnpm run build`)
- [ ] Verify disclaimer appears on generated emails in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)