### PR TITLE
Remove appId, keySource, and local identity tables

### DIFF
--- a/drizzle/0019_remove_appid_keysource_identity.sql
+++ b/drizzle/0019_remove_appid_keysource_identity.sql
@@ -1,0 +1,47 @@
+-- Migration: Remove appId, keySource, and local identity tables
+-- This migration:
+-- 1. Backfills campaigns.org_id with the external org ID from the orgs lookup table
+-- 2. Backfills campaigns.created_by_user_id with the external user ID from the users lookup table
+-- 3. Converts org_id and created_by_user_id columns from uuid to text
+-- 4. Drops app_id and key_source columns
+-- 5. Drops the local orgs and users identity tables
+
+-- Step 1: Backfill org_id with external org ID
+UPDATE "campaigns"
+SET "org_id" = (
+  SELECT "orgs"."org_id"
+  FROM "orgs"
+  WHERE "orgs"."id" = "campaigns"."org_id"::uuid
+)
+WHERE EXISTS (
+  SELECT 1 FROM "orgs" WHERE "orgs"."id" = "campaigns"."org_id"::uuid
+);
+
+-- Step 2: Backfill created_by_user_id with external user ID
+UPDATE "campaigns"
+SET "created_by_user_id" = (
+  SELECT "users"."user_id"
+  FROM "users"
+  WHERE "users"."id" = "campaigns"."created_by_user_id"::uuid
+)
+WHERE "created_by_user_id" IS NOT NULL
+AND EXISTS (
+  SELECT 1 FROM "users" WHERE "users"."id" = "campaigns"."created_by_user_id"::uuid
+);
+
+-- Step 3: Drop FK constraints and change column types
+ALTER TABLE "campaigns" DROP CONSTRAINT IF EXISTS "campaigns_org_id_orgs_id_fk";
+ALTER TABLE "campaigns" DROP CONSTRAINT IF EXISTS "campaigns_created_by_user_id_users_id_fk";
+ALTER TABLE "campaigns" ALTER COLUMN "org_id" TYPE text;
+ALTER TABLE "campaigns" ALTER COLUMN "created_by_user_id" TYPE text;
+
+-- Step 4: Drop app_id column and its index
+DROP INDEX IF EXISTS "idx_campaigns_app_id";
+ALTER TABLE "campaigns" DROP COLUMN IF EXISTS "app_id";
+
+-- Step 5: Drop key_source column
+ALTER TABLE "campaigns" DROP COLUMN IF EXISTS "key_source";
+
+-- Step 6: Drop local identity tables
+DROP TABLE IF EXISTS "users";
+DROP TABLE IF EXISTS "orgs";

--- a/openapi.json
+++ b/openapi.json
@@ -28,13 +28,11 @@
             "format": "uuid"
           },
           "orgId": {
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           "createdByUserId": {
             "type": "string",
-            "nullable": true,
-            "format": "uuid"
+            "nullable": true
           },
           "name": {
             "type": "string"
@@ -55,10 +53,6 @@
             "type": "string",
             "nullable": true,
             "format": "uuid"
-          },
-          "appId": {
-            "type": "string",
-            "nullable": true
           },
           "targetAudience": {
             "type": "string",
@@ -100,9 +94,6 @@
             "type": "string",
             "nullable": true
           },
-          "keySource": {
-            "type": "string"
-          },
           "status": {
             "type": "string"
           },
@@ -138,7 +129,6 @@
           "brandUrl",
           "brandId",
           "parentRunId",
-          "appId",
           "targetAudience",
           "targetOutcome",
           "valueForTarget",
@@ -149,7 +139,6 @@
           "maxLeads",
           "startDate",
           "endDate",
-          "keySource",
           "status",
           "toResumeAt",
           "notifyFrequency",
@@ -197,10 +186,6 @@
             "type": "string",
             "format": "uuid"
           },
-          "appId": {
-            "type": "string",
-            "minLength": 1
-          },
           "targetAudience": {
             "type": "string"
           },
@@ -233,15 +218,6 @@
           "endDate": {
             "type": "string"
           },
-          "keySource": {
-            "type": "string",
-            "enum": [
-              "platform",
-              "app",
-              "byok"
-            ],
-            "description": "How downstream services resolve API keys. \"platform\" = platform-owned keys (no appId needed), \"app\" = client app keys (per appId), \"byok\" = end user's own keys."
-          },
           "notifyFrequency": {
             "type": "string"
           },
@@ -259,10 +235,8 @@
           "parentRunId",
           "brandUrl",
           "brandId",
-          "appId",
           "targetOutcome",
-          "valueForTarget",
-          "keySource"
+          "valueForTarget"
         ]
       },
       "UpdateCampaignBody": {
@@ -321,14 +295,6 @@
               "stop"
             ]
           },
-          "keySource": {
-            "type": "string",
-            "enum": [
-              "platform",
-              "app",
-              "byok"
-            ]
-          },
           "notifyFrequency": {
             "type": "string"
           },
@@ -336,9 +302,6 @@
             "type": "string"
           },
           "notifyDestination": {
-            "type": "string"
-          },
-          "appId": {
             "type": "string"
           }
         }
@@ -383,9 +346,6 @@
         "type": "object",
         "properties": {
           "orgId": {
-            "type": "string"
-          },
-          "appId": {
             "type": "string"
           },
           "brandId": {
@@ -469,9 +429,6 @@
           "brandDomain": {
             "type": "string"
           },
-          "appId": {
-            "type": "string"
-          },
           "workflowName": {
             "type": "string"
           },
@@ -493,14 +450,6 @@
             "additionalProperties": {
               "nullable": true
             }
-          },
-          "keySource": {
-            "type": "string",
-            "enum": [
-              "platform",
-              "app",
-              "byok"
-            ]
           }
         },
         "required": [
@@ -510,13 +459,11 @@
           "brandId",
           "brandUrl",
           "brandDomain",
-          "appId",
           "workflowName",
           "userId",
           "targetOutcome",
           "valueForTarget",
-          "searchParams",
-          "keySource"
+          "searchParams"
         ]
       },
       "StartRunBody": {

--- a/packages/runs-client/src/index.ts
+++ b/packages/runs-client/src/index.ts
@@ -13,7 +13,6 @@ export interface Run {
   parentRunId: string | null;
   organizationId: string;
   userId: string | null;
-  appId: string;
   brandId: string | null;
   campaignId: string | null;
   serviceName: string;
@@ -27,7 +26,6 @@ export interface Run {
 
 export interface CreateRunParams {
   orgId: string;
-  appId: string;
   serviceName: string;
   taskName: string;
   userId?: string;
@@ -40,7 +38,6 @@ export interface CreateRunParams {
 export interface ListRunsParams {
   orgId: string;
   userId?: string;
-  appId?: string;
   brandId?: string;
   campaignId?: string;
   serviceName?: string;
@@ -67,7 +64,6 @@ export interface BudgetWindowResult {
 
 export interface StatsBudgetParams {
   orgId: string;
-  appId: string;
   campaignId?: string;
   brandId?: string;
   workflowName?: string;
@@ -139,7 +135,6 @@ export async function listRuns(
   const searchParams = new URLSearchParams();
   searchParams.set("orgId", params.orgId);
   if (params.userId) searchParams.set("userId", params.userId);
-  if (params.appId) searchParams.set("appId", params.appId);
   if (params.brandId) searchParams.set("brandId", params.brandId);
   if (params.campaignId) searchParams.set("campaignId", params.campaignId);
   if (params.serviceName) searchParams.set("serviceName", params.serviceName);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,44 +1,13 @@
-import { pgTable, uuid, text, timestamp, uniqueIndex, index, date, decimal, integer } from "drizzle-orm/pg-core";
-
-// Local users table (maps to client-service)
-export const users = pgTable(
-  "users",
-  {
-    id: uuid("id").primaryKey().defaultRandom(),
-    externalUserId: text("user_id").notNull().unique(),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => [
-    uniqueIndex("idx_users_user_id").on(table.externalUserId),
-  ]
-);
-
-// Local orgs table (maps to client-service)
-export const orgs = pgTable(
-  "orgs",
-  {
-    id: uuid("id").primaryKey().defaultRandom(),
-    externalOrgId: text("org_id").notNull().unique(),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => [
-    uniqueIndex("idx_orgs_org_id").on(table.externalOrgId),
-  ]
-);
+import { pgTable, text, timestamp, index, date, decimal, integer } from "drizzle-orm/pg-core";
 
 // Campaigns table
 export const campaigns = pgTable(
   "campaigns",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
-    orgId: uuid("org_id")
-      .notNull()
-      .references(() => orgs.id, { onDelete: "cascade" }),
-    createdByUserId: uuid("created_by_user_id")
-      .references(() => users.id),  // Optional - MCP calls don't have user context
-    
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    orgId: text("org_id").notNull(),
+    createdByUserId: text("created_by_user_id"),
+
     name: text("name").notNull(),
 
     // Workflow name — resolved by workflow-service, passed at campaign creation
@@ -46,17 +15,13 @@ export const campaigns = pgTable(
 
     // Brand URL - used to identify which brand this campaign promotes
     brandUrl: text("brand_url"),
-    
+
     // Brand ID from brand-service (set by worker after brand-upsert)
     // Nullable initially, populated when brand is created/found in brand-service
-    brandId: uuid("brand_id"),
+    brandId: text("brand_id"),
 
     // Parent run ID from api-service — root of the cost tree for this campaign's runs
-    parentRunId: uuid("parent_run_id"),
-
-    // App ID from external app/product service
-    // Nullable, populated when campaign is associated with an app
-    appId: text("app_id"),
+    parentRunId: text("parent_run_id"),
 
     // Free-text target audience description (e.g. "CEOs at SaaS startups in the US")
     targetAudience: text("target_audience"),
@@ -79,34 +44,23 @@ export const campaigns = pgTable(
     // Scheduling
     startDate: date("start_date"),
     endDate: date("end_date"),
-    
-    // Key source: how downstream services resolve API keys ('byok' = org's own keys, 'app' = platform keys)
-    keySource: text("key_source").notNull().default("byok"),
 
     // Status: 'ongoing' or 'stopped'
     status: text("status").notNull().default("ongoing"),
     toResumeAt: timestamp("to_resume_at", { withTimezone: true }),
-    
-    // Reporting (coming soon - will be required: 'none', 'daily', 'weekly', 'monthly')
-    // reportingFrequency: text("reporting_frequency").notNull(),
-    
+
     // Notifications (legacy - to be replaced by reportingFrequency)
     notifyFrequency: text("notify_frequency"),  // 'daily', 'weekly', 'per_reply'
     notifyChannel: text("notify_channel"),      // 'email', 'webhook'
     notifyDestination: text("notify_destination"),  // email address or webhook URL
-    
+
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     index("idx_campaigns_org").on(table.orgId),
-    index("idx_campaigns_app_id").on(table.appId),
   ]
 );
 
-export type User = typeof users.$inferSelect;
-export type NewUser = typeof users.$inferInsert;
-export type Org = typeof orgs.$inferSelect;
-export type NewOrg = typeof orgs.$inferInsert;
 export type Campaign = typeof campaigns.$inferSelect;
 export type NewCampaign = typeof campaigns.$inferInsert;

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -9,7 +9,6 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 export interface GateCheckInput {
   campaignId: string;
   orgId: string;
-  appId: string;
   brandId: string;
   status: string;
   maxBudgetDailyUsd: string | null;
@@ -35,7 +34,6 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   // Fetch all runs for this campaign (needed for stale cleanup, running check, consecutive failures)
   const { runs } = await listRuns({
     orgId: campaign.orgId,
-    appId: campaign.appId,
     serviceName: "campaign-service",
     taskName: campaign.campaignId,
   });
@@ -89,7 +87,6 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   // Single call to runs-service for all budget windows
   const budgetResult = await getStatsBudget({
     orgId: campaign.orgId,
-    appId: campaign.appId,
     campaignId: campaign.campaignId,
     windows,
   });
@@ -113,7 +110,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     const completedRuns = runs.filter((r: Run) => r.status === "completed");
     let totalServed: number;
     try {
-      const leadStats = await fetchLeadStats(campaign.orgId, campaign.campaignId, campaign.brandId, campaign.appId);
+      const leadStats = await fetchLeadStats(campaign.orgId, campaign.campaignId, campaign.brandId);
       totalServed = Math.max(leadStats.totalServed, completedRuns.length);
     } catch (err: unknown) {
       if (err instanceof Error && "status" in err && (err as { status: number }).status === 404) {
@@ -157,7 +154,6 @@ async function fetchLeadStats(
   orgId: string,
   campaignId: string,
   brandId: string,
-  appId: string,
 ): Promise<{ totalServed: number }> {
   const url = process.env.LEAD_SERVICE_URL;
   const apiKey = process.env.LEAD_SERVICE_API_KEY;
@@ -167,7 +163,6 @@ async function fetchLeadStats(
   const res = await fetch(`${url}/stats?${params}`, {
     headers: {
       "x-api-key": apiKey,
-      "x-app-id": appId,
       "x-org-id": orgId,
     },
   });

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -1,5 +1,5 @@
 import { db } from "../db/index.js";
-import { campaigns, orgs } from "../db/schema.js";
+import { campaigns } from "../db/schema.js";
 import { eq, and, lte, isNotNull } from "drizzle-orm";
 import { executeCampaignWorkflow } from "./workflows.js";
 
@@ -15,12 +15,10 @@ export async function resumeDueCampaigns(): Promise<number> {
   const dueCampaigns = await db
     .select({
       id: campaigns.id,
+      orgId: campaigns.orgId,
       workflowName: campaigns.workflowName,
-      appId: campaigns.appId,
-      externalOrgId: orgs.externalOrgId,
     })
     .from(campaigns)
-    .innerJoin(orgs, eq(campaigns.orgId, orgs.id))
     .where(
       and(
         eq(campaigns.status, "ongoing"),
@@ -43,8 +41,7 @@ export async function resumeDueCampaigns(): Promise<number> {
       console.log(`[Scheduler] Re-triggering campaign ${campaign.id} (workflow=${campaign.workflowName})`);
       executeCampaignWorkflow(campaign.workflowName, {
         campaignId: campaign.id,
-        orgId: campaign.externalOrgId,
-        appId: campaign.appId || "",
+        orgId: campaign.orgId,
       }).catch((err) => {
         console.error(`[Scheduler] Failed to re-trigger campaign ${campaign.id}:`, err);
       });

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -7,12 +7,12 @@
  */
 export async function executeCampaignWorkflow(
   workflowName: string,
-  inputs: { campaignId: string; orgId: string; appId: string },
+  inputs: { campaignId: string; orgId: string },
 ): Promise<void> {
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
 
-  console.log(`[Workflow] executeCampaignWorkflow called: workflowName=${workflowName}, campaignId=${inputs.campaignId}, orgId=${inputs.orgId}, appId=${inputs.appId}`);
+  console.log(`[Workflow] executeCampaignWorkflow called: workflowName=${workflowName}, campaignId=${inputs.campaignId}, orgId=${inputs.orgId}`);
 
   if (!url || !apiKey) {
     console.warn("[Workflow] WORKFLOW_SERVICE_URL or WORKFLOW_SERVICE_API_KEY not set, skipping workflow execution");
@@ -29,7 +29,6 @@ export async function executeCampaignWorkflow(
       "x-api-key": apiKey,
     },
     body: JSON.stringify({
-      appId: inputs.appId,
       orgId: inputs.orgId,
       inputs: {
         campaignId: inputs.campaignId,

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,16 +1,8 @@
 import { Request, Response, NextFunction } from "express";
-import { eq } from "drizzle-orm";
-import { db } from "../db/index.js";
-import { users, orgs } from "../db/schema.js";
-
-// Re-export users for serviceAuth to use
-export { users };
 
 export interface AuthenticatedRequest extends Request {
   userId?: string;
   orgId?: string;
-  externalUserId?: string;
-  externalOrgId?: string;
 }
 
 /**
@@ -18,58 +10,24 @@ export interface AuthenticatedRequest extends Request {
  * Uses x-org-id header to identify org (client-service UUID)
  * Optionally uses x-user-id header to identify user (client-service UUID)
  */
-export async function serviceAuth(
+export function serviceAuth(
   req: AuthenticatedRequest,
   res: Response,
   next: NextFunction
 ) {
-  try {
-    const externalOrgId = req.headers["x-org-id"] as string;
-    const externalUserId = req.headers["x-user-id"] as string | undefined;
+  const orgId = req.headers["x-org-id"] as string;
+  const userId = req.headers["x-user-id"] as string | undefined;
 
-    if (!externalOrgId) {
-      return res.status(400).json({ error: "x-org-id header required" });
-    }
-
-    // Find or create org
-    let org = await db.query.orgs.findFirst({
-      where: eq(orgs.externalOrgId, externalOrgId),
-    });
-
-    if (!org) {
-      const [newOrg] = await db
-        .insert(orgs)
-        .values({ externalOrgId })
-        .returning();
-      org = newOrg;
-    }
-
-    req.orgId = org.id;
-    req.externalOrgId = externalOrgId;
-
-    // Handle optional user context
-    if (externalUserId) {
-      let user = await db.query.users.findFirst({
-        where: eq(users.externalUserId, externalUserId),
-      });
-
-      if (!user) {
-        const [newUser] = await db
-          .insert(users)
-          .values({ externalUserId })
-          .returning();
-        user = newUser;
-      }
-
-      req.userId = user.id;
-      req.externalUserId = externalUserId;
-    }
-
-    next();
-  } catch (error) {
-    console.error("[Campaign Service] Service auth error:", error);
-    return res.status(401).json({ error: "Service authentication failed" });
+  if (!orgId) {
+    return res.status(400).json({ error: "x-org-id header required" });
   }
+
+  req.orgId = orgId;
+  if (userId) {
+    req.userId = userId;
+  }
+
+  next();
 }
 
 /**

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { eq, and, desc, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { campaigns, orgs } from "../db/schema.js";
+import { campaigns } from "../db/schema.js";
 import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { normalizeUrl, extractDomain } from "../lib/domain.js";
@@ -34,11 +34,9 @@ router.get("/campaigns/list", requireApiKey, async (_req, res) => {
         maxBudgetTotalUsd: campaigns.maxBudgetTotalUsd,
         maxLeads: campaigns.maxLeads,
         createdAt: campaigns.createdAt,
-        externalOrgId: orgs.externalOrgId,
         brandUrl: campaigns.brandUrl,
       })
       .from(campaigns)
-      .innerJoin(orgs, eq(campaigns.orgId, orgs.id))
       .orderBy(campaigns.createdAt);
 
     const enrichedCampaigns = allCampaigns.map(c => ({
@@ -64,14 +62,12 @@ router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBu
     const campaignRows = await db
       .select({
         id: campaigns.id,
-        appId: campaigns.appId,
+        orgId: campaigns.orgId,
         status: campaigns.status,
         maxLeads: campaigns.maxLeads,
         maxBudgetTotalUsd: campaigns.maxBudgetTotalUsd,
-        externalOrgId: orgs.externalOrgId,
       })
       .from(campaigns)
-      .innerJoin(orgs, eq(campaigns.orgId, orgs.id))
       .where(inArray(campaigns.id, campaignIds));
 
     const campaignMap = new Map(
@@ -90,8 +86,7 @@ router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBu
 
         try {
           const budgetResult = await getStatsBudget({
-            orgId: row.externalOrgId,
-            appId: row.appId || "",
+            orgId: row.orgId,
             campaignId,
             windows: [{ label: "total" }],
           });
@@ -124,18 +119,10 @@ router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBu
  */
 router.post("/campaigns/stats", requireApiKey, validateBody(StatsFilterBody), async (req, res) => {
   try {
-    const { orgId, appId, brandId, campaignId } = req.body;
+    const { orgId, brandId, campaignId } = req.body;
 
     const conditions = [];
-    if (orgId) {
-      const org = await db.query.orgs.findFirst({
-        where: eq(orgs.externalOrgId, orgId),
-        columns: { id: true },
-      });
-      if (org) conditions.push(eq(campaigns.orgId, org.id));
-      else return res.json({ stats: { totalCampaigns: 0, byStatus: {}, budgetTotalUsd: null, maxLeadsTotal: null } });
-    }
-    if (appId) conditions.push(eq(campaigns.appId, appId));
+    if (orgId) conditions.push(eq(campaigns.orgId, orgId));
     if (brandId) conditions.push(eq(campaigns.brandId, brandId));
     if (campaignId) conditions.push(eq(campaigns.id, campaignId));
 
@@ -232,7 +219,6 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       parentRunId,
       brandUrl,
       brandId,
-      appId,
       targetAudience,
       targetOutcome,
       valueForTarget,
@@ -243,7 +229,6 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       maxLeads,
       startDate,
       endDate,
-      keySource,
       notifyFrequency,
       notifyChannel,
       notifyDestination,
@@ -260,7 +245,6 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         name,
         workflowName,
         parentRunId,
-        appId,
         brandUrl: normalizedBrandUrl,
         brandId,
         targetAudience,
@@ -273,7 +257,6 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         maxLeads,
         startDate,
         endDate,
-        keySource,
         notifyFrequency,
         notifyChannel,
         notifyDestination,
@@ -285,8 +268,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     console.log(`[Campaign Service] Campaign created: campaignId=${campaign.id}, workflowName=${campaign.workflowName}, triggering first workflow execution`);
     executeCampaignWorkflow(campaign.workflowName, {
       campaignId: campaign.id,
-      orgId: req.externalOrgId!,
-      appId: campaign.appId || "",
+      orgId: req.orgId!,
     }).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
@@ -335,11 +317,10 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
 
     // Trigger workflow on activation
     if (req.body.status === "activate") {
-      console.log(`[Campaign Service] Activation triggered: campaignId=${updated.id}, workflowName=${updated.workflowName}, orgId=${req.externalOrgId}`);
+      console.log(`[Campaign Service] Activation triggered: campaignId=${updated.id}, workflowName=${updated.workflowName}, orgId=${req.orgId}`);
       executeCampaignWorkflow(updated.workflowName, {
         campaignId: updated.id,
-        orgId: req.externalOrgId!,
-        appId: updated.appId || "",
+        orgId: req.orgId!,
       }).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { campaigns, orgs, users } from "../db/schema.js";
+import { campaigns } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun } from "@mcpfactory/runs-client";
@@ -25,7 +25,7 @@ const router = Router();
  *
  * Returns:
  *   200 — gate check result (allowed or blocked)
- *   404 — campaign/org not found
+ *   404 — campaign not found
  *   500 — internal error
  */
 router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (req, res) => {
@@ -33,16 +33,8 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
     const { campaignId, orgId } = req.body;
     console.log(`[Gate Check] Received request: campaignId=${campaignId}, orgId=${orgId}`);
 
-    const org = await db.query.orgs.findFirst({
-      where: eq(orgs.externalOrgId, orgId),
-    });
-    if (!org) {
-      console.warn(`[Gate Check] Org not found: ${orgId}`);
-      return res.status(404).json({ error: "Organization not found" });
-    }
-
     const campaign = await db.query.campaigns.findFirst({
-      where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
+      where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
     });
     if (!campaign) {
       console.warn(`[Gate Check] Campaign not found: ${campaignId}`);
@@ -53,7 +45,6 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
     const result = await runGateChecks({
       campaignId,
       orgId,
-      appId: campaign.appId || "",
       brandId: campaign.brandId || "",
       status: campaign.status,
       maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
@@ -99,7 +90,7 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
  * Returns:
  *   200 — run started, campaign data returned
  *   400 — bad request (missing brandUrl/brandId)
- *   404 — campaign/org not found
+ *   404 — campaign not found
  *   500 — internal error
  */
 router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req, res) => {
@@ -107,19 +98,11 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
     const { campaignId, orgId } = req.body;
     console.log(`[Start Run] Received request: campaignId=${campaignId}, orgId=${orgId}`);
 
-    const org = await db.query.orgs.findFirst({
-      where: eq(orgs.externalOrgId, orgId),
-    });
-    if (!org) {
-      console.warn(`[Start Run] Org not found: ${orgId}`);
-      return res.status(404).json({ error: "Organization not found" });
-    }
-
     const campaign = await db.query.campaigns.findFirst({
-      where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
+      where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
     });
     if (!campaign) {
-      console.warn(`[Start Run] Campaign not found: ${campaignId} (orgId=${org.id})`);
+      console.warn(`[Start Run] Campaign not found: ${campaignId} (orgId=${orgId})`);
       return res.status(404).json({ error: "Campaign not found" });
     }
     console.log(`[Start Run] Campaign found: name=${campaign.name}, workflowName=${campaign.workflowName}, status=${campaign.status}, brandUrl=${campaign.brandUrl}`);
@@ -132,28 +115,15 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
       return res.status(400).json({ error: "Campaign has no brandId" });
     }
 
-    const appId = campaign.appId || "";
-
-    // Look up user's external ID if campaign has a createdByUserId
-    let externalUserId: string | undefined;
-    if (campaign.createdByUserId) {
-      const user = await db.query.users.findFirst({
-        where: eq(users.id, campaign.createdByUserId),
-        columns: { externalUserId: true },
-      });
-      externalUserId = user?.externalUserId;
-    }
-
     // Create run in runs-service (parentRunId links to api-service's parent run)
     console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId} (parentRunId=${campaign.parentRunId || "none"})...`);
     const run = await createRun({
       orgId,
-      appId,
       serviceName: "campaign-service",
       taskName: campaignId,
       campaignId,
       brandId: campaign.brandId,
-      userId: externalUserId,
+      userId: campaign.createdByUserId || undefined,
       parentRunId: campaign.parentRunId || undefined,
       workflowName: campaign.workflowName,
     });
@@ -182,13 +152,11 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
       brandId: campaign.brandId,
       brandUrl: campaign.brandUrl,
       brandDomain,
-      appId,
       workflowName: campaign.workflowName,
-      userId: externalUserId ?? null,
+      userId: campaign.createdByUserId ?? null,
       targetOutcome: campaign.targetOutcome,
       valueForTarget: campaign.valueForTarget,
       searchParams,
-      keySource: campaign.keySource,
     });
   } catch (error) {
     console.error("[Start Run] Unhandled error:", error);
@@ -214,22 +182,10 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
 
     const status = success === true ? "completed" : "failed";
 
-    // Fetch campaign to get appId
-    const org = await db.query.orgs.findFirst({
-      where: eq(orgs.externalOrgId, orgId),
-    });
-    const campaign = org
-      ? await db.query.campaigns.findFirst({
-          where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
-        })
-      : undefined;
-    const appId = campaign?.appId || "";
-
     // Find and update running runs for this campaign
     try {
       const { runs } = await listRuns({
         orgId,
-        appId,
         serviceName: "campaign-service",
         taskName: campaignId,
       });
@@ -253,12 +209,10 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
     // No leads found → auto-stop campaign, no re-trigger
     if (success === true && leadFound === false) {
       try {
-        if (org) {
-          await db.update(campaigns)
-            .set({ status: "stopped" })
-            .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)));
-          console.log(`[End Run] No leads found — auto-stopped campaign ${campaignId}`);
-        }
+        await db.update(campaigns)
+          .set({ status: "stopped" })
+          .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
+        console.log(`[End Run] No leads found — auto-stopped campaign ${campaignId}`);
       } catch (err) {
         console.error(`[End Run] Failed to auto-stop campaign:`, err);
       }
@@ -267,14 +221,9 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
 
     // Re-trigger if campaign is still ongoing
     try {
-      if (!org) {
-        console.warn(`[End Run] Org not found for re-trigger: ${orgId}`);
-        return;
-      }
-
       // Re-fetch campaign for fresh status (may have been auto-stopped by gate-check)
       const freshCampaign = await db.query.campaigns.findFirst({
-        where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, org.id)),
+        where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
       });
       console.log(`[End Run] Campaign status for re-trigger: ${freshCampaign?.status || "NOT FOUND"}, workflowName=${freshCampaign?.workflowName || "N/A"}`);
       if (freshCampaign?.status !== "ongoing") {
@@ -284,7 +233,7 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
 
       // Fire-and-forget: gate-check in the next workflow execution will validate limits
       console.log(`[End Run] Re-triggering workflow=${freshCampaign.workflowName} for campaign ${campaignId}`);
-      executeCampaignWorkflow(freshCampaign.workflowName, { campaignId, orgId, appId }).catch((err) => {
+      executeCampaignWorkflow(freshCampaign.workflowName, { campaignId, orgId }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });
     } catch (err) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -11,14 +11,13 @@ export const ErrorResponse = z.object({
 
 export const CampaignSchema = z.object({
   id: z.string().uuid(),
-  orgId: z.string().uuid(),
-  createdByUserId: z.string().uuid().nullable(),
+  orgId: z.string(),
+  createdByUserId: z.string().nullable(),
   name: z.string(),
   workflowName: z.string(),
   brandUrl: z.string().nullable(),
   brandId: z.string().uuid().nullable(),
   parentRunId: z.string().uuid().nullable(),
-  appId: z.string().nullable(),
   targetAudience: z.string().nullable(),
   targetOutcome: z.string().nullable(),
   valueForTarget: z.string().nullable(),
@@ -29,7 +28,6 @@ export const CampaignSchema = z.object({
   maxLeads: z.number().int().nullable(),
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
-  keySource: z.string(),
   status: z.string(),
   toResumeAt: z.string().nullable(),
   notifyFrequency: z.string().nullable(),
@@ -48,7 +46,6 @@ export const CreateCampaignBody = z.object({
   parentRunId: z.string().uuid("parentRunId must be a valid UUID"),
   brandUrl: z.string().min(1, "brandUrl is required"),
   brandId: z.string().uuid("brandId must be a valid UUID"),
-  appId: z.string().min(1, "appId is required"),
   targetAudience: z.string().optional(),
   targetOutcome: z.string().min(1, "targetOutcome is required"),
   valueForTarget: z.string().min(1, "valueForTarget is required"),
@@ -59,7 +56,6 @@ export const CreateCampaignBody = z.object({
   maxLeads: z.number().int().optional(),
   startDate: z.string().optional(),
   endDate: z.string().optional(),
-  keySource: z.enum(["platform", "app", "byok"], { error: "keySource is required and must be \"platform\", \"app\", or \"byok\"" }).openapi({ description: "How downstream services resolve API keys. \"platform\" = platform-owned keys (no appId needed), \"app\" = client app keys (per appId), \"byok\" = end user's own keys." }),
   notifyFrequency: z.string().optional(),
   notifyChannel: z.string().optional(),
   notifyDestination: z.string().optional(),
@@ -81,23 +77,20 @@ export const UpdateCampaignBody = z.object({
   startDate: z.string().optional(),
   endDate: z.string().optional(),
   status: z.enum(["activate", "stop"]).optional(),
-  keySource: z.enum(["platform", "app", "byok"]).optional(),
   notifyFrequency: z.string().optional(),
   notifyChannel: z.string().optional(),
   notifyDestination: z.string().optional(),
-  appId: z.string().optional(),
 }).openapi("UpdateCampaignBody");
 
 // --- Stats ---
 
 export const StatsFilterBody = z.object({
   orgId: z.string().optional(),
-  appId: z.string().optional(),
   brandId: z.string().optional(),
   campaignId: z.string().optional(),
 }).refine(
-  (data) => data.orgId || data.appId || data.brandId || data.campaignId,
-  { message: "At least one filter required: orgId, appId, brandId, or campaignId" }
+  (data) => data.orgId || data.brandId || data.campaignId,
+  { message: "At least one filter required: orgId, brandId, or campaignId" }
 ).openapi("StatsFilterBody");
 
 export const StatsResponse = z.object({
@@ -140,13 +133,11 @@ export const StartRunResponse = z.object({
   brandId: z.string().uuid(),
   brandUrl: z.string(),
   brandDomain: z.string(),
-  appId: z.string(),
   workflowName: z.string(),
   userId: z.string().nullable(),
   targetOutcome: z.string().nullable(),
   valueForTarget: z.string().nullable(),
   searchParams: z.record(z.string(), z.unknown()).nullable(),
-  keySource: z.enum(["platform", "app", "byok"]),
 }).openapi("StartRunResponse");
 
 export const EndRunBody = z.object({

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,43 +1,16 @@
 import { db, sql } from "../../src/db/index.js";
-import { orgs, users, campaigns } from "../../src/db/schema.js";
+import { campaigns } from "../../src/db/schema.js";
 
 /**
  * Clean all test data from the database
  */
 export async function cleanTestData() {
   await db.delete(campaigns);
-  await db.delete(users);
-  await db.delete(orgs);
 }
 
 /**
- * Insert a test org
- */
-export async function insertTestOrg(data: { externalOrgId?: string } = {}) {
-  const [org] = await db
-    .insert(orgs)
-    .values({
-      externalOrgId: data.externalOrgId || `test-org-${Date.now()}`,
-    })
-    .returning();
-  return org;
-}
-
-/**
- * Insert a test user
- */
-export async function insertTestUser(data: { externalUserId?: string } = {}) {
-  const [user] = await db
-    .insert(users)
-    .values({
-      externalUserId: data.externalUserId || `test-user-${Date.now()}`,
-    })
-    .returning();
-  return user;
-}
-
-/**
- * Insert a test campaign
+ * Insert a test campaign.
+ * orgId is now the external org ID (client-service UUID) stored directly.
  */
 export async function insertTestCampaign(
   orgId: string,
@@ -48,7 +21,6 @@ export async function insertTestCampaign(
     parentRunId?: string;
     brandUrl?: string;
     brandId?: string;
-    appId?: string;
     maxBudgetDailyUsd?: string;
     maxBudgetWeeklyUsd?: string;
     maxBudgetMonthlyUsd?: string;
@@ -58,6 +30,7 @@ export async function insertTestCampaign(
     targetOutcome?: string;
     valueForTarget?: string;
     toResumeAt?: Date | null;
+    createdByUserId?: string;
   } = {}
 ) {
   const [campaign] = await db
@@ -70,7 +43,6 @@ export async function insertTestCampaign(
       parentRunId: data.parentRunId || null,
       brandUrl: data.brandUrl || null,
       brandId: data.brandId || null,
-      appId: data.appId || null,
       maxBudgetDailyUsd: data.maxBudgetDailyUsd || "10.00",
       maxBudgetWeeklyUsd: data.maxBudgetWeeklyUsd || null,
       maxBudgetMonthlyUsd: data.maxBudgetMonthlyUsd || null,
@@ -80,6 +52,7 @@ export async function insertTestCampaign(
       targetOutcome: data.targetOutcome || null,
       valueForTarget: data.valueForTarget || null,
       toResumeAt: data.toResumeAt ?? null,
+      createdByUserId: data.createdByUserId || null,
     })
     .returning();
   return campaign;

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import request from "supertest";
 import app from "../../src/index.js";
-import { cleanTestData, closeDb, insertTestOrg } from "../helpers/test-db.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
 
 const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 
@@ -22,10 +22,8 @@ describe("Campaign CRUD", () => {
     parentRunId: crypto.randomUUID(),
     brandUrl: "https://example.com",
     brandId: crypto.randomUUID(),
-    appId: "mcpfactory",
     targetOutcome: "Book sales demos",
     valueForTarget: "Access to enterprise analytics at startup pricing",
-    keySource: "byok" as const,
   };
 
   describe("POST /campaigns", () => {
@@ -41,7 +39,6 @@ describe("Campaign CRUD", () => {
       expect(res.body.campaign.name).toBe("Test Campaign");
       expect(res.body.campaign.workflowName).toBe("sales-email-cold-outreach");
       expect(res.body.campaign.brandId).toBe(validBody.brandId);
-      expect(res.body.campaign.appId).toBe("mcpfactory");
     });
 
     it("should reject when workflowName is missing", async () => {
@@ -94,19 +91,6 @@ describe("Campaign CRUD", () => {
 
     it("should reject when brandId is missing", async () => {
       const { brandId, ...body } = validBody;
-
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(body)
-        .expect(400);
-
-      expect(res.body.error).toBeDefined();
-    });
-
-    it("should reject when appId is missing", async () => {
-      const { appId, ...body } = validBody;
 
       const res = await request(app)
         .post("/campaigns")
@@ -225,28 +209,6 @@ describe("Campaign CRUD", () => {
       expect(res.body.error).toBeDefined();
     });
 
-    it("should create a campaign with keySource 'platform'", async () => {
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({ ...validBody, keySource: "platform" })
-        .expect(201);
-
-      expect(res.body.campaign.keySource).toBe("platform");
-    });
-
-    it("should reject an invalid keySource value", async () => {
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({ ...validBody, keySource: "invalid" })
-        .expect(400);
-
-      expect(res.body.error).toBeDefined();
-    });
-
     it("should reject Apollo fields that no longer exist", async () => {
       const res = await request(app)
         .post("/campaigns")
@@ -260,7 +222,7 @@ describe("Campaign CRUD", () => {
       expect(res.body.campaign).not.toHaveProperty("personTitles");
     });
 
-    it("should not have sales-specific fields on campaign", async () => {
+    it("should not have legacy fields on campaign", async () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
@@ -273,6 +235,8 @@ describe("Campaign CRUD", () => {
       expect(res.body.campaign).not.toHaveProperty("riskReversal");
       expect(res.body.campaign).not.toHaveProperty("socialProof");
       expect(res.body.campaign).not.toHaveProperty("type");
+      expect(res.body.campaign).not.toHaveProperty("appId");
+      expect(res.body.campaign).not.toHaveProperty("keySource");
     });
   });
 
@@ -338,7 +302,6 @@ describe("Campaign CRUD", () => {
     });
 
     it("should update targetAudience", async () => {
-      // Create campaign first
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
-import { orgs, campaigns } from "../../src/db/schema.js";
-import { cleanTestData, closeDb, insertTestOrg, insertTestCampaign } from "../helpers/test-db.js";
+import { campaigns } from "../../src/db/schema.js";
+import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
 
 describe("Campaign Service Database", () => {
   beforeEach(async () => {
@@ -14,84 +14,35 @@ describe("Campaign Service Database", () => {
     await closeDb();
   });
 
-  describe("orgs table", () => {
-    it("should create and query an org", async () => {
-      const org = await insertTestOrg({ externalOrgId: "org_test123" });
-
-      expect(org.id).toBeDefined();
-      expect(org.externalOrgId).toBe("org_test123");
-
-      const found = await db.query.orgs.findFirst({
-        where: eq(orgs.id, org.id),
-      });
-      expect(found?.externalOrgId).toBe("org_test123");
-    });
-  });
-
   describe("campaigns table", () => {
-    it("should create a campaign linked to org", async () => {
-      const org = await insertTestOrg();
-      const campaign = await insertTestCampaign(org.id, {
+    it("should create a campaign with orgId stored directly", async () => {
+      const campaign = await insertTestCampaign("org_test_123", {
         name: "Test Campaign",
-        status: "active",
+        status: "ongoing",
       });
 
       expect(campaign.id).toBeDefined();
       expect(campaign.name).toBe("Test Campaign");
-      expect(campaign.status).toBe("active");
+      expect(campaign.status).toBe("ongoing");
+      expect(campaign.orgId).toBe("org_test_123");
     });
 
-    it("should create a campaign with appId", async () => {
-      const org = await insertTestOrg();
-      const appId = crypto.randomUUID();
-      const campaign = await insertTestCampaign(org.id, {
-        name: "App Campaign",
-        appId,
-      });
-
-      expect(campaign.appId).toBe(appId);
-    });
-
-    it("should store null appId when not provided", async () => {
-      const org = await insertTestOrg();
-      const campaign = await insertTestCampaign(org.id, {
-        name: "No App Campaign",
-      });
-
-      expect(campaign.appId).toBeNull();
-    });
-
-    it("should query campaign and return appId column", async () => {
-      const org = await insertTestOrg();
-      const appId = crypto.randomUUID();
-      await insertTestCampaign(org.id, { name: "Queryable", appId });
-
-      const found = await db.query.campaigns.findFirst({
-        where: eq(campaigns.orgId, org.id),
-      });
-
-      expect(found).toBeDefined();
-      expect(found!.appId).toBe(appId);
-    });
-
-    it("should select all campaigns with appId column present", async () => {
-      const org = await insertTestOrg();
-      const appId = crypto.randomUUID();
-      await insertTestCampaign(org.id, { name: "Select Test", appId });
+    it("should query campaigns by orgId", async () => {
+      await insertTestCampaign("org_1", { name: "Org1 Campaign" });
+      await insertTestCampaign("org_2", { name: "Org2 Campaign" });
 
       const results = await db
         .select()
         .from(campaigns)
-        .where(eq(campaigns.orgId, org.id));
+        .where(eq(campaigns.orgId, "org_1"));
 
       expect(results).toHaveLength(1);
-      expect(results[0].appId).toBe(appId);
+      expect(results[0].name).toBe("Org1 Campaign");
     });
 
     it("should create a campaign with brandId", async () => {
-      const org = await insertTestOrg();
       const brandId = crypto.randomUUID();
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign("org_1", {
         name: "Brand Campaign",
         brandId,
       });
@@ -100,8 +51,7 @@ describe("Campaign Service Database", () => {
     });
 
     it("should store null brandId when not provided", async () => {
-      const org = await insertTestOrg();
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign("org_1", {
         name: "No Brand Campaign",
       });
 
@@ -109,10 +59,9 @@ describe("Campaign Service Database", () => {
     });
 
     it("should query campaigns by brandId", async () => {
-      const org = await insertTestOrg();
       const brandId = crypto.randomUUID();
-      await insertTestCampaign(org.id, { name: "With Brand", brandId });
-      await insertTestCampaign(org.id, { name: "Without Brand" });
+      await insertTestCampaign("org_1", { name: "With Brand", brandId });
+      await insertTestCampaign("org_1", { name: "Without Brand" });
 
       const results = await db
         .select()
@@ -124,16 +73,13 @@ describe("Campaign Service Database", () => {
       expect(results[0].brandId).toBe(brandId);
     });
 
-    it("should cascade delete when org is deleted", async () => {
-      const org = await insertTestOrg();
-      const campaign = await insertTestCampaign(org.id);
-
-      await db.delete(orgs).where(eq(orgs.id, org.id));
-
-      const found = await db.query.campaigns.findFirst({
-        where: eq(campaigns.id, campaign.id),
+    it("should not have appId or keySource columns", async () => {
+      const campaign = await insertTestCampaign("org_1", {
+        name: "No Legacy Fields",
       });
-      expect(found).toBeUndefined();
+
+      expect(campaign).not.toHaveProperty("appId");
+      expect(campaign).not.toHaveProperty("keySource");
     });
   });
 });

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -34,19 +34,17 @@ import app from "../../src/index.js";
 import { db } from "../../src/db/index.js";
 import { campaigns } from "../../src/db/schema.js";
 import { eq } from "drizzle-orm";
-import { cleanTestData, closeDb, insertTestOrg, insertTestCampaign } from "../helpers/test-db.js";
+import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
 
 const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 
 describe("Pipeline routes", () => {
-  let org: { id: string; externalOrgId: string };
+  const orgId = "org_internal_test";
   const brandId = crypto.randomUUID();
 
   beforeEach(async () => {
     await cleanTestData();
     vi.clearAllMocks();
-
-    org = await insertTestOrg({ externalOrgId: "org_internal_test" });
 
     // Default mock behaviors
     mockCreateRun.mockResolvedValue({ id: "run-123" });
@@ -80,28 +78,18 @@ describe("Pipeline routes", () => {
         .expect(400);
     });
 
-    it("should return 404 if org not found", async () => {
+    it("should return 404 if campaign not found", async () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
         .send({ campaignId: crypto.randomUUID(), orgId: "nonexistent-org" })
         .expect(404);
 
-      expect(res.body.error).toBe("Organization not found");
-    });
-
-    it("should return 404 if campaign not found", async () => {
-      const res = await request(app)
-        .post("/gate-check")
-        .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), orgId: org.externalOrgId })
-        .expect(404);
-
       expect(res.body.error).toBe("Campaign not found");
     });
 
     it("should return allowed: true when gate checks pass", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -109,7 +97,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(res.body.allowed).toBe(true);
@@ -117,7 +105,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should return allowed: false with reason when gate checks fail", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -130,7 +118,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(res.body.allowed).toBe(false);
@@ -138,7 +126,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should return autoStopped flag when campaign is auto-stopped", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -152,7 +140,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(res.body.allowed).toBe(false);
@@ -160,7 +148,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should save toResumeAt to DB when gate-check returns it", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -178,7 +166,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       // Verify toResumeAt was saved to the DB
@@ -190,7 +178,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should NOT save toResumeAt when gate-check does not return it", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -204,7 +192,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       const updated = await db.query.campaigns.findFirst({
@@ -214,7 +202,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should pass campaign data to runGateChecks", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
         maxBudgetDailyUsd: "50.00",
@@ -224,13 +212,13 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(mockGateChecks).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
+          orgId,
           brandId,
           status: "ongoing",
           maxBudgetDailyUsd: "50.00",
@@ -251,28 +239,18 @@ describe("Pipeline routes", () => {
         .expect(400);
     });
 
-    it("should return 404 if org not found", async () => {
+    it("should return 404 if campaign not found", async () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
         .send({ campaignId: crypto.randomUUID(), orgId: "nonexistent-org" })
         .expect(404);
 
-      expect(res.body.error).toBe("Organization not found");
-    });
-
-    it("should return 404 if campaign not found", async () => {
-      const res = await request(app)
-        .post("/start-run")
-        .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), orgId: org.externalOrgId })
-        .expect(404);
-
       expect(res.body.error).toBe("Campaign not found");
     });
 
     it("should return 400 if campaign has no brandUrl", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandId,
         brandUrl: undefined,
       });
@@ -280,14 +258,14 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(400);
 
       expect(res.body.error).toBe("Campaign has no brandUrl");
     });
 
     it("should return 400 if campaign has no brandId", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId: undefined,
       });
@@ -295,17 +273,16 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(400);
 
       expect(res.body.error).toBe("Campaign has no brandId");
     });
 
     it("should return 200 with campaign data and runId", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
-        appId: "mcpfactory",
         targetOutcome: "Book demos",
         valueForTarget: "Analytics platform",
       });
@@ -313,23 +290,24 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(res.body.runId).toBe("run-123");
       expect(res.body.campaignId).toBe(campaign.id);
-      expect(res.body.orgId).toBe(org.externalOrgId);
+      expect(res.body.orgId).toBe(orgId);
       expect(res.body.brandId).toBe(brandId);
       expect(res.body.brandUrl).toBe("https://example.com");
       expect(res.body.brandDomain).toBe("example.com");
-      expect(res.body.appId).toBe("mcpfactory");
       expect(res.body.workflowName).toBe("sales-email-cold-outreach");
       expect(res.body.targetOutcome).toBe("Book demos");
       expect(res.body.valueForTarget).toBe("Analytics platform");
+      expect(res.body).not.toHaveProperty("appId");
+      expect(res.body).not.toHaveProperty("keySource");
     });
 
     it("should not return sales-specific fields", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -337,7 +315,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(res.body).not.toHaveProperty("urgency");
@@ -347,7 +325,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should pass all user context as unstructured searchParams", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
         targetAudience: "VPs of Sales at B2B SaaS companies",
@@ -358,7 +336,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(res.body.searchParams).toEqual({
@@ -369,7 +347,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should have null searchParams when no user context is set", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -377,14 +355,14 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(res.body.searchParams).toBeNull();
     });
 
     it("should extract brandDomain from brandUrl", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://www.example.com/path",
         brandId,
       });
@@ -392,7 +370,7 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(res.body.brandDomain).toBe("example.com");
@@ -401,7 +379,7 @@ describe("Pipeline routes", () => {
 
     it("should pass parentRunId to createRun when campaign has one", async () => {
       const parentRunId = crypto.randomUUID();
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
         parentRunId,
@@ -410,7 +388,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -419,7 +397,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should NOT pass parentRunId to createRun when campaign has none", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -427,7 +405,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -436,7 +414,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should pass workflowName to createRun", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
         workflowName: "pr-email-cold-outreach",
@@ -445,7 +423,7 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -454,7 +432,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should NOT call gate checks (gate check is a separate DAG node)", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -462,10 +440,26 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId: org.externalOrgId })
+        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(mockGateChecks).not.toHaveBeenCalled();
+    });
+
+    it("should not pass appId to createRun", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      await request(app)
+        .post("/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, orgId })
+        .expect(200);
+
+      const callArgs = mockCreateRun.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty("appId");
     });
   });
 
@@ -481,7 +475,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should find and mark running run as completed when success is true", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -497,7 +491,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
+          orgId,
           success: true,
         })
         .expect(200);
@@ -507,7 +501,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should find and mark running run as failed when success is false", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -523,7 +517,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
+          orgId,
           success: false,
         })
         .expect(200);
@@ -533,7 +527,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should skip run update when no running runs exist (gate-check blocked)", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
       });
@@ -545,7 +539,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
+          orgId,
           success: false,
         })
         .expect(200);
@@ -555,7 +549,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should re-trigger workflow using workflowName if campaign is still ongoing", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
         status: "ongoing",
@@ -567,7 +561,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
+          orgId,
           success: true,
         })
         .expect(200);
@@ -579,14 +573,13 @@ describe("Pipeline routes", () => {
         "sales-email-cold-outreach",
         {
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
-          appId: "",
+          orgId,
         },
       );
     });
 
     it("should NOT re-trigger if campaign is stopped", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
         status: "stopped",
@@ -597,7 +590,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
+          orgId,
           success: true,
         })
         .expect(200);
@@ -608,7 +601,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should auto-stop campaign and NOT re-trigger when leadFound is false", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
         status: "ongoing",
@@ -625,7 +618,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
+          orgId,
           success: true,
           leadFound: false,
         })
@@ -642,7 +635,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should re-trigger normally when leadFound is true", async () => {
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
         status: "ongoing",
@@ -659,7 +652,7 @@ describe("Pipeline routes", () => {
         .set("x-api-key", API_KEY)
         .send({
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
+          orgId,
           success: true,
           leadFound: true,
         })
@@ -672,9 +665,31 @@ describe("Pipeline routes", () => {
         "sales-email-cold-outreach",
         expect.objectContaining({
           campaignId: campaign.id,
-          orgId: org.externalOrgId,
+          orgId,
         }),
       );
+    });
+
+    it("should not pass appId to listRuns", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandUrl: "https://example.com",
+        brandId,
+      });
+
+      mockListRuns.mockResolvedValue({ runs: [] });
+
+      await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          campaignId: campaign.id,
+          orgId,
+          success: true,
+        })
+        .expect(200);
+
+      const callArgs = mockListRuns.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty("appId");
     });
   });
 });

--- a/tests/integration/scheduler-campaigns.test.ts
+++ b/tests/integration/scheduler-campaigns.test.ts
@@ -13,7 +13,7 @@ vi.mock("@mcpfactory/runs-client", () => ({
 }));
 
 import app from "../../src/index.js";
-import { cleanTestData, closeDb, insertTestOrg, insertTestCampaign } from "../helpers/test-db.js";
+import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
 
 const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 
@@ -31,11 +31,8 @@ describe("Scheduler Endpoints", () => {
 
   describe("GET /campaigns/list", () => {
     it("should return all campaigns across all orgs", async () => {
-      const org1 = await insertTestOrg({ externalOrgId: "org_1" });
-      const org2 = await insertTestOrg({ externalOrgId: "org_2" });
-
-      await insertTestCampaign(org1.id, { name: "Org1 Campaign", status: "ongoing" });
-      await insertTestCampaign(org2.id, { name: "Org2 Campaign", status: "ongoing" });
+      await insertTestCampaign("org_1", { name: "Org1 Campaign", status: "ongoing" });
+      await insertTestCampaign("org_2", { name: "Org2 Campaign", status: "ongoing" });
 
       const res = await request(app)
         .get("/campaigns/list")
@@ -43,19 +40,17 @@ describe("Scheduler Endpoints", () => {
         .expect(200);
 
       expect(res.body.campaigns).toHaveLength(2);
-      expect(res.body.campaigns[0].externalOrgId).toBeDefined();
     });
 
-    it("should include externalOrgId for downstream service calls", async () => {
-      const org = await insertTestOrg({ externalOrgId: "org_test_ext" });
-      await insertTestCampaign(org.id, { name: "Test", status: "ongoing" });
+    it("should include orgId for downstream service calls", async () => {
+      await insertTestCampaign("org_test_ext", { name: "Test", status: "ongoing" });
 
       const res = await request(app)
         .get("/campaigns/list")
         .set("x-api-key", API_KEY)
         .expect(200);
 
-      expect(res.body.campaigns[0].externalOrgId).toBe("org_test_ext");
+      expect(res.body.campaigns[0].orgId).toBe("org_test_ext");
     });
 
     it("should return empty array when no campaigns", async () => {
@@ -70,12 +65,10 @@ describe("Scheduler Endpoints", () => {
 
   describe("POST /campaigns/batch-budget-usage", () => {
     it("should return cost total from getStatsBudget for each campaign", async () => {
-      const org = await insertTestOrg({ externalOrgId: "org_batch" });
-      const campaign = await insertTestCampaign(org.id, {
+      const campaign = await insertTestCampaign("org_batch", {
         status: "ongoing",
         maxBudgetTotalUsd: "50.00",
         maxLeads: 100,
-        appId: "mcpfactory",
       });
 
       mockGetStatsBudget.mockResolvedValue({
@@ -96,8 +89,7 @@ describe("Scheduler Endpoints", () => {
     });
 
     it("should call getStatsBudget with correct params", async () => {
-      const org = await insertTestOrg({ externalOrgId: "org_batch_params" });
-      const campaign = await insertTestCampaign(org.id, { appId: "mcpfactory" });
+      const campaign = await insertTestCampaign("org_batch_params", {});
 
       mockGetStatsBudget.mockResolvedValue({ windows: [] });
 
@@ -109,7 +101,6 @@ describe("Scheduler Endpoints", () => {
 
       expect(mockGetStatsBudget).toHaveBeenCalledWith({
         orgId: "org_batch_params",
-        appId: "mcpfactory",
         campaignId: campaign.id,
         windows: [{ label: "total" }],
       });
@@ -128,8 +119,7 @@ describe("Scheduler Endpoints", () => {
     });
 
     it("should handle getStatsBudget failure gracefully", async () => {
-      const org = await insertTestOrg({ externalOrgId: "org_batch_err" });
-      const campaign = await insertTestCampaign(org.id, { appId: "mcpfactory" });
+      const campaign = await insertTestCampaign("org_batch_err", {});
 
       mockGetStatsBudget.mockRejectedValue(new Error("runs-service down"));
 
@@ -143,8 +133,7 @@ describe("Scheduler Endpoints", () => {
     });
 
     it("should return null totalCostInUsdCents when no windows returned", async () => {
-      const org = await insertTestOrg({ externalOrgId: "org_batch_empty" });
-      const campaign = await insertTestCampaign(org.id, { appId: "mcpfactory" });
+      const campaign = await insertTestCampaign("org_batch_empty", {});
 
       mockGetStatsBudget.mockResolvedValue({ windows: [] });
 
@@ -158,9 +147,8 @@ describe("Scheduler Endpoints", () => {
     });
 
     it("should handle multiple campaigns in batch", async () => {
-      const org = await insertTestOrg({ externalOrgId: "org_multi" });
-      const c1 = await insertTestCampaign(org.id, { appId: "mcpfactory", status: "ongoing" });
-      const c2 = await insertTestCampaign(org.id, { appId: "mcpfactory", status: "stopped" });
+      const c1 = await insertTestCampaign("org_multi", { status: "ongoing" });
+      const c2 = await insertTestCampaign("org_multi", { status: "stopped" });
 
       mockGetStatsBudget
         .mockResolvedValueOnce({

--- a/tests/integration/scheduler-resume.test.ts
+++ b/tests/integration/scheduler-resume.test.ts
@@ -16,17 +16,16 @@ vi.mock("@mcpfactory/runs-client", () => ({
 import { db } from "../../src/db/index.js";
 import { campaigns } from "../../src/db/schema.js";
 import { eq } from "drizzle-orm";
-import { cleanTestData, closeDb, insertTestOrg, insertTestCampaign } from "../helpers/test-db.js";
+import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
 import { resumeDueCampaigns } from "../../src/lib/scheduler.js";
 
-describe("Scheduler - resumeDueCampaigns (integration)", () => {
-  let org: { id: string; externalOrgId: string };
+const orgId = "scheduler-test-org";
 
+describe("Scheduler - resumeDueCampaigns (integration)", () => {
   beforeEach(async () => {
     await cleanTestData();
     vi.clearAllMocks();
     mockExecute.mockResolvedValue(undefined);
-    org = await insertTestOrg({ externalOrgId: "scheduler-test-org" });
   });
 
   afterAll(async () => {
@@ -35,9 +34,8 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
   });
 
   it("should not trigger anything when no campaigns are due", async () => {
-    await insertTestCampaign(org.id, {
+    await insertTestCampaign(orgId, {
       status: "ongoing",
-      appId: "mcpfactory",
     });
 
     const count = await resumeDueCampaigns();
@@ -47,9 +45,8 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
 
   it("should resume campaign whose toResumeAt is in the past", async () => {
     const pastDate = new Date(Date.now() - 60_000); // 1 minute ago
-    const campaign = await insertTestCampaign(org.id, {
+    const campaign = await insertTestCampaign(orgId, {
       status: "ongoing",
-      appId: "mcpfactory",
       toResumeAt: pastDate,
     });
 
@@ -67,17 +64,15 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
       "sales-email-cold-outreach",
       {
         campaignId: campaign.id,
-        orgId: org.externalOrgId,
-        appId: "mcpfactory",
+        orgId,
       },
     );
   });
 
   it("should NOT resume campaign whose toResumeAt is in the future", async () => {
     const futureDate = new Date(Date.now() + 3_600_000); // 1 hour from now
-    await insertTestCampaign(org.id, {
+    await insertTestCampaign(orgId, {
       status: "ongoing",
-      appId: "mcpfactory",
       toResumeAt: futureDate,
     });
 
@@ -88,9 +83,8 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
 
   it("should NOT resume stopped campaigns even with past toResumeAt", async () => {
     const pastDate = new Date(Date.now() - 60_000);
-    await insertTestCampaign(org.id, {
+    await insertTestCampaign(orgId, {
       status: "stopped",
-      appId: "mcpfactory",
       toResumeAt: pastDate,
     });
 
@@ -102,37 +96,19 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
   it("should resume multiple due campaigns", async () => {
     const pastDate = new Date(Date.now() - 60_000);
 
-    await insertTestCampaign(org.id, {
+    await insertTestCampaign(orgId, {
       name: "Campaign A",
       status: "ongoing",
-      appId: "mcpfactory",
       toResumeAt: pastDate,
     });
-    await insertTestCampaign(org.id, {
+    await insertTestCampaign(orgId, {
       name: "Campaign B",
       status: "ongoing",
-      appId: "mcpfactory",
       toResumeAt: pastDate,
     });
 
     const count = await resumeDueCampaigns();
     expect(count).toBe(2);
     expect(mockExecute).toHaveBeenCalledTimes(2);
-  });
-
-  it("should use empty string for appId when campaign has no appId", async () => {
-    const pastDate = new Date(Date.now() - 60_000);
-    await insertTestCampaign(org.id, {
-      status: "ongoing",
-      appId: undefined,
-      toResumeAt: pastDate,
-    });
-
-    await resumeDueCampaigns();
-
-    expect(mockExecute).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ appId: "" }),
-    );
   });
 });

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -32,11 +32,9 @@ const validBody = {
   parentRunId: crypto.randomUUID(),
   brandUrl: "https://example.com",
   brandId: crypto.randomUUID(),
-  appId: "mcpfactory",
   targetOutcome: "Book sales demos",
   valueForTarget: "Enterprise analytics at startup pricing",
   targetAudience: "CTOs at SaaS companies",
-  keySource: "byok" as const,
 };
 
 describe("Workflow trigger", () => {
@@ -71,7 +69,6 @@ describe("Workflow trigger", () => {
         {
           campaignId,
           orgId: "org_activation_test",
-          appId: "mcpfactory",
         },
       );
     });
@@ -133,7 +130,6 @@ describe("Workflow trigger", () => {
         {
           campaignId,
           orgId: "org_activation_test",
-          appId: "mcpfactory",
         },
       );
     });

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -47,7 +47,6 @@ function makeCampaign(overrides: Partial<GateCheckInput> = {}): GateCheckInput {
   return {
     campaignId: "campaign-1",
     orgId: "org-1",
-    appId: "mcpfactory",
     brandId: "brand-1",
     status: "ongoing",
     maxBudgetDailyUsd: "10.00",
@@ -67,7 +66,6 @@ function makeRun(overrides: Partial<{ id: string; status: string; startedAt: str
     parentRunId: null,
     organizationId: "org-1",
     userId: null,
-    appId: "mcpfactory",
     brandId: null,
     campaignId: "campaign-1",
     serviceName: "campaign-service",
@@ -205,7 +203,7 @@ describe("Gate Check", () => {
       expect(mockDbUpdate).toHaveBeenCalled();
     });
 
-    it("should call getStatsBudget with correct windows", async () => {
+    it("should call getStatsBudget with correct windows (no appId)", async () => {
       await runGateChecks(makeCampaign({
         maxBudgetDailyUsd: "10.00",
         maxBudgetWeeklyUsd: "50.00",
@@ -215,7 +213,6 @@ describe("Gate Check", () => {
       expect(mockGetStatsBudget).toHaveBeenCalledWith(
         expect.objectContaining({
           orgId: "org-1",
-          appId: "mcpfactory",
           campaignId: "campaign-1",
           windows: expect.arrayContaining([
             expect.objectContaining({ label: "daily" }),
@@ -224,6 +221,10 @@ describe("Gate Check", () => {
           ]),
         })
       );
+
+      // Should NOT include appId
+      const callArgs = mockGetStatsBudget.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty("appId");
     });
 
     it("should only include windows for configured budgets", async () => {

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -12,9 +12,8 @@ const {
   const mockDbUpdate = vi.fn().mockReturnValue({ set: mockSet });
   const mockDbValues: Array<{
     id: string;
+    orgId: string;
     workflowName: string;
-    appId: string | null;
-    externalOrgId: string;
   }> = [];
 
   return {
@@ -34,9 +33,7 @@ vi.mock("../../src/db/index.js", () => ({
   db: {
     select: vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
-        innerJoin: vi.fn().mockReturnValue({
-          where: vi.fn().mockImplementation(() => mockDbValues),
-        }),
+        where: vi.fn().mockImplementation(() => mockDbValues),
       }),
     }),
     update: mockDbUpdate,
@@ -49,13 +46,8 @@ vi.mock("../../src/db/schema.js", () => ({
     status: "status",
     toResumeAt: "to_resume_at",
     workflowName: "workflow_name",
-    appId: "app_id",
     orgId: "org_id",
     updatedAt: "updated_at",
-  },
-  orgs: {
-    id: "id",
-    externalOrgId: "org_id",
   },
 }));
 
@@ -84,9 +76,8 @@ describe("Scheduler - resumeDueCampaigns", () => {
   it("should re-trigger due campaigns and clear toResumeAt", async () => {
     mockDbValues.push({
       id: "campaign-1",
+      orgId: "org-ext-1",
       workflowName: "sales-email-cold-outreach",
-      appId: "mcpfactory",
-      externalOrgId: "org-ext-1",
     });
 
     const count = await resumeDueCampaigns();
@@ -101,7 +92,6 @@ describe("Scheduler - resumeDueCampaigns", () => {
       {
         campaignId: "campaign-1",
         orgId: "org-ext-1",
-        appId: "mcpfactory",
       },
     );
   });
@@ -110,15 +100,13 @@ describe("Scheduler - resumeDueCampaigns", () => {
     mockDbValues.push(
       {
         id: "campaign-1",
+        orgId: "org-ext-1",
         workflowName: "sales-email-cold-outreach",
-        appId: "mcpfactory",
-        externalOrgId: "org-ext-1",
       },
       {
         id: "campaign-2",
+        orgId: "org-ext-2",
         workflowName: "pr-email-cold-outreach",
-        appId: "mcpfactory",
-        externalOrgId: "org-ext-2",
       },
     );
 
@@ -128,35 +116,17 @@ describe("Scheduler - resumeDueCampaigns", () => {
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledTimes(2);
   });
 
-  it("should use empty string when appId is null", async () => {
-    mockDbValues.push({
-      id: "campaign-1",
-      workflowName: "sales-email-cold-outreach",
-      appId: null,
-      externalOrgId: "org-ext-1",
-    });
-
-    await resumeDueCampaigns();
-
-    expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
-      "sales-email-cold-outreach",
-      expect.objectContaining({ appId: "" }),
-    );
-  });
-
   it("should continue processing other campaigns if one fails", async () => {
     mockDbValues.push(
       {
         id: "campaign-1",
+        orgId: "org-ext-1",
         workflowName: "sales-email-cold-outreach",
-        appId: "mcpfactory",
-        externalOrgId: "org-ext-1",
       },
       {
         id: "campaign-2",
+        orgId: "org-ext-2",
         workflowName: "pr-email-cold-outreach",
-        appId: "mcpfactory",
-        externalOrgId: "org-ext-2",
       },
     );
 

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -23,7 +23,6 @@ describe("Workflow module", () => {
       await executeCampaignWorkflow("sales-email-cold-outreach", {
         campaignId: "campaign-1",
         orgId: "org_test",
-        appId: "mcpfactory",
       });
 
       expect(mockFetch).toHaveBeenCalledOnce();
@@ -32,7 +31,7 @@ describe("Workflow module", () => {
       expect(opts.method).toBe("POST");
 
       const body = JSON.parse(opts.body);
-      expect(body.appId).toBe("mcpfactory");
+      expect(body).not.toHaveProperty("appId");
       expect(body.orgId).toBe("org_test");
       expect(body.inputs).toEqual({
         campaignId: "campaign-1",
@@ -52,7 +51,6 @@ describe("Workflow module", () => {
         executeCampaignWorkflow("sales-email-cold-outreach", {
           campaignId: "campaign-1",
           orgId: "org_test",
-          appId: "mcpfactory",
         })
       ).resolves.not.toThrow();
     });
@@ -66,7 +64,6 @@ describe("Workflow module", () => {
         executeCampaignWorkflow("any-workflow", {
           campaignId: "campaign-1",
           orgId: "org_test",
-          appId: "mcpfactory",
         })
       ).resolves.not.toThrow();
       expect(mockFetch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Remove `appId` from all schemas, DB columns, routes, runs-client, workflow calls, and gate-check logic
- Remove `keySource` from schemas, DB, and StartRunResponse — downstream services now resolve keys directly via key-service
- Remove local `orgs` and `users` tables — campaign-service now stores client-service UUIDs directly in `campaigns.org_id` and `campaigns.created_by_user_id`
- Simplify auth middleware from DB-backed org/user lookup to direct header passthrough
- Include DB migration (`0019_remove_appid_keysource_identity.sql`) that backfills org/user IDs before dropping tables

## Test plan
- [x] All 119 tests pass (12 test files)
- [x] TypeScript builds cleanly
- [x] OpenAPI spec regenerated
- [x] No remaining references to `appId`, `keySource`, or `x-app-id` in src/
- [ ] Run migration on staging before deploying new code
- [ ] Coordinate with runs-service team — runs-client no longer sends `appId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)