### PR TITLE
refactor: migrate clerkOrgId/clerkUserId to orgId/userId

### DIFF
--- a/drizzle/0018_rename_clerk_to_org_user_ids.sql
+++ b/drizzle/0018_rename_clerk_to_org_user_ids.sql
@@ -1,0 +1,17 @@
+-- Rename clerk_org_id -> org_id on orgs table
+ALTER TABLE "orgs" RENAME COLUMN "clerk_org_id" TO "org_id";
+
+-- Rename clerk_user_id -> user_id on users table
+ALTER TABLE "users" RENAME COLUMN "clerk_user_id" TO "user_id";
+
+-- Drop old indexes
+DROP INDEX IF EXISTS "idx_orgs_clerk_id";
+DROP INDEX IF EXISTS "idx_users_clerk_id";
+
+-- Recreate indexes with new names
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_orgs_org_id" ON "orgs" USING btree ("org_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_user_id" ON "users" USING btree ("user_id");
+
+-- Rename unique constraints
+ALTER TABLE "orgs" RENAME CONSTRAINT "orgs_clerk_org_id_unique" TO "orgs_org_id_unique";
+ALTER TABLE "users" RENAME CONSTRAINT "users_clerk_user_id_unique" TO "users_user_id_unique";

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,385 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prevId": "39d8c1c6-eb57-44b6-9a75-dab79ed5b8a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_url": {
+          "name": "brand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_outcome": {
+          "name": "target_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_for_target": {
+          "name": "value_for_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_daily_usd": {
+          "name": "max_budget_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_weekly_usd": {
+          "name": "max_budget_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_monthly_usd": {
+          "name": "max_budget_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_total_usd": {
+          "name": "max_budget_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_leads": {
+          "name": "max_leads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'byok'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ongoing'"
+        },
+        "to_resume_at": {
+          "name": "to_resume_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_frequency": {
+          "name": "notify_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_channel": {
+          "name": "notify_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_destination": {
+          "name": "notify_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_campaigns_org": {
+          "name": "idx_campaigns_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_campaigns_app_id": {
+          "name": "idx_campaigns_app_id",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaigns_org_id_orgs_id_fk": {
+          "name": "campaigns_org_id_orgs_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_created_by_user_id_users_id_fk": {
+          "name": "campaigns_created_by_user_id_users_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_org_id": {
+          "name": "idx_orgs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_org_id_unique": {
+          "name": "orgs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_user_id": {
+          "name": "idx_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1771600000000,
       "tag": "0017_replace_type_with_workflow_name",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1771700000000,
+      "tag": "0018_rename_clerk_to_org_user_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -181,7 +181,7 @@
             "type": "string",
             "minLength": 1
           },
-          "clerkOrgId": {
+          "orgId": {
             "type": "string",
             "minLength": 1
           },
@@ -254,7 +254,7 @@
         "required": [
           "name",
           "workflowName",
-          "clerkOrgId",
+          "orgId",
           "parentRunId",
           "brandUrl",
           "brandId",
@@ -380,7 +380,7 @@
       "StatsFilterBody": {
         "type": "object",
         "properties": {
-          "clerkOrgId": {
+          "orgId": {
             "type": "string"
           },
           "appId": {
@@ -433,14 +433,14 @@
             "type": "string",
             "format": "uuid"
           },
-          "clerkOrgId": {
+          "orgId": {
             "type": "string",
             "minLength": 1
           }
         },
         "required": [
           "campaignId",
-          "clerkOrgId"
+          "orgId"
         ]
       },
       "StartRunResponse": {
@@ -454,7 +454,7 @@
             "type": "string",
             "format": "uuid"
           },
-          "clerkOrgId": {
+          "orgId": {
             "type": "string"
           },
           "brandId": {
@@ -473,7 +473,7 @@
           "workflowName": {
             "type": "string"
           },
-          "clerkUserId": {
+          "userId": {
             "type": "string",
             "nullable": true
           },
@@ -503,13 +503,13 @@
         "required": [
           "runId",
           "campaignId",
-          "clerkOrgId",
+          "orgId",
           "brandId",
           "brandUrl",
           "brandDomain",
           "appId",
           "workflowName",
-          "clerkUserId",
+          "userId",
           "targetOutcome",
           "valueForTarget",
           "searchParams",
@@ -523,14 +523,14 @@
             "type": "string",
             "format": "uuid"
           },
-          "clerkOrgId": {
+          "orgId": {
             "type": "string",
             "minLength": 1
           }
         },
         "required": [
           "campaignId",
-          "clerkOrgId"
+          "orgId"
         ]
       },
       "EndRunResponse": {
@@ -551,7 +551,7 @@
             "type": "string",
             "format": "uuid"
           },
-          "clerkOrgId": {
+          "orgId": {
             "type": "string",
             "minLength": 1
           },
@@ -564,7 +564,7 @@
         },
         "required": [
           "campaignId",
-          "clerkOrgId",
+          "orgId",
           "success"
         ]
       }
@@ -983,7 +983,7 @@
                           {
                             "type": "object",
                             "properties": {
-                              "clerkOrgId": {
+                              "externalOrgId": {
                                 "type": "string"
                               },
                               "brandDomain": {
@@ -996,7 +996,7 @@
                               }
                             },
                             "required": [
-                              "clerkOrgId",
+                              "externalOrgId",
                               "brandDomain",
                               "brandName"
                             ]

--- a/packages/runs-client/src/index.ts
+++ b/packages/runs-client/src/index.ts
@@ -26,11 +26,11 @@ export interface Run {
 }
 
 export interface CreateRunParams {
-  clerkOrgId: string;
+  orgId: string;
   appId: string;
   serviceName: string;
   taskName: string;
-  clerkUserId?: string;
+  userId?: string;
   brandId?: string;
   campaignId?: string;
   parentRunId?: string;
@@ -38,8 +38,8 @@ export interface CreateRunParams {
 }
 
 export interface ListRunsParams {
-  clerkOrgId: string;
-  clerkUserId?: string;
+  orgId: string;
+  userId?: string;
   appId?: string;
   brandId?: string;
   campaignId?: string;
@@ -66,7 +66,7 @@ export interface BudgetWindowResult {
 }
 
 export interface StatsBudgetParams {
-  clerkOrgId: string;
+  orgId: string;
   appId: string;
   campaignId?: string;
   brandId?: string;
@@ -137,8 +137,8 @@ export async function listRuns(
   params: ListRunsParams
 ): Promise<{ runs: Run[]; limit: number; offset: number }> {
   const searchParams = new URLSearchParams();
-  searchParams.set("clerkOrgId", params.clerkOrgId);
-  if (params.clerkUserId) searchParams.set("clerkUserId", params.clerkUserId);
+  searchParams.set("orgId", params.orgId);
+  if (params.userId) searchParams.set("userId", params.userId);
   if (params.appId) searchParams.set("appId", params.appId);
   if (params.brandId) searchParams.set("brandId", params.brandId);
   if (params.campaignId) searchParams.set("campaignId", params.campaignId);

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -153,7 +153,7 @@ registry.registerPath({
   summary: "List all campaigns across all orgs",
   security: [{ [apiKeyAuth.name]: [] }],
   responses: {
-    200: { description: "All campaigns with org info", content: { "application/json": { schema: z.object({ campaigns: z.array(CampaignSchema.extend({ clerkOrgId: z.string(), brandDomain: z.string().nullable(), brandName: z.string().nullable() })) }) } } },
+    200: { description: "All campaigns with org info", content: { "application/json": { schema: z.object({ campaigns: z.array(CampaignSchema.extend({ externalOrgId: z.string(), brandDomain: z.string().nullable(), brandName: z.string().nullable() })) }) } } },
   },
 });
 

--- a/scripts/migrate-clerk-to-client-ids.ts
+++ b/scripts/migrate-clerk-to-client-ids.ts
@@ -1,0 +1,115 @@
+/**
+ * One-shot migration script: resolve Clerk IDs → client-service UUIDs
+ *
+ * For each org/user in the local DB, calls client-service to resolve
+ * the old Clerk ID to the internal client-service UUID, then updates
+ * the local record.
+ *
+ * Prerequisites:
+ *   - DB migration 0018 (column rename) must be applied first
+ *   - CLIENT_SERVICE_URL and CLIENT_SERVICE_API_KEY env vars must be set
+ *
+ * Usage:
+ *   CLIENT_SERVICE_URL=https://... CLIENT_SERVICE_API_KEY=... npx tsx scripts/migrate-clerk-to-client-ids.ts
+ */
+
+import { db, sql } from "../src/db/index.js";
+import { orgs, users } from "../src/db/schema.js";
+import { eq } from "drizzle-orm";
+
+const CLIENT_SERVICE_URL = process.env.CLIENT_SERVICE_URL;
+const CLIENT_SERVICE_API_KEY = process.env.CLIENT_SERVICE_API_KEY;
+
+if (!CLIENT_SERVICE_URL || !CLIENT_SERVICE_API_KEY) {
+  console.error("CLIENT_SERVICE_URL and CLIENT_SERVICE_API_KEY are required");
+  process.exit(1);
+}
+
+async function resolveOrgId(clerkOrgId: string): Promise<string | null> {
+  const res = await fetch(`${CLIENT_SERVICE_URL}/orgs/by-clerk/${encodeURIComponent(clerkOrgId)}`, {
+    headers: { "x-api-key": CLIENT_SERVICE_API_KEY! },
+  });
+  if (!res.ok) {
+    console.error(`  Failed to resolve org ${clerkOrgId}: ${res.status}`);
+    return null;
+  }
+  const data = (await res.json()) as { org: { id: string } };
+  return data.org.id;
+}
+
+async function resolveUserId(clerkUserId: string): Promise<string | null> {
+  const res = await fetch(`${CLIENT_SERVICE_URL}/users/by-clerk/${encodeURIComponent(clerkUserId)}`, {
+    headers: { "x-api-key": CLIENT_SERVICE_API_KEY! },
+  });
+  if (!res.ok) {
+    console.error(`  Failed to resolve user ${clerkUserId}: ${res.status}`);
+    return null;
+  }
+  const data = (await res.json()) as { user: { id: string } };
+  return data.user.id;
+}
+
+async function main() {
+  console.log("=== Migrating Clerk IDs to client-service UUIDs ===\n");
+
+  // Migrate orgs
+  const allOrgs = await db.select().from(orgs);
+  console.log(`Found ${allOrgs.length} orgs to migrate`);
+
+  let orgSuccess = 0;
+  let orgSkipped = 0;
+  let orgFailed = 0;
+
+  for (const org of allOrgs) {
+    // Skip if already looks like a UUID (already migrated)
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(org.externalOrgId)) {
+      orgSkipped++;
+      continue;
+    }
+
+    const newId = await resolveOrgId(org.externalOrgId);
+    if (newId) {
+      await db.update(orgs).set({ externalOrgId: newId }).where(eq(orgs.id, org.id));
+      console.log(`  org ${org.id}: ${org.externalOrgId} → ${newId}`);
+      orgSuccess++;
+    } else {
+      orgFailed++;
+    }
+  }
+
+  console.log(`\nOrgs: ${orgSuccess} migrated, ${orgSkipped} skipped (already UUID), ${orgFailed} failed\n`);
+
+  // Migrate users
+  const allUsers = await db.select().from(users);
+  console.log(`Found ${allUsers.length} users to migrate`);
+
+  let userSuccess = 0;
+  let userSkipped = 0;
+  let userFailed = 0;
+
+  for (const user of allUsers) {
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(user.externalUserId)) {
+      userSkipped++;
+      continue;
+    }
+
+    const newId = await resolveUserId(user.externalUserId);
+    if (newId) {
+      await db.update(users).set({ externalUserId: newId }).where(eq(users.id, user.id));
+      console.log(`  user ${user.id}: ${user.externalUserId} → ${newId}`);
+      userSuccess++;
+    } else {
+      userFailed++;
+    }
+  }
+
+  console.log(`\nUsers: ${userSuccess} migrated, ${userSkipped} skipped (already UUID), ${userFailed} failed`);
+  console.log("\n=== Migration complete ===");
+
+  await sql.end();
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,30 +1,30 @@
 import { pgTable, uuid, text, timestamp, uniqueIndex, index, date, decimal, integer } from "drizzle-orm/pg-core";
 
-// Local users table (maps to Clerk)
+// Local users table (maps to client-service)
 export const users = pgTable(
   "users",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    clerkUserId: text("clerk_user_id").notNull().unique(),
+    externalUserId: text("user_id").notNull().unique(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("idx_users_clerk_id").on(table.clerkUserId),
+    uniqueIndex("idx_users_user_id").on(table.externalUserId),
   ]
 );
 
-// Local orgs table (maps to Clerk)
+// Local orgs table (maps to client-service)
 export const orgs = pgTable(
   "orgs",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    clerkOrgId: text("clerk_org_id").notNull().unique(),
+    externalOrgId: text("org_id").notNull().unique(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("idx_orgs_clerk_id").on(table.clerkOrgId),
+    uniqueIndex("idx_orgs_org_id").on(table.externalOrgId),
   ]
 );
 

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -8,7 +8,7 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 
 export interface GateCheckInput {
   campaignId: string;
-  clerkOrgId: string;
+  orgId: string;
   appId: string;
   brandId: string;
   status: string;
@@ -33,7 +33,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
 
   // Fetch all runs for this campaign (needed for stale cleanup, running check, consecutive failures)
   const { runs } = await listRuns({
-    clerkOrgId: campaign.clerkOrgId,
+    orgId: campaign.orgId,
     appId: campaign.appId,
     serviceName: "campaign-service",
     taskName: campaign.campaignId,
@@ -87,7 +87,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
 
   // Single call to runs-service for all budget windows
   const budgetResult = await getStatsBudget({
-    clerkOrgId: campaign.clerkOrgId,
+    orgId: campaign.orgId,
     appId: campaign.appId,
     campaignId: campaign.campaignId,
     windows,
@@ -112,7 +112,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     const completedRuns = runs.filter((r: Run) => r.status === "completed");
     let totalServed: number;
     try {
-      const leadStats = await fetchLeadStats(campaign.clerkOrgId, campaign.campaignId, campaign.brandId, campaign.appId);
+      const leadStats = await fetchLeadStats(campaign.orgId, campaign.campaignId, campaign.brandId, campaign.appId);
       totalServed = Math.max(leadStats.totalServed, completedRuns.length);
     } catch (err: unknown) {
       if (err instanceof Error && "status" in err && (err as { status: number }).status === 404) {
@@ -153,7 +153,7 @@ async function autoStopCampaign(campaignId: string): Promise<void> {
 }
 
 async function fetchLeadStats(
-  clerkOrgId: string,
+  orgId: string,
   campaignId: string,
   brandId: string,
   appId: string,
@@ -167,7 +167,7 @@ async function fetchLeadStats(
     headers: {
       "x-api-key": apiKey,
       "x-app-id": appId,
-      "x-org-id": clerkOrgId,
+      "x-org-id": orgId,
     },
   });
 

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -7,12 +7,12 @@
  */
 export async function executeCampaignWorkflow(
   workflowName: string,
-  inputs: { campaignId: string; clerkOrgId: string; appId: string },
+  inputs: { campaignId: string; orgId: string; appId: string },
 ): Promise<void> {
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
 
-  console.log(`[Workflow] executeCampaignWorkflow called: workflowName=${workflowName}, campaignId=${inputs.campaignId}, clerkOrgId=${inputs.clerkOrgId}, appId=${inputs.appId}`);
+  console.log(`[Workflow] executeCampaignWorkflow called: workflowName=${workflowName}, campaignId=${inputs.campaignId}, orgId=${inputs.orgId}, appId=${inputs.appId}`);
 
   if (!url || !apiKey) {
     console.warn("[Workflow] WORKFLOW_SERVICE_URL or WORKFLOW_SERVICE_API_KEY not set, skipping workflow execution");
@@ -30,10 +30,10 @@ export async function executeCampaignWorkflow(
     },
     body: JSON.stringify({
       appId: inputs.appId,
-      orgId: inputs.clerkOrgId,
+      orgId: inputs.orgId,
       inputs: {
         campaignId: inputs.campaignId,
-        clerkOrgId: inputs.clerkOrgId,
+        orgId: inputs.orgId,
       },
     }),
   });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -9,14 +9,14 @@ export { users };
 export interface AuthenticatedRequest extends Request {
   userId?: string;
   orgId?: string;
-  clerkUserId?: string;
-  clerkOrgId?: string;
+  externalUserId?: string;
+  externalOrgId?: string;
 }
 
 /**
  * Service-to-service auth for internal calls (Railway private network)
- * Uses x-clerk-org-id header to identify org
- * Optionally uses x-clerk-user-id header to identify user
+ * Uses x-org-id header to identify org (client-service UUID)
+ * Optionally uses x-user-id header to identify user (client-service UUID)
  */
 export async function serviceAuth(
   req: AuthenticatedRequest,
@@ -24,45 +24,45 @@ export async function serviceAuth(
   next: NextFunction
 ) {
   try {
-    const clerkOrgId = req.headers["x-clerk-org-id"] as string;
-    const clerkUserId = req.headers["x-clerk-user-id"] as string | undefined;
+    const externalOrgId = req.headers["x-org-id"] as string;
+    const externalUserId = req.headers["x-user-id"] as string | undefined;
 
-    if (!clerkOrgId) {
-      return res.status(400).json({ error: "x-clerk-org-id header required" });
+    if (!externalOrgId) {
+      return res.status(400).json({ error: "x-org-id header required" });
     }
 
     // Find or create org
     let org = await db.query.orgs.findFirst({
-      where: eq(orgs.clerkOrgId, clerkOrgId),
+      where: eq(orgs.externalOrgId, externalOrgId),
     });
 
     if (!org) {
       const [newOrg] = await db
         .insert(orgs)
-        .values({ clerkOrgId })
+        .values({ externalOrgId })
         .returning();
       org = newOrg;
     }
 
     req.orgId = org.id;
-    req.clerkOrgId = clerkOrgId;
+    req.externalOrgId = externalOrgId;
 
     // Handle optional user context
-    if (clerkUserId) {
+    if (externalUserId) {
       let user = await db.query.users.findFirst({
-        where: eq(users.clerkUserId, clerkUserId),
+        where: eq(users.externalUserId, externalUserId),
       });
 
       if (!user) {
         const [newUser] = await db
           .insert(users)
-          .values({ clerkUserId })
+          .values({ externalUserId })
           .returning();
         user = newUser;
       }
 
       req.userId = user.id;
-      req.clerkUserId = clerkUserId;
+      req.externalUserId = externalUserId;
     }
 
     next();

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -34,7 +34,7 @@ router.get("/campaigns/list", requireApiKey, async (_req, res) => {
         maxBudgetTotalUsd: campaigns.maxBudgetTotalUsd,
         maxLeads: campaigns.maxLeads,
         createdAt: campaigns.createdAt,
-        clerkOrgId: orgs.clerkOrgId,
+        externalOrgId: orgs.externalOrgId,
         brandUrl: campaigns.brandUrl,
       })
       .from(campaigns)
@@ -68,7 +68,7 @@ router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBu
         status: campaigns.status,
         maxLeads: campaigns.maxLeads,
         maxBudgetTotalUsd: campaigns.maxBudgetTotalUsd,
-        clerkOrgId: orgs.clerkOrgId,
+        externalOrgId: orgs.externalOrgId,
       })
       .from(campaigns)
       .innerJoin(orgs, eq(campaigns.orgId, orgs.id))
@@ -90,7 +90,7 @@ router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBu
 
         try {
           const budgetResult = await getStatsBudget({
-            clerkOrgId: row.clerkOrgId,
+            orgId: row.externalOrgId,
             appId: row.appId || "",
             campaignId,
             windows: [{ label: "total" }],
@@ -124,12 +124,12 @@ router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBu
  */
 router.post("/campaigns/stats", requireApiKey, validateBody(StatsFilterBody), async (req, res) => {
   try {
-    const { clerkOrgId, appId, brandId, campaignId } = req.body;
+    const { orgId, appId, brandId, campaignId } = req.body;
 
     const conditions = [];
-    if (clerkOrgId) {
+    if (orgId) {
       const org = await db.query.orgs.findFirst({
-        where: eq(orgs.clerkOrgId, clerkOrgId),
+        where: eq(orgs.externalOrgId, orgId),
         columns: { id: true },
       });
       if (org) conditions.push(eq(campaigns.orgId, org.id));
@@ -170,7 +170,7 @@ router.post("/campaigns/stats", requireApiKey, validateBody(StatsFilterBody), as
   }
 });
 
-// === User routes (Clerk JWT authed) ===
+// === User routes (service-auth) ===
 
 /**
  * GET /campaigns - List all campaigns for org
@@ -283,7 +283,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     console.log(`[Campaign Service] Campaign created: campaignId=${campaign.id}, workflowName=${campaign.workflowName}, triggering first workflow execution`);
     executeCampaignWorkflow(campaign.workflowName, {
       campaignId: campaign.id,
-      clerkOrgId: req.clerkOrgId!,
+      orgId: req.externalOrgId!,
       appId: campaign.appId || "",
     }).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
@@ -333,10 +333,10 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
 
     // Trigger workflow on activation
     if (req.body.status === "activate") {
-      console.log(`[Campaign Service] Activation triggered: campaignId=${updated.id}, workflowName=${updated.workflowName}, clerkOrgId=${req.clerkOrgId}`);
+      console.log(`[Campaign Service] Activation triggered: campaignId=${updated.id}, workflowName=${updated.workflowName}, orgId=${req.externalOrgId}`);
       executeCampaignWorkflow(updated.workflowName, {
         campaignId: updated.id,
-        clerkOrgId: req.clerkOrgId!,
+        orgId: req.externalOrgId!,
         appId: updated.appId || "",
       }).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { campaigns, orgs } from "../db/schema.js";
+import { campaigns, orgs, users } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun } from "@mcpfactory/runs-client";
@@ -30,14 +30,14 @@ const router = Router();
  */
 router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (req, res) => {
   try {
-    const { campaignId, clerkOrgId } = req.body;
-    console.log(`[Gate Check] Received request: campaignId=${campaignId}, clerkOrgId=${clerkOrgId}`);
+    const { campaignId, orgId } = req.body;
+    console.log(`[Gate Check] Received request: campaignId=${campaignId}, orgId=${orgId}`);
 
     const org = await db.query.orgs.findFirst({
-      where: eq(orgs.clerkOrgId, clerkOrgId),
+      where: eq(orgs.externalOrgId, orgId),
     });
     if (!org) {
-      console.warn(`[Gate Check] Org not found: ${clerkOrgId}`);
+      console.warn(`[Gate Check] Org not found: ${orgId}`);
       return res.status(404).json({ error: "Organization not found" });
     }
 
@@ -52,7 +52,7 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
     console.log(`[Gate Check] Running checks for campaign ${campaignId} (status=${campaign.status})...`);
     const result = await runGateChecks({
       campaignId,
-      clerkOrgId,
+      orgId,
       appId: campaign.appId || "",
       brandId: campaign.brandId || "",
       status: campaign.status,
@@ -96,14 +96,14 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
  */
 router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req, res) => {
   try {
-    const { campaignId, clerkOrgId } = req.body;
-    console.log(`[Start Run] Received request: campaignId=${campaignId}, clerkOrgId=${clerkOrgId}`);
+    const { campaignId, orgId } = req.body;
+    console.log(`[Start Run] Received request: campaignId=${campaignId}, orgId=${orgId}`);
 
     const org = await db.query.orgs.findFirst({
-      where: eq(orgs.clerkOrgId, clerkOrgId),
+      where: eq(orgs.externalOrgId, orgId),
     });
     if (!org) {
-      console.warn(`[Start Run] Org not found: ${clerkOrgId}`);
+      console.warn(`[Start Run] Org not found: ${orgId}`);
       return res.status(404).json({ error: "Organization not found" });
     }
 
@@ -126,16 +126,26 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
 
     const appId = campaign.appId || "";
 
+    // Look up user's external ID if campaign has a createdByUserId
+    let externalUserId: string | undefined;
+    if (campaign.createdByUserId) {
+      const user = await db.query.users.findFirst({
+        where: eq(users.id, campaign.createdByUserId),
+        columns: { externalUserId: true },
+      });
+      externalUserId = user?.externalUserId;
+    }
+
     // Create run in runs-service (parentRunId links to api-service's parent run)
     console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId} (parentRunId=${campaign.parentRunId || "none"})...`);
     const run = await createRun({
-      clerkOrgId,
+      orgId,
       appId,
       serviceName: "campaign-service",
       taskName: campaignId,
       campaignId,
       brandId: campaign.brandId,
-      clerkUserId: campaign.createdByUserId || undefined,
+      userId: externalUserId,
       parentRunId: campaign.parentRunId || undefined,
       workflowName: campaign.workflowName,
     });
@@ -160,13 +170,13 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
     res.json({
       runId: run.id,
       campaignId,
-      clerkOrgId,
+      orgId,
       brandId: campaign.brandId,
       brandUrl: campaign.brandUrl,
       brandDomain,
       appId,
       workflowName: campaign.workflowName,
-      clerkUserId: campaign.createdByUserId,
+      userId: externalUserId ?? null,
       targetOutcome: campaign.targetOutcome,
       valueForTarget: campaign.valueForTarget,
       searchParams,
@@ -191,14 +201,14 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
  */
 router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res) => {
   try {
-    const { campaignId, clerkOrgId, success, leadFound } = req.body;
-    console.log(`[End Run] Received request: campaignId=${campaignId}, clerkOrgId=${clerkOrgId}, success=${success}, leadFound=${leadFound}`);
+    const { campaignId, orgId, success, leadFound } = req.body;
+    console.log(`[End Run] Received request: campaignId=${campaignId}, orgId=${orgId}, success=${success}, leadFound=${leadFound}`);
 
     const status = success === true ? "completed" : "failed";
 
     // Fetch campaign to get appId
     const org = await db.query.orgs.findFirst({
-      where: eq(orgs.clerkOrgId, clerkOrgId),
+      where: eq(orgs.externalOrgId, orgId),
     });
     const campaign = org
       ? await db.query.campaigns.findFirst({
@@ -210,7 +220,7 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
     // Find and update running runs for this campaign
     try {
       const { runs } = await listRuns({
-        clerkOrgId,
+        orgId,
         appId,
         serviceName: "campaign-service",
         taskName: campaignId,
@@ -250,7 +260,7 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
     // Re-trigger if campaign is still ongoing
     try {
       if (!org) {
-        console.warn(`[End Run] Org not found for re-trigger: ${clerkOrgId}`);
+        console.warn(`[End Run] Org not found for re-trigger: ${orgId}`);
         return;
       }
 
@@ -266,7 +276,7 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
 
       // Fire-and-forget: gate-check in the next workflow execution will validate limits
       console.log(`[End Run] Re-triggering workflow=${freshCampaign.workflowName} for campaign ${campaignId}`);
-      executeCampaignWorkflow(freshCampaign.workflowName, { campaignId, clerkOrgId, appId }).catch((err) => {
+      executeCampaignWorkflow(freshCampaign.workflowName, { campaignId, orgId, appId }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });
     } catch (err) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -44,7 +44,7 @@ export const CampaignSchema = z.object({
 export const CreateCampaignBody = z.object({
   name: z.string().min(1, "Campaign name is required"),
   workflowName: z.string().min(1, "workflowName is required"),
-  clerkOrgId: z.string().min(1, "clerkOrgId is required"),
+  orgId: z.string().min(1, "orgId is required"),
   parentRunId: z.string().uuid("parentRunId must be a valid UUID"),
   brandUrl: z.string().min(1, "brandUrl is required"),
   brandId: z.string().uuid("brandId must be a valid UUID"),
@@ -91,13 +91,13 @@ export const UpdateCampaignBody = z.object({
 // --- Stats ---
 
 export const StatsFilterBody = z.object({
-  clerkOrgId: z.string().optional(),
+  orgId: z.string().optional(),
   appId: z.string().optional(),
   brandId: z.string().optional(),
   campaignId: z.string().optional(),
 }).refine(
-  (data) => data.clerkOrgId || data.appId || data.brandId || data.campaignId,
-  { message: "At least one filter required: clerkOrgId, appId, brandId, or campaignId" }
+  (data) => data.orgId || data.appId || data.brandId || data.campaignId,
+  { message: "At least one filter required: orgId, appId, brandId, or campaignId" }
 ).openapi("StatsFilterBody");
 
 export const StatsResponse = z.object({
@@ -119,7 +119,7 @@ export const BatchBudgetUsageBody = z.object({
 
 export const GateCheckBody = z.object({
   campaignId: z.string().uuid("campaignId must be a valid UUID"),
-  clerkOrgId: z.string().min(1, "clerkOrgId is required"),
+  orgId: z.string().min(1, "orgId is required"),
 }).openapi("GateCheckBody");
 
 export const GateCheckResponse = z.object({
@@ -130,19 +130,19 @@ export const GateCheckResponse = z.object({
 
 export const StartRunBody = z.object({
   campaignId: z.string().uuid("campaignId must be a valid UUID"),
-  clerkOrgId: z.string().min(1, "clerkOrgId is required"),
+  orgId: z.string().min(1, "orgId is required"),
 }).openapi("StartRunBody");
 
 export const StartRunResponse = z.object({
   runId: z.string().uuid(),
   campaignId: z.string().uuid(),
-  clerkOrgId: z.string(),
+  orgId: z.string(),
   brandId: z.string().uuid(),
   brandUrl: z.string(),
   brandDomain: z.string(),
   appId: z.string(),
   workflowName: z.string(),
-  clerkUserId: z.string().nullable(),
+  userId: z.string().nullable(),
   targetOutcome: z.string().nullable(),
   valueForTarget: z.string().nullable(),
   searchParams: z.record(z.string(), z.unknown()).nullable(),
@@ -151,7 +151,7 @@ export const StartRunResponse = z.object({
 
 export const EndRunBody = z.object({
   campaignId: z.string().uuid("campaignId must be a valid UUID"),
-  clerkOrgId: z.string().min(1, "clerkOrgId is required"),
+  orgId: z.string().min(1, "orgId is required"),
   success: z.boolean(),
   leadFound: z.boolean().optional(),
 }).openapi("EndRunBody");

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -13,11 +13,11 @@ export async function cleanTestData() {
 /**
  * Insert a test org
  */
-export async function insertTestOrg(data: { clerkOrgId?: string } = {}) {
+export async function insertTestOrg(data: { externalOrgId?: string } = {}) {
   const [org] = await db
     .insert(orgs)
     .values({
-      clerkOrgId: data.clerkOrgId || `test-org-${Date.now()}`,
+      externalOrgId: data.externalOrgId || `test-org-${Date.now()}`,
     })
     .returning();
   return org;
@@ -26,11 +26,11 @@ export async function insertTestOrg(data: { clerkOrgId?: string } = {}) {
 /**
  * Insert a test user
  */
-export async function insertTestUser(data: { clerkUserId?: string } = {}) {
+export async function insertTestUser(data: { externalUserId?: string } = {}) {
   const [user] = await db
     .insert(users)
     .values({
-      clerkUserId: data.clerkUserId || `test-user-${Date.now()}`,
+      externalUserId: data.externalUserId || `test-user-${Date.now()}`,
     })
     .returning();
   return user;

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -18,7 +18,7 @@ describe("Campaign CRUD", () => {
   const validBody = {
     name: "Test Campaign",
     workflowName: "sales-email-cold-outreach",
-    clerkOrgId: "org_test_crud",
+    orgId: "org_test_crud",
     parentRunId: crypto.randomUUID(),
     brandUrl: "https://example.com",
     brandId: crypto.randomUUID(),
@@ -33,7 +33,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(validBody)
         .expect(201);
 
@@ -50,7 +50,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(body)
         .expect(400);
 
@@ -61,7 +61,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(validBody)
         .expect(201);
 
@@ -74,7 +74,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(body)
         .expect(400);
 
@@ -85,7 +85,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ ...validBody, parentRunId: "not-a-uuid" })
         .expect(400);
 
@@ -98,7 +98,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(body)
         .expect(400);
 
@@ -111,20 +111,20 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(body)
         .expect(400);
 
       expect(res.body.error).toBeDefined();
     });
 
-    it("should reject when clerkOrgId is missing from body", async () => {
-      const { clerkOrgId, ...body } = validBody;
+    it("should reject when orgId is missing from body", async () => {
+      const { orgId, ...body } = validBody;
 
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(body)
         .expect(400);
 
@@ -135,7 +135,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ ...validBody, brandId: "not-a-uuid" })
         .expect(400);
 
@@ -147,7 +147,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ ...validBody, targetAudience: audience })
         .expect(201);
 
@@ -158,7 +158,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(validBody)
         .expect(201);
 
@@ -169,7 +169,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(validBody)
         .expect(201);
 
@@ -183,7 +183,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(body)
         .expect(400);
 
@@ -196,7 +196,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(body)
         .expect(400);
 
@@ -207,7 +207,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ ...validBody, targetOutcome: "" })
         .expect(400);
 
@@ -218,7 +218,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ ...validBody, valueForTarget: "" })
         .expect(400);
 
@@ -229,7 +229,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ ...validBody, personTitles: ["CEO"] });
 
       // Zod strips unknown fields by default, so it should still succeed
@@ -242,7 +242,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(validBody)
         .expect(201);
 
@@ -259,7 +259,7 @@ describe("Campaign CRUD", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(validBody)
         .expect(201);
 
@@ -269,7 +269,7 @@ describe("Campaign CRUD", () => {
       await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ status: "stop" })
         .expect(200);
 
@@ -277,7 +277,7 @@ describe("Campaign CRUD", () => {
       const res = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ status: "activate" })
         .expect(400);
 
@@ -288,7 +288,7 @@ describe("Campaign CRUD", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(validBody)
         .expect(201);
 
@@ -298,7 +298,7 @@ describe("Campaign CRUD", () => {
       await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ status: "stop" })
         .expect(200);
 
@@ -307,7 +307,7 @@ describe("Campaign CRUD", () => {
       const activateRes = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ status: "activate", parentRunId: newParentRunId })
         .expect(200);
 
@@ -320,7 +320,7 @@ describe("Campaign CRUD", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(validBody)
         .expect(201);
 
@@ -330,7 +330,7 @@ describe("Campaign CRUD", () => {
       const updateRes = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({ targetAudience: newAudience })
         .expect(200);
 
@@ -341,7 +341,7 @@ describe("Campaign CRUD", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send(validBody)
         .expect(201);
 
@@ -350,7 +350,7 @@ describe("Campaign CRUD", () => {
       const updateRes = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_test_crud")
+        .set("x-org-id", "org_test_crud")
         .send({
           targetOutcome: "Recruit community ambassadors",
           valueForTarget: "Early access to beta features",

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -16,15 +16,15 @@ describe("Campaign Service Database", () => {
 
   describe("orgs table", () => {
     it("should create and query an org", async () => {
-      const org = await insertTestOrg({ clerkOrgId: "org_test123" });
+      const org = await insertTestOrg({ externalOrgId: "org_test123" });
 
       expect(org.id).toBeDefined();
-      expect(org.clerkOrgId).toBe("org_test123");
+      expect(org.externalOrgId).toBe("org_test123");
 
       const found = await db.query.orgs.findFirst({
         where: eq(orgs.id, org.id),
       });
-      expect(found?.clerkOrgId).toBe("org_test123");
+      expect(found?.externalOrgId).toBe("org_test123");
     });
   });
 

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -36,14 +36,14 @@ import { cleanTestData, closeDb, insertTestOrg, insertTestCampaign } from "../he
 const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 
 describe("Pipeline routes", () => {
-  let org: { id: string; clerkOrgId: string };
+  let org: { id: string; externalOrgId: string };
   const brandId = crypto.randomUUID();
 
   beforeEach(async () => {
     await cleanTestData();
     vi.clearAllMocks();
 
-    org = await insertTestOrg({ clerkOrgId: "org_internal_test" });
+    org = await insertTestOrg({ externalOrgId: "org_internal_test" });
 
     // Default mock behaviors
     mockCreateRun.mockResolvedValue({ id: "run-123" });
@@ -65,11 +65,11 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ clerkOrgId: "some-org" })
+        .send({ orgId: "some-org" })
         .expect(400);
     });
 
-    it("should return 400 if clerkOrgId is missing", async () => {
+    it("should return 400 if orgId is missing", async () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
@@ -81,7 +81,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), clerkOrgId: "nonexistent-org" })
+        .send({ campaignId: crypto.randomUUID(), orgId: "nonexistent-org" })
         .expect(404);
 
       expect(res.body.error).toBe("Organization not found");
@@ -91,7 +91,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: crypto.randomUUID(), orgId: org.externalOrgId })
         .expect(404);
 
       expect(res.body.error).toBe("Campaign not found");
@@ -106,7 +106,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(res.body.allowed).toBe(true);
@@ -127,7 +127,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(res.body.allowed).toBe(false);
@@ -149,7 +149,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(res.body.allowed).toBe(false);
@@ -167,13 +167,13 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(mockGateChecks).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
           brandId,
           status: "ongoing",
           maxBudgetDailyUsd: "50.00",
@@ -190,7 +190,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ clerkOrgId: "some-org" })
+        .send({ orgId: "some-org" })
         .expect(400);
     });
 
@@ -198,7 +198,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), clerkOrgId: "nonexistent-org" })
+        .send({ campaignId: crypto.randomUUID(), orgId: "nonexistent-org" })
         .expect(404);
 
       expect(res.body.error).toBe("Organization not found");
@@ -208,7 +208,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: crypto.randomUUID(), orgId: org.externalOrgId })
         .expect(404);
 
       expect(res.body.error).toBe("Campaign not found");
@@ -223,7 +223,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(400);
 
       expect(res.body.error).toBe("Campaign has no brandUrl");
@@ -238,7 +238,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(400);
 
       expect(res.body.error).toBe("Campaign has no brandId");
@@ -256,12 +256,12 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(res.body.runId).toBe("run-123");
       expect(res.body.campaignId).toBe(campaign.id);
-      expect(res.body.clerkOrgId).toBe(org.clerkOrgId);
+      expect(res.body.orgId).toBe(org.externalOrgId);
       expect(res.body.brandId).toBe(brandId);
       expect(res.body.brandUrl).toBe("https://example.com");
       expect(res.body.brandDomain).toBe("example.com");
@@ -280,7 +280,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(res.body).not.toHaveProperty("urgency");
@@ -301,7 +301,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(res.body.searchParams).toEqual({
@@ -320,7 +320,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(res.body.searchParams).toBeNull();
@@ -335,7 +335,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(res.body.brandDomain).toBe("example.com");
@@ -353,7 +353,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -370,7 +370,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -388,7 +388,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -405,7 +405,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, clerkOrgId: org.clerkOrgId })
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
         .expect(200);
 
       expect(mockGateChecks).not.toHaveBeenCalled();
@@ -419,7 +419,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), clerkOrgId: "org-1" })
+        .send({ campaignId: crypto.randomUUID(), orgId: "org-1" })
         .expect(400);
     });
 
@@ -440,7 +440,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
           success: true,
         })
         .expect(200);
@@ -466,7 +466,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
           success: false,
         })
         .expect(200);
@@ -488,7 +488,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
           success: false,
         })
         .expect(200);
@@ -510,7 +510,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
           success: true,
         })
         .expect(200);
@@ -522,7 +522,7 @@ describe("Pipeline routes", () => {
         "sales-email-cold-outreach",
         {
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
           appId: "",
         },
       );
@@ -540,7 +540,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
           success: true,
         })
         .expect(200);
@@ -568,7 +568,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
           success: true,
           leadFound: false,
         })
@@ -602,7 +602,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
           success: true,
           leadFound: true,
         })
@@ -615,7 +615,7 @@ describe("Pipeline routes", () => {
         "sales-email-cold-outreach",
         expect.objectContaining({
           campaignId: campaign.id,
-          clerkOrgId: org.clerkOrgId,
+          orgId: org.externalOrgId,
         }),
       );
     });

--- a/tests/integration/scheduler-campaigns.test.ts
+++ b/tests/integration/scheduler-campaigns.test.ts
@@ -31,8 +31,8 @@ describe("Scheduler Endpoints", () => {
 
   describe("GET /campaigns/list", () => {
     it("should return all campaigns across all orgs", async () => {
-      const org1 = await insertTestOrg({ clerkOrgId: "org_1" });
-      const org2 = await insertTestOrg({ clerkOrgId: "org_2" });
+      const org1 = await insertTestOrg({ externalOrgId: "org_1" });
+      const org2 = await insertTestOrg({ externalOrgId: "org_2" });
 
       await insertTestCampaign(org1.id, { name: "Org1 Campaign", status: "ongoing" });
       await insertTestCampaign(org2.id, { name: "Org2 Campaign", status: "ongoing" });
@@ -43,11 +43,11 @@ describe("Scheduler Endpoints", () => {
         .expect(200);
 
       expect(res.body.campaigns).toHaveLength(2);
-      expect(res.body.campaigns[0].clerkOrgId).toBeDefined();
+      expect(res.body.campaigns[0].externalOrgId).toBeDefined();
     });
 
-    it("should include clerkOrgId for downstream service calls", async () => {
-      const org = await insertTestOrg({ clerkOrgId: "org_test_clerk" });
+    it("should include externalOrgId for downstream service calls", async () => {
+      const org = await insertTestOrg({ externalOrgId: "org_test_ext" });
       await insertTestCampaign(org.id, { name: "Test", status: "ongoing" });
 
       const res = await request(app)
@@ -55,7 +55,7 @@ describe("Scheduler Endpoints", () => {
         .set("x-api-key", API_KEY)
         .expect(200);
 
-      expect(res.body.campaigns[0].clerkOrgId).toBe("org_test_clerk");
+      expect(res.body.campaigns[0].externalOrgId).toBe("org_test_ext");
     });
 
     it("should return empty array when no campaigns", async () => {
@@ -70,7 +70,7 @@ describe("Scheduler Endpoints", () => {
 
   describe("POST /campaigns/batch-budget-usage", () => {
     it("should return cost total from getStatsBudget for each campaign", async () => {
-      const org = await insertTestOrg({ clerkOrgId: "org_batch" });
+      const org = await insertTestOrg({ externalOrgId: "org_batch" });
       const campaign = await insertTestCampaign(org.id, {
         status: "ongoing",
         maxBudgetTotalUsd: "50.00",
@@ -96,7 +96,7 @@ describe("Scheduler Endpoints", () => {
     });
 
     it("should call getStatsBudget with correct params", async () => {
-      const org = await insertTestOrg({ clerkOrgId: "org_batch_params" });
+      const org = await insertTestOrg({ externalOrgId: "org_batch_params" });
       const campaign = await insertTestCampaign(org.id, { appId: "mcpfactory" });
 
       mockGetStatsBudget.mockResolvedValue({ windows: [] });
@@ -108,7 +108,7 @@ describe("Scheduler Endpoints", () => {
         .expect(200);
 
       expect(mockGetStatsBudget).toHaveBeenCalledWith({
-        clerkOrgId: "org_batch_params",
+        orgId: "org_batch_params",
         appId: "mcpfactory",
         campaignId: campaign.id,
         windows: [{ label: "total" }],
@@ -128,7 +128,7 @@ describe("Scheduler Endpoints", () => {
     });
 
     it("should handle getStatsBudget failure gracefully", async () => {
-      const org = await insertTestOrg({ clerkOrgId: "org_batch_err" });
+      const org = await insertTestOrg({ externalOrgId: "org_batch_err" });
       const campaign = await insertTestCampaign(org.id, { appId: "mcpfactory" });
 
       mockGetStatsBudget.mockRejectedValue(new Error("runs-service down"));
@@ -143,7 +143,7 @@ describe("Scheduler Endpoints", () => {
     });
 
     it("should return null totalCostInUsdCents when no windows returned", async () => {
-      const org = await insertTestOrg({ clerkOrgId: "org_batch_empty" });
+      const org = await insertTestOrg({ externalOrgId: "org_batch_empty" });
       const campaign = await insertTestCampaign(org.id, { appId: "mcpfactory" });
 
       mockGetStatsBudget.mockResolvedValue({ windows: [] });
@@ -158,7 +158,7 @@ describe("Scheduler Endpoints", () => {
     });
 
     it("should handle multiple campaigns in batch", async () => {
-      const org = await insertTestOrg({ clerkOrgId: "org_multi" });
+      const org = await insertTestOrg({ externalOrgId: "org_multi" });
       const c1 = await insertTestCampaign(org.id, { appId: "mcpfactory", status: "ongoing" });
       const c2 = await insertTestCampaign(org.id, { appId: "mcpfactory", status: "stopped" });
 

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -28,7 +28,7 @@ const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 const validBody = {
   name: "Activation Test Campaign",
   workflowName: "sales-email-cold-outreach",
-  clerkOrgId: "org_activation_test",
+  orgId: "org_activation_test",
   parentRunId: crypto.randomUUID(),
   brandUrl: "https://example.com",
   brandId: crypto.randomUUID(),
@@ -56,7 +56,7 @@ describe("Workflow trigger", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send(validBody)
         .expect(201);
 
@@ -70,7 +70,7 @@ describe("Workflow trigger", () => {
         "sales-email-cold-outreach",
         {
           campaignId,
-          clerkOrgId: "org_activation_test",
+          orgId: "org_activation_test",
           appId: "mcpfactory",
         },
       );
@@ -82,7 +82,7 @@ describe("Workflow trigger", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send(validBody)
         .expect(201);
 
@@ -97,7 +97,7 @@ describe("Workflow trigger", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send(validBody)
         .expect(201);
 
@@ -107,7 +107,7 @@ describe("Workflow trigger", () => {
       await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send({ status: "stop" })
         .expect(200);
 
@@ -118,7 +118,7 @@ describe("Workflow trigger", () => {
       const activateRes = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send({ status: "activate", parentRunId: crypto.randomUUID() })
         .expect(200);
 
@@ -132,7 +132,7 @@ describe("Workflow trigger", () => {
         "sales-email-cold-outreach",
         {
           campaignId,
-          clerkOrgId: "org_activation_test",
+          orgId: "org_activation_test",
           appId: "mcpfactory",
         },
       );
@@ -142,7 +142,7 @@ describe("Workflow trigger", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send(validBody)
         .expect(201);
 
@@ -156,7 +156,7 @@ describe("Workflow trigger", () => {
       await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send({ status: "stop" })
         .expect(200);
 
@@ -169,7 +169,7 @@ describe("Workflow trigger", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send(validBody)
         .expect(201);
 
@@ -183,7 +183,7 @@ describe("Workflow trigger", () => {
       await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send({ name: "Updated Name" })
         .expect(200);
 
@@ -196,7 +196,7 @@ describe("Workflow trigger", () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send(validBody)
         .expect(201);
 
@@ -206,7 +206,7 @@ describe("Workflow trigger", () => {
       await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send({ status: "stop" })
         .expect(200);
 
@@ -215,7 +215,7 @@ describe("Workflow trigger", () => {
       const activateRes = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
-        .set("x-clerk-org-id", "org_activation_test")
+        .set("x-org-id", "org_activation_test")
         .send({ status: "activate", parentRunId: crypto.randomUUID() })
         .expect(200);
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,7 @@
 import { beforeAll, afterAll, vi } from "vitest";
 
 process.env.NODE_ENV = "test";
-process.env.CAMPAIGN_SERVICE_DATABASE_URL = process.env.CAMPAIGN_SERVICE_DATABASE_URL || "postgresql://test:test@localhost/test";
+process.env.CAMPAIGN_SERVICE_DATABASE_URL = process.env.CAMPAIGN_SERVICE_DATABASE_URL || "postgresql://test:test@localhost/campaign_test";
 process.env.SERVICE_SECRET_KEY = "test-service-secret";
 process.env.RUNS_SERVICE_URL = "https://runs.mcpfactory.org";
 process.env.RUNS_SERVICE_API_KEY = "test-api-key";

--- a/tests/unit/campaign.test.ts
+++ b/tests/unit/campaign.test.ts
@@ -10,7 +10,7 @@ describe("Campaign model", () => {
   it("should define campaign interface", () => {
     const campaign = {
       id: "camp_123",
-      clerkOrgId: "org_456",
+      orgId: "org_456",
       name: "Q1 Outreach",
       status: "active",
       dailyBudgetUsd: 10,

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -46,7 +46,7 @@ import { runGateChecks, type GateCheckInput } from "../../src/lib/gate-check.js"
 function makeCampaign(overrides: Partial<GateCheckInput> = {}): GateCheckInput {
   return {
     campaignId: "campaign-1",
-    clerkOrgId: "org-1",
+    orgId: "org-1",
     appId: "mcpfactory",
     brandId: "brand-1",
     status: "ongoing",
@@ -214,7 +214,7 @@ describe("Gate Check", () => {
 
       expect(mockGetStatsBudget).toHaveBeenCalledWith(
         expect.objectContaining({
-          clerkOrgId: "org-1",
+          orgId: "org-1",
           appId: "mcpfactory",
           campaignId: "campaign-1",
           windows: expect.arrayContaining([

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -22,7 +22,7 @@ describe("Workflow module", () => {
       const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
       await executeCampaignWorkflow("sales-email-cold-outreach", {
         campaignId: "campaign-1",
-        clerkOrgId: "org_test",
+        orgId: "org_test",
         appId: "mcpfactory",
       });
 
@@ -36,7 +36,7 @@ describe("Workflow module", () => {
       expect(body.orgId).toBe("org_test");
       expect(body.inputs).toEqual({
         campaignId: "campaign-1",
-        clerkOrgId: "org_test",
+        orgId: "org_test",
       });
     });
 
@@ -51,7 +51,7 @@ describe("Workflow module", () => {
       await expect(
         executeCampaignWorkflow("sales-email-cold-outreach", {
           campaignId: "campaign-1",
-          clerkOrgId: "org_test",
+          orgId: "org_test",
           appId: "mcpfactory",
         })
       ).resolves.not.toThrow();
@@ -65,7 +65,7 @@ describe("Workflow module", () => {
       await expect(
         executeCampaignWorkflow("any-workflow", {
           campaignId: "campaign-1",
-          clerkOrgId: "org_test",
+          orgId: "org_test",
           appId: "mcpfactory",
         })
       ).resolves.not.toThrow();


### PR DESCRIPTION
## Summary
- Replace Clerk IDs with client-service UUIDs as shared identifiers between backend services
- Rename API fields (`clerkOrgId` → `orgId`, `clerkUserId` → `userId`), headers (`x-clerk-org-id` → `x-org-id`), and DB columns (`clerk_org_id` → `org_id`)
- Fix bug in `/start-run` where local FK UUID was incorrectly passed as `clerkUserId` to runs-service — now looks up the user's external ID
- Add one-shot data migration script (`scripts/migrate-clerk-to-client-ids.ts`) to resolve existing Clerk IDs via client-service

## Deployment sequence
1. Run DB migration 0018 (column rename — instant, metadata-only)
2. Run `scripts/migrate-clerk-to-client-ids.ts` to resolve Clerk IDs → client-service UUIDs
3. Deploy new code
4. Coordinate with calling services to send new headers/body fields

## Test plan
- [x] All 105 tests pass (10 test files)
- [x] TypeScript builds cleanly
- [x] Zero `clerk` references remaining in `src/` and `tests/`
- [x] OpenAPI spec regenerated with updated field names
- [ ] Coordinate with workflow-service to update DAG input field names (`clerkOrgId` → `orgId`)
- [ ] Coordinate with runs-service to accept `orgId`/`userId` params

🤖 Generated with [Claude Code](https://claude.com/claude-code)