### PR TITLE
feat: auto-resume campaigns after temporal budget resets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ const openapiPath = join(__dirname, "..", "openapi.json");
 import healthRoutes from "./routes/health.js";
 import campaignsRoutes from "./routes/campaigns.js";
 import internalRoutes from "./routes/internal.js";
+import { startScheduler } from "./lib/scheduler.js";
 const app = express();
 const PORT = process.env.PORT || 3003;
 
@@ -62,6 +63,7 @@ if (process.env.NODE_ENV !== "test") {
   migrate(db, { migrationsFolder: "./drizzle" })
     .then(() => {
       console.log("[Campaign Service] Migrations complete");
+      startScheduler();
       app.listen(Number(PORT), "::", () => {
         console.log(`[Campaign Service] Running on port ${PORT}`);
       });

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -23,6 +23,7 @@ export interface GateCheckResult {
   allowed: boolean;
   reason?: string;
   autoStopped?: boolean;
+  toResumeAt?: Date;
 }
 
 export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheckResult> {
@@ -65,20 +66,20 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   }
 
   // Build windows for configured budgets only
-  const budgetLimits: Array<{ limit: string; label: string; autoStop: boolean }> = [];
+  const budgetLimits: Array<{ limit: string; label: string; autoStop: boolean; resumeAt?: Date }> = [];
   const windows: BudgetWindow[] = [];
 
   if (campaign.maxBudgetDailyUsd) {
     windows.push({ label: "daily", since: startOfToday().toISOString() });
-    budgetLimits.push({ limit: campaign.maxBudgetDailyUsd, label: "daily", autoStop: false });
+    budgetLimits.push({ limit: campaign.maxBudgetDailyUsd, label: "daily", autoStop: false, resumeAt: nextDayStart() });
   }
   if (campaign.maxBudgetWeeklyUsd) {
     windows.push({ label: "weekly", since: daysAgo(7).toISOString() });
-    budgetLimits.push({ limit: campaign.maxBudgetWeeklyUsd, label: "weekly", autoStop: false });
+    budgetLimits.push({ limit: campaign.maxBudgetWeeklyUsd, label: "weekly", autoStop: false, resumeAt: nextWeekStart() });
   }
   if (campaign.maxBudgetMonthlyUsd) {
     windows.push({ label: "monthly", since: startOfMonth().toISOString() });
-    budgetLimits.push({ limit: campaign.maxBudgetMonthlyUsd, label: "monthly", autoStop: false });
+    budgetLimits.push({ limit: campaign.maxBudgetMonthlyUsd, label: "monthly", autoStop: false, resumeAt: nextMonthStart() });
   }
   if (campaign.maxBudgetTotalUsd) {
     windows.push({ label: "total" });
@@ -103,7 +104,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
         await autoStopCampaign(campaign.campaignId);
         return { allowed: false, reason: "Total budget exceeded", autoStopped: true };
       }
-      return { allowed: false, reason: `${budgetLimit.label} budget exceeded` };
+      return { allowed: false, reason: `${budgetLimit.label} budget exceeded`, toResumeAt: budgetLimit.resumeAt };
     }
   }
 
@@ -193,6 +194,30 @@ function daysAgo(n: number): Date {
 
 function startOfMonth(): Date {
   const d = new Date();
+  d.setDate(1);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function nextDayStart(): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function nextWeekStart(): Date {
+  const d = new Date();
+  const dayOfWeek = d.getDay(); // 0=Sun, 1=Mon...
+  const daysUntilMonday = dayOfWeek === 0 ? 1 : 8 - dayOfWeek;
+  d.setDate(d.getDate() + daysUntilMonday);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function nextMonthStart(): Date {
+  const d = new Date();
+  d.setMonth(d.getMonth() + 1);
   d.setDate(1);
   d.setHours(0, 0, 0, 0);
   return d;

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -1,0 +1,72 @@
+import { db } from "../db/index.js";
+import { campaigns, orgs } from "../db/schema.js";
+import { eq, and, lte, isNotNull } from "drizzle-orm";
+import { executeCampaignWorkflow } from "./workflows.js";
+
+const SCHEDULER_INTERVAL_MS = 60_000; // 1 minute
+
+/**
+ * Find all ongoing campaigns whose toResumeAt has passed,
+ * clear the flag, and re-trigger their workflow.
+ */
+export async function resumeDueCampaigns(): Promise<number> {
+  const now = new Date();
+
+  const dueCampaigns = await db
+    .select({
+      id: campaigns.id,
+      workflowName: campaigns.workflowName,
+      appId: campaigns.appId,
+      externalOrgId: orgs.externalOrgId,
+    })
+    .from(campaigns)
+    .innerJoin(orgs, eq(campaigns.orgId, orgs.id))
+    .where(
+      and(
+        eq(campaigns.status, "ongoing"),
+        isNotNull(campaigns.toResumeAt),
+        lte(campaigns.toResumeAt, now),
+      ),
+    );
+
+  if (dueCampaigns.length === 0) return 0;
+
+  console.log(`[Scheduler] Found ${dueCampaigns.length} campaign(s) due for resume`);
+
+  for (const campaign of dueCampaigns) {
+    try {
+      // Clear toResumeAt before re-triggering (prevent double-fire)
+      await db.update(campaigns)
+        .set({ toResumeAt: null, updatedAt: new Date() })
+        .where(eq(campaigns.id, campaign.id));
+
+      console.log(`[Scheduler] Re-triggering campaign ${campaign.id} (workflow=${campaign.workflowName})`);
+      executeCampaignWorkflow(campaign.workflowName, {
+        campaignId: campaign.id,
+        orgId: campaign.externalOrgId,
+        appId: campaign.appId || "",
+      }).catch((err) => {
+        console.error(`[Scheduler] Failed to re-trigger campaign ${campaign.id}:`, err);
+      });
+    } catch (err) {
+      console.error(`[Scheduler] Error processing campaign ${campaign.id}:`, err);
+    }
+  }
+
+  return dueCampaigns.length;
+}
+
+/**
+ * Start the scheduler interval. Returns a cleanup function.
+ */
+export function startScheduler(): () => void {
+  console.log(`[Scheduler] Starting (interval=${SCHEDULER_INTERVAL_MS}ms)`);
+
+  const handle = setInterval(() => {
+    resumeDueCampaigns().catch((err) => {
+      console.error("[Scheduler] Unhandled error:", err);
+    });
+  }, SCHEDULER_INTERVAL_MS);
+
+  return () => clearInterval(handle);
+}

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -65,6 +65,14 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
 
     if (!result.allowed) {
       console.warn(`[Gate Check] BLOCKED: reason=${result.reason}, autoStopped=${result.autoStopped}`);
+
+      // Save toResumeAt so the scheduler can re-trigger when the budget window resets
+      if (result.toResumeAt) {
+        await db.update(campaigns)
+          .set({ toResumeAt: result.toResumeAt, updatedAt: new Date() })
+          .where(eq(campaigns.id, campaignId));
+        console.log(`[Gate Check] Set toResumeAt=${result.toResumeAt.toISOString()} for campaign ${campaignId}`);
+      }
     } else {
       console.log(`[Gate Check] PASSED for campaign ${campaignId}`);
     }

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -57,6 +57,7 @@ export async function insertTestCampaign(
     targetAudience?: string;
     targetOutcome?: string;
     valueForTarget?: string;
+    toResumeAt?: Date | null;
   } = {}
 ) {
   const [campaign] = await db
@@ -78,6 +79,7 @@ export async function insertTestCampaign(
       targetAudience: data.targetAudience || null,
       targetOutcome: data.targetOutcome || null,
       valueForTarget: data.valueForTarget || null,
+      toResumeAt: data.toResumeAt ?? null,
     })
     .returning();
   return campaign;

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -31,6 +31,9 @@ vi.mock("../../src/lib/gate-check.js", () => ({
 }));
 
 import app from "../../src/index.js";
+import { db } from "../../src/db/index.js";
+import { campaigns } from "../../src/db/schema.js";
+import { eq } from "drizzle-orm";
 import { cleanTestData, closeDb, insertTestOrg, insertTestCampaign } from "../helpers/test-db.js";
 
 const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
@@ -154,6 +157,60 @@ describe("Pipeline routes", () => {
 
       expect(res.body.allowed).toBe(false);
       expect(res.body.autoStopped).toBe(true);
+    });
+
+    it("should save toResumeAt to DB when gate-check returns it", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(0, 0, 0, 0);
+
+      mockGateChecks.mockResolvedValue({
+        allowed: false,
+        reason: "daily budget exceeded",
+        toResumeAt: tomorrow,
+      });
+
+      await request(app)
+        .post("/gate-check")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .expect(200);
+
+      // Verify toResumeAt was saved to the DB
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.toResumeAt).not.toBeNull();
+      expect(new Date(updated!.toResumeAt!).getTime()).toBe(tomorrow.getTime());
+    });
+
+    it("should NOT save toResumeAt when gate-check does not return it", async () => {
+      const campaign = await insertTestCampaign(org.id, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      mockGateChecks.mockResolvedValue({
+        allowed: false,
+        reason: "Total budget exceeded",
+        autoStopped: true,
+      });
+
+      await request(app)
+        .post("/gate-check")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .expect(200);
+
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.toResumeAt).toBeNull();
     });
 
     it("should pass campaign data to runGateChecks", async () => {

--- a/tests/integration/scheduler-resume.test.ts
+++ b/tests/integration/scheduler-resume.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+
+const mockExecute = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/lib/workflows.js", () => ({
+  executeCampaignWorkflow: mockExecute,
+}));
+
+vi.mock("@mcpfactory/runs-client", () => ({
+  listRuns: vi.fn().mockResolvedValue({ runs: [] }),
+  createRun: vi.fn(),
+  updateRun: vi.fn(),
+  getStatsBudget: vi.fn(),
+}));
+
+import { db } from "../../src/db/index.js";
+import { campaigns } from "../../src/db/schema.js";
+import { eq } from "drizzle-orm";
+import { cleanTestData, closeDb, insertTestOrg, insertTestCampaign } from "../helpers/test-db.js";
+import { resumeDueCampaigns } from "../../src/lib/scheduler.js";
+
+describe("Scheduler - resumeDueCampaigns (integration)", () => {
+  let org: { id: string; externalOrgId: string };
+
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue(undefined);
+    org = await insertTestOrg({ externalOrgId: "scheduler-test-org" });
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("should not trigger anything when no campaigns are due", async () => {
+    await insertTestCampaign(org.id, {
+      status: "ongoing",
+      appId: "mcpfactory",
+    });
+
+    const count = await resumeDueCampaigns();
+    expect(count).toBe(0);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("should resume campaign whose toResumeAt is in the past", async () => {
+    const pastDate = new Date(Date.now() - 60_000); // 1 minute ago
+    const campaign = await insertTestCampaign(org.id, {
+      status: "ongoing",
+      appId: "mcpfactory",
+      toResumeAt: pastDate,
+    });
+
+    const count = await resumeDueCampaigns();
+    expect(count).toBe(1);
+
+    // Should have cleared toResumeAt
+    const updated = await db.query.campaigns.findFirst({
+      where: eq(campaigns.id, campaign.id),
+    });
+    expect(updated!.toResumeAt).toBeNull();
+
+    // Should have triggered workflow
+    expect(mockExecute).toHaveBeenCalledWith(
+      "sales-email-cold-outreach",
+      {
+        campaignId: campaign.id,
+        orgId: org.externalOrgId,
+        appId: "mcpfactory",
+      },
+    );
+  });
+
+  it("should NOT resume campaign whose toResumeAt is in the future", async () => {
+    const futureDate = new Date(Date.now() + 3_600_000); // 1 hour from now
+    await insertTestCampaign(org.id, {
+      status: "ongoing",
+      appId: "mcpfactory",
+      toResumeAt: futureDate,
+    });
+
+    const count = await resumeDueCampaigns();
+    expect(count).toBe(0);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("should NOT resume stopped campaigns even with past toResumeAt", async () => {
+    const pastDate = new Date(Date.now() - 60_000);
+    await insertTestCampaign(org.id, {
+      status: "stopped",
+      appId: "mcpfactory",
+      toResumeAt: pastDate,
+    });
+
+    const count = await resumeDueCampaigns();
+    expect(count).toBe(0);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("should resume multiple due campaigns", async () => {
+    const pastDate = new Date(Date.now() - 60_000);
+
+    await insertTestCampaign(org.id, {
+      name: "Campaign A",
+      status: "ongoing",
+      appId: "mcpfactory",
+      toResumeAt: pastDate,
+    });
+    await insertTestCampaign(org.id, {
+      name: "Campaign B",
+      status: "ongoing",
+      appId: "mcpfactory",
+      toResumeAt: pastDate,
+    });
+
+    const count = await resumeDueCampaigns();
+    expect(count).toBe(2);
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+  });
+
+  it("should use empty string for appId when campaign has no appId", async () => {
+    const pastDate = new Date(Date.now() - 60_000);
+    await insertTestCampaign(org.id, {
+      status: "ongoing",
+      appId: undefined,
+      toResumeAt: pastDate,
+    });
+
+    await resumeDueCampaigns();
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ appId: "" }),
+    );
+  });
+});

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -41,7 +41,7 @@ vi.mock("drizzle-orm", () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { runGateChecks, type GateCheckInput } from "../../src/lib/gate-check.js";
+import { runGateChecks, nextDayStart, nextWeekStart, nextMonthStart, type GateCheckInput } from "../../src/lib/gate-check.js";
 
 function makeCampaign(overrides: Partial<GateCheckInput> = {}): GateCheckInput {
   return {
@@ -340,6 +340,111 @@ describe("Gate Check", () => {
 
       const result = await runGateChecks(makeCampaign());
       expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe("toResumeAt on temporal budget exceeded", () => {
+    it("should return toResumeAt when daily budget is exceeded", async () => {
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "daily", totalCostInUsdCents: "1500" }])
+      );
+
+      const result = await runGateChecks(makeCampaign({ maxBudgetDailyUsd: "10.00" }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("daily budget exceeded");
+      expect(result.toResumeAt).toBeInstanceOf(Date);
+      // Should be tomorrow at midnight
+      const expected = nextDayStart();
+      expect(result.toResumeAt!.getTime()).toBe(expected.getTime());
+    });
+
+    it("should return toResumeAt when weekly budget is exceeded", async () => {
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "weekly", totalCostInUsdCents: "6000" }])
+      );
+
+      const result = await runGateChecks(makeCampaign({
+        maxBudgetDailyUsd: null,
+        maxBudgetWeeklyUsd: "50.00",
+      }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("weekly budget exceeded");
+      expect(result.toResumeAt).toBeInstanceOf(Date);
+      const expected = nextWeekStart();
+      expect(result.toResumeAt!.getTime()).toBe(expected.getTime());
+    });
+
+    it("should return toResumeAt when monthly budget is exceeded", async () => {
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "monthly", totalCostInUsdCents: "11000" }])
+      );
+
+      const result = await runGateChecks(makeCampaign({
+        maxBudgetDailyUsd: null,
+        maxBudgetMonthlyUsd: "100.00",
+      }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("monthly budget exceeded");
+      expect(result.toResumeAt).toBeInstanceOf(Date);
+      const expected = nextMonthStart();
+      expect(result.toResumeAt!.getTime()).toBe(expected.getTime());
+    });
+
+    it("should NOT return toResumeAt when total budget is exceeded (auto-stop instead)", async () => {
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "total", totalCostInUsdCents: "5500" }])
+      );
+
+      const result = await runGateChecks(makeCampaign({
+        maxBudgetDailyUsd: null,
+        maxBudgetTotalUsd: "50.00",
+      }));
+      expect(result.allowed).toBe(false);
+      expect(result.autoStopped).toBe(true);
+      expect(result.toResumeAt).toBeUndefined();
+    });
+
+    it("should return earliest toResumeAt when daily exceeds before weekly", async () => {
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([
+          { label: "daily", totalCostInUsdCents: "1500" },
+          { label: "weekly", totalCostInUsdCents: "1500" },
+        ])
+      );
+
+      const result = await runGateChecks(makeCampaign({
+        maxBudgetDailyUsd: "10.00",
+        maxBudgetWeeklyUsd: "50.00",
+      }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("daily budget exceeded");
+      // Daily is checked first, so toResumeAt should be next day
+      const expected = nextDayStart();
+      expect(result.toResumeAt!.getTime()).toBe(expected.getTime());
+    });
+  });
+
+  describe("nextDayStart / nextWeekStart / nextMonthStart helpers", () => {
+    it("nextDayStart returns tomorrow at midnight", () => {
+      const result = nextDayStart();
+      expect(result.getHours()).toBe(0);
+      expect(result.getMinutes()).toBe(0);
+      expect(result.getSeconds()).toBe(0);
+      expect(result.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it("nextWeekStart returns next Monday at midnight", () => {
+      const result = nextWeekStart();
+      expect(result.getDay()).toBe(1); // Monday
+      expect(result.getHours()).toBe(0);
+      expect(result.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it("nextMonthStart returns 1st of next month at midnight", () => {
+      const result = nextMonthStart();
+      expect(result.getDate()).toBe(1);
+      expect(result.getHours()).toBe(0);
+      expect(result.getTime()).toBeGreaterThan(Date.now());
     });
   });
 });

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  mockExecuteCampaignWorkflow,
+  mockDbValues,
+  mockDbUpdate,
+  mockSet,
+  mockWhere,
+} = vi.hoisted(() => {
+  const mockWhere = vi.fn().mockResolvedValue(undefined);
+  const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockDbUpdate = vi.fn().mockReturnValue({ set: mockSet });
+  const mockDbValues: Array<{
+    id: string;
+    workflowName: string;
+    appId: string | null;
+    externalOrgId: string;
+  }> = [];
+
+  return {
+    mockExecuteCampaignWorkflow: vi.fn(),
+    mockDbValues,
+    mockDbUpdate,
+    mockSet,
+    mockWhere,
+  };
+});
+
+vi.mock("../../src/lib/workflows.js", () => ({
+  executeCampaignWorkflow: mockExecuteCampaignWorkflow,
+}));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => mockDbValues),
+        }),
+      }),
+    }),
+    update: mockDbUpdate,
+  },
+}));
+
+vi.mock("../../src/db/schema.js", () => ({
+  campaigns: {
+    id: "id",
+    status: "status",
+    toResumeAt: "to_resume_at",
+    workflowName: "workflow_name",
+    appId: "app_id",
+    orgId: "org_id",
+    updatedAt: "updated_at",
+  },
+  orgs: {
+    id: "id",
+    externalOrgId: "org_id",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  lte: vi.fn(),
+  isNotNull: vi.fn(),
+}));
+
+import { resumeDueCampaigns } from "../../src/lib/scheduler.js";
+
+describe("Scheduler - resumeDueCampaigns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbValues.length = 0;
+    mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
+  });
+
+  it("should return 0 when no campaigns are due", async () => {
+    const count = await resumeDueCampaigns();
+    expect(count).toBe(0);
+    expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("should re-trigger due campaigns and clear toResumeAt", async () => {
+    mockDbValues.push({
+      id: "campaign-1",
+      workflowName: "sales-email-cold-outreach",
+      appId: "mcpfactory",
+      externalOrgId: "org-ext-1",
+    });
+
+    const count = await resumeDueCampaigns();
+
+    expect(count).toBe(1);
+    expect(mockDbUpdate).toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ toResumeAt: null }),
+    );
+    expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
+      "sales-email-cold-outreach",
+      {
+        campaignId: "campaign-1",
+        orgId: "org-ext-1",
+        appId: "mcpfactory",
+      },
+    );
+  });
+
+  it("should handle multiple due campaigns", async () => {
+    mockDbValues.push(
+      {
+        id: "campaign-1",
+        workflowName: "sales-email-cold-outreach",
+        appId: "mcpfactory",
+        externalOrgId: "org-ext-1",
+      },
+      {
+        id: "campaign-2",
+        workflowName: "pr-email-cold-outreach",
+        appId: "mcpfactory",
+        externalOrgId: "org-ext-2",
+      },
+    );
+
+    const count = await resumeDueCampaigns();
+
+    expect(count).toBe(2);
+    expect(mockExecuteCampaignWorkflow).toHaveBeenCalledTimes(2);
+  });
+
+  it("should use empty string when appId is null", async () => {
+    mockDbValues.push({
+      id: "campaign-1",
+      workflowName: "sales-email-cold-outreach",
+      appId: null,
+      externalOrgId: "org-ext-1",
+    });
+
+    await resumeDueCampaigns();
+
+    expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
+      "sales-email-cold-outreach",
+      expect.objectContaining({ appId: "" }),
+    );
+  });
+
+  it("should continue processing other campaigns if one fails", async () => {
+    mockDbValues.push(
+      {
+        id: "campaign-1",
+        workflowName: "sales-email-cold-outreach",
+        appId: "mcpfactory",
+        externalOrgId: "org-ext-1",
+      },
+      {
+        id: "campaign-2",
+        workflowName: "pr-email-cold-outreach",
+        appId: "mcpfactory",
+        externalOrgId: "org-ext-2",
+      },
+    );
+
+    // First update call fails (clearing toResumeAt for campaign-1)
+    mockDbUpdate
+      .mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockRejectedValue(new Error("DB error")),
+        }),
+      })
+      .mockReturnValue({ set: mockSet });
+
+    const count = await resumeDueCampaigns();
+
+    expect(count).toBe(2);
+    expect(mockExecuteCampaignWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
+      "pr-email-cold-outreach",
+      expect.objectContaining({ campaignId: "campaign-2" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- When gate-check blocks a campaign due to daily/weekly/monthly budget limits, it now calculates the next window boundary (midnight, next Monday, 1st of month) and writes `toResumeAt` on the campaign
- A scheduler (`setInterval` at 1-min) queries campaigns where `status = ongoing AND to_resume_at <= NOW()`, clears the flag, and re-triggers the workflow
- Total budget exceeded still auto-stops the campaign permanently (no resume)

## Test plan
- [x] Unit tests for `toResumeAt` calculation on daily/weekly/monthly budget exceeded
- [x] Unit tests for `nextDayStart`, `nextWeekStart`, `nextMonthStart` helpers
- [x] Unit tests for scheduler `resumeDueCampaigns` (0 due, 1 due, multiple, null appId, error resilience)
- [x] Integration test: gate-check saves `toResumeAt` to DB
- [x] Integration test: gate-check does NOT save `toResumeAt` on total budget (auto-stop)
- [x] Integration test: scheduler resumes past-due campaigns, skips future/stopped ones
- [x] All 126 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)