### PR TITLE
refactor: use stopAfterIf on gate-check DAG node

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -164,7 +164,7 @@ function buildColdEmailDag() {
           service: "campaign",
           method: "POST",
           path: "/gate-check",
-          validateResponse: { field: "allowed", equals: true },
+          stopAfterIf: "result.allowed == false",
         },
         inputMapping: {
           "body.campaignId": "$ref:flow_input.campaignId",

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -58,8 +58,8 @@ async function ensurePromptRegistered(appId: string, clerkOrgId: string): Promis
  * and campaign status.
  *
  * Called as the first DAG node. Returns { allowed: true } to proceed
- * or { allowed: false, reason } to stop. Windmill uses validateResponse
- * to treat allowed=false as a node error → triggers onError handler.
+ * or { allowed: false, reason } to stop. The DAG uses stopAfterIf to
+ * end the flow cleanly without triggering onError.
  *
  * Returns:
  *   200 — gate check result (allowed or blocked)

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -114,13 +114,11 @@ describe("Workflow module", () => {
       expect(startRun?.retries).toBeUndefined();
     });
 
-    it("should have validateResponse on gate-check to catch allowed: false", () => {
+    it("should have stopAfterIf on gate-check to stop flow cleanly when not allowed", () => {
       const dag = buildColdEmailDag();
       const gateCheck = dag.nodes.find((n) => n.id === "gate-check");
-      expect(gateCheck?.config.validateResponse).toEqual({
-        field: "allowed",
-        equals: true,
-      });
+      expect(gateCheck?.config.stopAfterIf).toBe("result.allowed == false");
+      expect(gateCheck?.config.validateResponse).toBeUndefined();
     });
 
     it("should have validateResponse on email-send to catch success: false", () => {


### PR DESCRIPTION
## Summary
- Replace `validateResponse` with `stopAfterIf: "result.allowed == false"` on the `gate-check` DAG node
- When a campaign is paused/stopped/over-budget, the flow now stops cleanly instead of throwing an error that triggers `end-run-error` and produces red logs in Railway

## Test plan
- [x] Unit test updated: verifies `stopAfterIf` is set and `validateResponse` is absent on gate-check
- [x] All 36 workflow unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)