### PR TITLE
refactor: replace parentRunId body field with x-run-id header

### DIFF
--- a/drizzle/0020_drop_parent_run_id.sql
+++ b/drizzle/0020_drop_parent_run_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "campaigns" DROP COLUMN IF EXISTS "parent_run_id";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,20 @@
       "when": 1771700000000,
       "tag": "0018_rename_clerk_to_org_user_ids",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1771800000000,
+      "tag": "0019_remove_appid_keysource_identity",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1772503751788,
+      "tag": "0020_drop_parent_run_id",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -49,11 +49,6 @@
             "nullable": true,
             "format": "uuid"
           },
-          "parentRunId": {
-            "type": "string",
-            "nullable": true,
-            "format": "uuid"
-          },
           "targetAudience": {
             "type": "string",
             "nullable": true
@@ -128,7 +123,6 @@
           "workflowName",
           "brandUrl",
           "brandId",
-          "parentRunId",
           "targetAudience",
           "targetOutcome",
           "valueForTarget",
@@ -173,10 +167,6 @@
           "orgId": {
             "type": "string",
             "minLength": 1
-          },
-          "parentRunId": {
-            "type": "string",
-            "format": "uuid"
           },
           "brandUrl": {
             "type": "string",
@@ -232,7 +222,6 @@
           "name",
           "workflowName",
           "orgId",
-          "parentRunId",
           "brandUrl",
           "brandId",
           "targetOutcome",
@@ -244,10 +233,6 @@
         "properties": {
           "name": {
             "type": "string"
-          },
-          "parentRunId": {
-            "type": "string",
-            "format": "uuid"
           },
           "brandUrl": {
             "type": "string"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -20,9 +20,6 @@ export const campaigns = pgTable(
     // Nullable initially, populated when brand is created/found in brand-service
     brandId: text("brand_id"),
 
-    // Parent run ID from api-service — root of the cost tree for this campaign's runs
-    parentRunId: text("parent_run_id"),
-
     // Free-text target audience description (e.g. "CEOs at SaaS startups in the US")
     targetAudience: text("target_audience"),
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from "express";
 export interface AuthenticatedRequest extends Request {
   userId?: string;
   orgId?: string;
+  runId?: string;
 }
 
 /**
@@ -17,6 +18,7 @@ export function serviceAuth(
 ) {
   const orgId = req.headers["x-org-id"] as string;
   const userId = req.headers["x-user-id"] as string | undefined;
+  const runId = req.headers["x-run-id"] as string | undefined;
 
   if (!orgId) {
     return res.status(400).json({ error: "x-org-id header required" });
@@ -25,6 +27,9 @@ export function serviceAuth(
   req.orgId = orgId;
   if (userId) {
     req.userId = userId;
+  }
+  if (runId) {
+    req.runId = runId;
   }
 
   next();

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -216,7 +216,6 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     const {
       name,
       workflowName,
-      parentRunId,
       brandUrl,
       brandId,
       targetAudience,
@@ -244,7 +243,6 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         createdByUserId: req.userId ?? null,
         name,
         workflowName,
-        parentRunId,
         brandUrl: normalizedBrandUrl,
         brandId,
         targetAudience,
@@ -296,11 +294,6 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
 
     if (!existing) {
       return res.status(404).json({ error: "Campaign not found" });
-    }
-
-    // Activating requires a parentRunId (api-service creates a parent run first)
-    if (req.body.status === "activate" && !req.body.parentRunId) {
-      return res.status(400).json({ error: "parentRunId is required when activating a campaign" });
     }
 
     const statusMap: Record<string, string> = { activate: "ongoing", stop: "stopped" };

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -115,8 +115,9 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
       return res.status(400).json({ error: "Campaign has no brandId" });
     }
 
-    // Create run in runs-service (parentRunId links to api-service's parent run)
-    console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId} (parentRunId=${campaign.parentRunId || "none"})...`);
+    // Create run in runs-service (x-run-id from caller becomes parentRunId)
+    const parentRunId = req.headers["x-run-id"] as string | undefined;
+    console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId} (parentRunId=${parentRunId || "none"})...`);
     const run = await createRun({
       orgId,
       serviceName: "campaign-service",
@@ -124,7 +125,7 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
       campaignId,
       brandId: campaign.brandId,
       userId: campaign.createdByUserId || undefined,
-      parentRunId: campaign.parentRunId || undefined,
+      parentRunId: parentRunId || undefined,
       workflowName: campaign.workflowName,
     });
     console.log(`[Start Run] Run created: runId=${run.id}`);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -17,7 +17,6 @@ export const CampaignSchema = z.object({
   workflowName: z.string(),
   brandUrl: z.string().nullable(),
   brandId: z.string().uuid().nullable(),
-  parentRunId: z.string().uuid().nullable(),
   targetAudience: z.string().nullable(),
   targetOutcome: z.string().nullable(),
   valueForTarget: z.string().nullable(),
@@ -43,7 +42,6 @@ export const CreateCampaignBody = z.object({
   name: z.string().min(1, "Campaign name is required"),
   workflowName: z.string().min(1, "workflowName is required"),
   orgId: z.string().min(1, "orgId is required"),
-  parentRunId: z.string().uuid("parentRunId must be a valid UUID"),
   brandUrl: z.string().min(1, "brandUrl is required"),
   brandId: z.string().uuid("brandId must be a valid UUID"),
   targetAudience: z.string().optional(),
@@ -63,7 +61,6 @@ export const CreateCampaignBody = z.object({
 
 export const UpdateCampaignBody = z.object({
   name: z.string().optional(),
-  parentRunId: z.string().uuid("parentRunId must be a valid UUID").optional(),
   brandUrl: z.string().optional(),
   brandId: z.string().uuid().optional(),
   targetAudience: z.string().optional(),

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -18,7 +18,6 @@ export async function insertTestCampaign(
     name?: string;
     workflowName?: string;
     status?: string;
-    parentRunId?: string;
     brandUrl?: string;
     brandId?: string;
     maxBudgetDailyUsd?: string;
@@ -40,7 +39,6 @@ export async function insertTestCampaign(
       name: data.name || `Test Campaign ${Date.now()}`,
       workflowName: data.workflowName || "sales-email-cold-outreach",
       status: data.status || "ongoing",
-      parentRunId: data.parentRunId || null,
       brandUrl: data.brandUrl || null,
       brandId: data.brandId || null,
       maxBudgetDailyUsd: data.maxBudgetDailyUsd || "10.00",

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -19,7 +19,6 @@ describe("Campaign CRUD", () => {
     name: "Test Campaign",
     workflowName: "sales-email-cold-outreach",
     orgId: "org_test_crud",
-    parentRunId: crypto.randomUUID(),
     brandUrl: "https://example.com",
     brandId: crypto.randomUUID(),
     targetOutcome: "Book sales demos",
@@ -49,41 +48,6 @@ describe("Campaign CRUD", () => {
         .set("x-api-key", API_KEY)
         .set("x-org-id", "org_test_crud")
         .send(body)
-        .expect(400);
-
-      expect(res.body.error).toBeDefined();
-    });
-
-    it("should store parentRunId on the campaign", async () => {
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(validBody)
-        .expect(201);
-
-      expect(res.body.campaign.parentRunId).toBe(validBody.parentRunId);
-    });
-
-    it("should reject when parentRunId is missing", async () => {
-      const { parentRunId, ...body } = validBody;
-
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(body)
-        .expect(400);
-
-      expect(res.body.error).toBeDefined();
-    });
-
-    it("should reject when parentRunId is not a valid UUID", async () => {
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({ ...validBody, parentRunId: "not-a-uuid" })
         .expect(400);
 
       expect(res.body.error).toBeDefined();
@@ -241,7 +205,7 @@ describe("Campaign CRUD", () => {
   });
 
   describe("PATCH /campaigns/:id", () => {
-    it("should reject activate without parentRunId", async () => {
+    it("should accept activate", async () => {
       const createRes = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
@@ -259,45 +223,14 @@ describe("Campaign CRUD", () => {
         .send({ status: "stop" })
         .expect(200);
 
-      // Activate without parentRunId → 400
-      const res = await request(app)
-        .patch(`/campaigns/${campaignId}`)
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({ status: "activate" })
-        .expect(400);
-
-      expect(res.body.error).toBe("parentRunId is required when activating a campaign");
-    });
-
-    it("should accept activate with parentRunId and update stored value", async () => {
-      const createRes = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(validBody)
-        .expect(201);
-
-      const campaignId = createRes.body.campaign.id;
-
-      // Stop first
-      await request(app)
-        .patch(`/campaigns/${campaignId}`)
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({ status: "stop" })
-        .expect(200);
-
-      // Activate with new parentRunId
-      const newParentRunId = crypto.randomUUID();
+      // Activate
       const activateRes = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
         .set("x-org-id", "org_test_crud")
-        .send({ status: "activate", parentRunId: newParentRunId })
+        .send({ status: "activate" })
         .expect(200);
 
-      expect(activateRes.body.campaign.parentRunId).toBe(newParentRunId);
       expect(activateRes.body.campaign.status).toBe("ongoing");
     });
 

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -377,17 +377,17 @@ describe("Pipeline routes", () => {
       expect(res.body.brandUrl).toBe("https://www.example.com/path");
     });
 
-    it("should pass parentRunId to createRun when campaign has one", async () => {
+    it("should pass x-run-id header as parentRunId to createRun", async () => {
       const parentRunId = crypto.randomUUID();
       const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
-        parentRunId,
       });
 
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
+        .set("x-run-id", parentRunId)
         .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
@@ -396,7 +396,7 @@ describe("Pipeline routes", () => {
       );
     });
 
-    it("should NOT pass parentRunId to createRun when campaign has none", async () => {
+    it("should NOT pass parentRunId to createRun when x-run-id header is absent", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -29,7 +29,6 @@ const validBody = {
   name: "Activation Test Campaign",
   workflowName: "sales-email-cold-outreach",
   orgId: "org_activation_test",
-  parentRunId: crypto.randomUUID(),
   brandUrl: "https://example.com",
   brandId: crypto.randomUUID(),
   targetOutcome: "Book sales demos",
@@ -116,7 +115,7 @@ describe("Workflow trigger", () => {
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
         .set("x-org-id", "org_activation_test")
-        .send({ status: "activate", parentRunId: crypto.randomUUID() })
+        .send({ status: "activate" })
         .expect(200);
 
       expect(activateRes.body.campaign.status).toBe("ongoing");
@@ -212,7 +211,7 @@ describe("Workflow trigger", () => {
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
         .set("x-org-id", "org_activation_test")
-        .send({ status: "activate", parentRunId: crypto.randomUUID() })
+        .send({ status: "activate" })
         .expect(200);
 
       expect(activateRes.body.campaign.status).toBe("ongoing");


### PR DESCRIPTION
## Summary
- Remove `parentRunId` from request bodies (`CreateCampaignBody`, `UpdateCampaignBody`) and DB column (`parent_run_id`)
- Add `x-run-id` header support in `serviceAuth` middleware (read into `req.runId`)
- `/start-run` now reads `x-run-id` from the caller's header and uses it as `parentRunId` when creating runs in runs-service
- The run tree lives exclusively in runs-service — campaign-service no longer stores it

## Test plan
- [x] All 115 tests pass (12 test files)
- [x] Build succeeds
- [x] OpenAPI spec regenerated — `parentRunId` removed from all schemas
- [x] Drizzle migration `0020_drop_parent_run_id.sql` created to drop the column

🤖 Generated with [Claude Code](https://claude.com/claude-code)