### PR TITLE
fix: resolve Clerk IDs to client-service UUIDs in migration

### DIFF
--- a/drizzle/0019_remove_appid_keysource_identity.sql
+++ b/drizzle/0019_remove_appid_keysource_identity.sql
@@ -1,39 +1,42 @@
 -- Migration: Remove appId, keySource, and local identity tables
+-- Prerequisites: run scripts/migrate-clerk-to-client-ids.ts FIRST to resolve
+-- Clerk IDs in orgs.org_id / users.user_id to client-service UUIDs.
+--
 -- This migration:
--- 1. Backfills campaigns.org_id with the external org ID from the orgs lookup table
--- 2. Backfills campaigns.created_by_user_id with the external user ID from the users lookup table
+-- 1. Backfills campaigns.org_id with the client-service UUID from the orgs lookup table
+-- 2. Backfills campaigns.created_by_user_id with the client-service UUID from the users lookup table
 -- 3. Converts org_id and created_by_user_id columns from uuid to text
 -- 4. Drops app_id and key_source columns
 -- 5. Drops the local orgs and users identity tables
 
--- Step 1: Backfill org_id with external org ID
+-- Step 1: Backfill org_id with client-service UUID (cast text → uuid for assignment)
 UPDATE "campaigns"
 SET "org_id" = (
-  SELECT "orgs"."org_id"
+  SELECT "orgs"."org_id"::uuid
   FROM "orgs"
-  WHERE "orgs"."id" = "campaigns"."org_id"::uuid
+  WHERE "orgs"."id" = "campaigns"."org_id"
 )
 WHERE EXISTS (
-  SELECT 1 FROM "orgs" WHERE "orgs"."id" = "campaigns"."org_id"::uuid
+  SELECT 1 FROM "orgs" WHERE "orgs"."id" = "campaigns"."org_id"
 );
 
--- Step 2: Backfill created_by_user_id with external user ID
+-- Step 2: Backfill created_by_user_id with client-service UUID
 UPDATE "campaigns"
 SET "created_by_user_id" = (
-  SELECT "users"."user_id"
+  SELECT "users"."user_id"::uuid
   FROM "users"
-  WHERE "users"."id" = "campaigns"."created_by_user_id"::uuid
+  WHERE "users"."id" = "campaigns"."created_by_user_id"
 )
 WHERE "created_by_user_id" IS NOT NULL
 AND EXISTS (
-  SELECT 1 FROM "users" WHERE "users"."id" = "campaigns"."created_by_user_id"::uuid
+  SELECT 1 FROM "users" WHERE "users"."id" = "campaigns"."created_by_user_id"
 );
 
 -- Step 3: Drop FK constraints and change column types
 ALTER TABLE "campaigns" DROP CONSTRAINT IF EXISTS "campaigns_org_id_orgs_id_fk";
 ALTER TABLE "campaigns" DROP CONSTRAINT IF EXISTS "campaigns_created_by_user_id_users_id_fk";
-ALTER TABLE "campaigns" ALTER COLUMN "org_id" TYPE text;
-ALTER TABLE "campaigns" ALTER COLUMN "created_by_user_id" TYPE text;
+ALTER TABLE "campaigns" ALTER COLUMN "org_id" TYPE text USING "org_id"::text;
+ALTER TABLE "campaigns" ALTER COLUMN "created_by_user_id" TYPE text USING "created_by_user_id"::text;
 
 -- Step 4: Drop app_id column and its index
 DROP INDEX IF EXISTS "idx_campaigns_app_id";

--- a/scripts/migrate-clerk-to-client-ids.ts
+++ b/scripts/migrate-clerk-to-client-ids.ts
@@ -1,115 +1,168 @@
 /**
  * One-shot migration script: resolve Clerk IDs → client-service UUIDs
  *
- * For each org/user in the local DB, calls client-service to resolve
- * the old Clerk ID to the internal client-service UUID, then updates
- * the local record.
+ * For each org/user in the local lookup tables, calls client-service to
+ * resolve the Clerk ID to the internal client-service UUID, then updates
+ * the local record. After this script runs, migration 0019 can safely
+ * backfill campaigns and drop the lookup tables.
  *
  * Prerequisites:
  *   - DB migration 0018 (column rename) must be applied first
- *   - CLIENT_SERVICE_URL and CLIENT_SERVICE_API_KEY env vars must be set
+ *   - Environment variables: CAMPAIGN_SERVICE_DATABASE_URL, CLIENT_SERVICE_URL, CLIENT_SERVICE_API_KEY
  *
  * Usage:
- *   CLIENT_SERVICE_URL=https://... CLIENT_SERVICE_API_KEY=... npx tsx scripts/migrate-clerk-to-client-ids.ts
+ *   CAMPAIGN_SERVICE_DATABASE_URL=... CLIENT_SERVICE_URL=... CLIENT_SERVICE_API_KEY=... npx tsx scripts/migrate-clerk-to-client-ids.ts
  */
 
-import { db, sql } from "../src/db/index.js";
-import { orgs, users } from "../src/db/schema.js";
-import { eq } from "drizzle-orm";
+import postgres from "postgres";
 
-const CLIENT_SERVICE_URL = process.env.CLIENT_SERVICE_URL;
-const CLIENT_SERVICE_API_KEY = process.env.CLIENT_SERVICE_API_KEY;
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-if (!CLIENT_SERVICE_URL || !CLIENT_SERVICE_API_KEY) {
-  console.error("CLIENT_SERVICE_URL and CLIENT_SERVICE_API_KEY are required");
-  process.exit(1);
+export function makeResolver(baseUrl: string, apiKey: string) {
+  async function resolveOrgId(clerkOrgId: string): Promise<string | null> {
+    const res = await fetch(
+      `${baseUrl}/orgs/by-clerk/${encodeURIComponent(clerkOrgId)}`,
+      { headers: { "x-api-key": apiKey } },
+    );
+    if (!res.ok) {
+      console.error(`  Failed to resolve org ${clerkOrgId}: ${res.status}`);
+      return null;
+    }
+    const data = (await res.json()) as { org: { id: string } };
+    return data.org.id;
+  }
+
+  async function resolveUserId(clerkUserId: string): Promise<string | null> {
+    const res = await fetch(
+      `${baseUrl}/users/by-clerk/${encodeURIComponent(clerkUserId)}`,
+      { headers: { "x-api-key": apiKey } },
+    );
+    if (!res.ok) {
+      console.error(`  Failed to resolve user ${clerkUserId}: ${res.status}`);
+      return null;
+    }
+    const data = (await res.json()) as { user: { id: string } };
+    return data.user.id;
+  }
+
+  return { resolveOrgId, resolveUserId };
 }
 
-async function resolveOrgId(clerkOrgId: string): Promise<string | null> {
-  const res = await fetch(`${CLIENT_SERVICE_URL}/orgs/by-clerk/${encodeURIComponent(clerkOrgId)}`, {
-    headers: { "x-api-key": CLIENT_SERVICE_API_KEY! },
-  });
-  if (!res.ok) {
-    console.error(`  Failed to resolve org ${clerkOrgId}: ${res.status}`);
-    return null;
+export async function migrateOrgs(
+  querySql: postgres.Sql,
+  resolve: (clerkId: string) => Promise<string | null>,
+): Promise<{ success: number; skipped: number; failed: number }> {
+  const allOrgs = await querySql`SELECT id, org_id FROM orgs`;
+  console.log(`Found ${allOrgs.length} orgs to migrate`);
+
+  let success = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const org of allOrgs) {
+    if (UUID_RE.test(org.org_id)) {
+      skipped++;
+      continue;
+    }
+
+    const newId = await resolve(org.org_id);
+    if (newId) {
+      await querySql`UPDATE orgs SET org_id = ${newId} WHERE id = ${org.id}`;
+      console.log(`  org ${org.id}: ${org.org_id} → ${newId}`);
+      success++;
+    } else {
+      failed++;
+    }
   }
-  const data = (await res.json()) as { org: { id: string } };
-  return data.org.id;
+
+  return { success, skipped, failed };
 }
 
-async function resolveUserId(clerkUserId: string): Promise<string | null> {
-  const res = await fetch(`${CLIENT_SERVICE_URL}/users/by-clerk/${encodeURIComponent(clerkUserId)}`, {
-    headers: { "x-api-key": CLIENT_SERVICE_API_KEY! },
-  });
-  if (!res.ok) {
-    console.error(`  Failed to resolve user ${clerkUserId}: ${res.status}`);
-    return null;
+export async function migrateUsers(
+  querySql: postgres.Sql,
+  resolve: (clerkId: string) => Promise<string | null>,
+): Promise<{ success: number; skipped: number; failed: number }> {
+  const allUsers = await querySql`SELECT id, user_id FROM users`;
+  console.log(`Found ${allUsers.length} users to migrate`);
+
+  let success = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const user of allUsers) {
+    if (UUID_RE.test(user.user_id)) {
+      skipped++;
+      continue;
+    }
+
+    const newId = await resolve(user.user_id);
+    if (newId) {
+      await querySql`UPDATE users SET user_id = ${newId} WHERE id = ${user.id}`;
+      console.log(`  user ${user.id}: ${user.user_id} → ${newId}`);
+      success++;
+    } else {
+      failed++;
+    }
   }
-  const data = (await res.json()) as { user: { id: string } };
-  return data.user.id;
+
+  return { success, skipped, failed };
 }
 
 async function main() {
+  const DATABASE_URL = process.env.CAMPAIGN_SERVICE_DATABASE_URL;
+  const CLIENT_SERVICE_URL = process.env.CLIENT_SERVICE_URL;
+  const CLIENT_SERVICE_API_KEY = process.env.CLIENT_SERVICE_API_KEY;
+
+  if (!DATABASE_URL || !CLIENT_SERVICE_URL || !CLIENT_SERVICE_API_KEY) {
+    console.error("Required: CAMPAIGN_SERVICE_DATABASE_URL, CLIENT_SERVICE_URL, CLIENT_SERVICE_API_KEY");
+    process.exit(1);
+  }
+
+  const sql = postgres(DATABASE_URL);
+  const { resolveOrgId, resolveUserId } = makeResolver(CLIENT_SERVICE_URL, CLIENT_SERVICE_API_KEY);
+
   console.log("=== Migrating Clerk IDs to client-service UUIDs ===\n");
 
-  // Migrate orgs
-  const allOrgs = await db.select().from(orgs);
-  console.log(`Found ${allOrgs.length} orgs to migrate`);
+  // Check if tables exist
+  const tables = await sql`
+    SELECT table_name FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name IN ('orgs', 'users')
+  `;
+  const tableNames = new Set(tables.map((t) => t.table_name));
 
-  let orgSuccess = 0;
-  let orgSkipped = 0;
-  let orgFailed = 0;
-
-  for (const org of allOrgs) {
-    // Skip if already looks like a UUID (already migrated)
-    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(org.externalOrgId)) {
-      orgSkipped++;
-      continue;
+  if (tableNames.has("orgs")) {
+    const orgResult = await migrateOrgs(sql, resolveOrgId);
+    console.log(`\nOrgs: ${orgResult.success} migrated, ${orgResult.skipped} skipped, ${orgResult.failed} failed\n`);
+    if (orgResult.failed > 0) {
+      console.error("ABORTING: some orgs failed to resolve");
+      await sql.end();
+      process.exit(1);
     }
-
-    const newId = await resolveOrgId(org.externalOrgId);
-    if (newId) {
-      await db.update(orgs).set({ externalOrgId: newId }).where(eq(orgs.id, org.id));
-      console.log(`  org ${org.id}: ${org.externalOrgId} → ${newId}`);
-      orgSuccess++;
-    } else {
-      orgFailed++;
-    }
+  } else {
+    console.log("orgs table does not exist — already migrated\n");
   }
 
-  console.log(`\nOrgs: ${orgSuccess} migrated, ${orgSkipped} skipped (already UUID), ${orgFailed} failed\n`);
-
-  // Migrate users
-  const allUsers = await db.select().from(users);
-  console.log(`Found ${allUsers.length} users to migrate`);
-
-  let userSuccess = 0;
-  let userSkipped = 0;
-  let userFailed = 0;
-
-  for (const user of allUsers) {
-    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(user.externalUserId)) {
-      userSkipped++;
-      continue;
+  if (tableNames.has("users")) {
+    const userResult = await migrateUsers(sql, resolveUserId);
+    console.log(`\nUsers: ${userResult.success} migrated, ${userResult.skipped} skipped, ${userResult.failed} failed`);
+    if (userResult.failed > 0) {
+      console.error("ABORTING: some users failed to resolve");
+      await sql.end();
+      process.exit(1);
     }
-
-    const newId = await resolveUserId(user.externalUserId);
-    if (newId) {
-      await db.update(users).set({ externalUserId: newId }).where(eq(users.id, user.id));
-      console.log(`  user ${user.id}: ${user.externalUserId} → ${newId}`);
-      userSuccess++;
-    } else {
-      userFailed++;
-    }
+  } else {
+    console.log("users table does not exist — already migrated");
   }
 
-  console.log(`\nUsers: ${userSuccess} migrated, ${userSkipped} skipped (already UUID), ${userFailed} failed`);
-  console.log("\n=== Migration complete ===");
-
+  console.log("\n=== Resolution complete ===");
   await sql.end();
 }
 
-main().catch((err) => {
-  console.error("Migration failed:", err);
-  process.exit(1);
-});
+// Only run main() when executed directly (not imported in tests)
+const isDirectRun = process.argv[1]?.includes("migrate-clerk-to-client-ids");
+if (isDirectRun) {
+  main().catch(async (err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/migration-script.test.ts
+++ b/tests/unit/migration-script.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { migrateOrgs, migrateUsers } from "../../scripts/migrate-clerk-to-client-ids.js";
+
+// Minimal tagged-template mock that mimics postgres `sql` usage.
+// The first call returns `rows` (SELECT); subsequent calls return [] (UPDATEs).
+function createMockSql(rows: Record<string, unknown>[]) {
+  let callCount = 0;
+  const fn = async () => {
+    callCount++;
+    return callCount === 1 ? rows : [];
+  };
+  return fn as unknown as Parameters<typeof migrateOrgs>[0];
+}
+
+// Tracking mock that records UPDATE values
+function createTrackingSql(rows: Record<string, unknown>[]) {
+  let callCount = 0;
+  const updates: Record<string, unknown>[] = [];
+  const fn = async (_strings: TemplateStringsArray, ..._values: unknown[]) => {
+    callCount++;
+    if (callCount === 1) return rows;
+    updates.push({ newValue: _values[0], id: _values[1] });
+    return [];
+  };
+  return { sql: fn as unknown as Parameters<typeof migrateOrgs>[0], updates };
+}
+
+describe("migrate-clerk-to-client-ids", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("migrateOrgs", () => {
+    it("resolves Clerk IDs and returns success count", async () => {
+      const rows = [
+        { id: "aaa-local-uuid", org_id: "org_2abc" },
+        { id: "bbb-local-uuid", org_id: "org_2def" },
+      ];
+      const { sql: mockSql, updates } = createTrackingSql(rows);
+
+      const resolve = vi.fn()
+        .mockResolvedValueOnce("aaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        .mockResolvedValueOnce("bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+      const result = await migrateOrgs(mockSql, resolve);
+
+      expect(result).toEqual({ success: 2, skipped: 0, failed: 0 });
+      expect(resolve).toHaveBeenCalledWith("org_2abc");
+      expect(resolve).toHaveBeenCalledWith("org_2def");
+      expect(updates).toHaveLength(2);
+      expect(updates[0]).toEqual({ newValue: "aaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", id: "aaa-local-uuid" });
+    });
+
+    it("skips rows that already have UUID values", async () => {
+      const rows = [
+        { id: "aaa", org_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479" },
+      ];
+      const mockSql = createMockSql(rows);
+      const resolve = vi.fn();
+
+      const result = await migrateOrgs(mockSql, resolve);
+
+      expect(result).toEqual({ success: 0, skipped: 1, failed: 0 });
+      expect(resolve).not.toHaveBeenCalled();
+    });
+
+    it("counts failures when resolve returns null", async () => {
+      const rows = [{ id: "aaa", org_id: "org_2fail" }];
+      const mockSql = createMockSql(rows);
+      const resolve = vi.fn().mockResolvedValue(null);
+
+      const result = await migrateOrgs(mockSql, resolve);
+
+      expect(result).toEqual({ success: 0, skipped: 0, failed: 1 });
+    });
+
+    it("handles empty table", async () => {
+      const mockSql = createMockSql([]);
+      const resolve = vi.fn();
+
+      const result = await migrateOrgs(mockSql, resolve);
+
+      expect(result).toEqual({ success: 0, skipped: 0, failed: 0 });
+      expect(resolve).not.toHaveBeenCalled();
+    });
+
+    it("handles mix of already-migrated and Clerk IDs", async () => {
+      const rows = [
+        { id: "aaa", org_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479" },
+        { id: "bbb", org_id: "org_2needsfix" },
+      ];
+      const { sql: mockSql } = createTrackingSql(rows);
+      const resolve = vi.fn().mockResolvedValue("cccc-cccc-cccc-cccc-cccccccccccc");
+
+      const result = await migrateOrgs(mockSql, resolve);
+
+      expect(result).toEqual({ success: 1, skipped: 1, failed: 0 });
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(resolve).toHaveBeenCalledWith("org_2needsfix");
+    });
+  });
+
+  describe("migrateUsers", () => {
+    it("resolves Clerk user IDs and returns success count", async () => {
+      const rows = [{ id: "uuu-local", user_id: "user_2abc" }];
+      const { sql: mockSql } = createTrackingSql(rows);
+      const resolve = vi.fn().mockResolvedValue("dddd-dddd-dddd-dddd-dddddddddddd");
+
+      const result = await migrateUsers(mockSql, resolve);
+
+      expect(result).toEqual({ success: 1, skipped: 0, failed: 0 });
+      expect(resolve).toHaveBeenCalledWith("user_2abc");
+    });
+
+    it("skips rows that already have UUID values", async () => {
+      const rows = [
+        { id: "uuu", user_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" },
+      ];
+      const mockSql = createMockSql(rows);
+      const resolve = vi.fn();
+
+      const result = await migrateUsers(mockSql, resolve);
+
+      expect(result).toEqual({ success: 0, skipped: 1, failed: 0 });
+      expect(resolve).not.toHaveBeenCalled();
+    });
+
+    it("counts failures when resolve returns null", async () => {
+      const rows = [{ id: "uuu", user_id: "user_2fail" }];
+      const mockSql = createMockSql(rows);
+      const resolve = vi.fn().mockResolvedValue(null);
+
+      const result = await migrateUsers(mockSql, resolve);
+
+      expect(result).toEqual({ success: 0, skipped: 0, failed: 1 });
+    });
+  });
+});

--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -84,8 +84,28 @@ describe('No Legacy Patterns - CRITICAL', () => {
   it('should have brandId column in schema', () => {
     const schemaFile = path.join(srcDir, 'db/schema.ts');
     const content = fs.readFileSync(schemaFile, 'utf-8');
-    
+
     expect(content).toContain('brandId');
     expect(content).toContain('brand_id');
+  });
+
+  it('should NOT define orgs or users tables in schema', () => {
+    const schemaFile = path.join(srcDir, 'db/schema.ts');
+    const content = fs.readFileSync(schemaFile, 'utf-8');
+
+    expect(content).not.toMatch(/export\s+const\s+orgs\b/);
+    expect(content).not.toMatch(/export\s+const\s+users\b/);
+    expect(content).not.toMatch(/pgTable\(\s*["']orgs["']/);
+    expect(content).not.toMatch(/pgTable\(\s*["']users["']/);
+  });
+
+  it('should NOT have appId or keySource columns in schema', () => {
+    const schemaFile = path.join(srcDir, 'db/schema.ts');
+    const content = fs.readFileSync(schemaFile, 'utf-8');
+
+    expect(content).not.toMatch(/appId\s*:/);
+    expect(content).not.toMatch(/["']app_id["']/);
+    expect(content).not.toMatch(/keySource\s*:/);
+    expect(content).not.toMatch(/["']key_source["']/);
   });
 });


### PR DESCRIPTION
## Summary
- Rewrote `scripts/migrate-clerk-to-client-ids.ts` to use raw SQL (orgs/users tables removed from schema.ts), correct column names (`org_id`/`user_id` after migration 0018 rename), idempotency (skips already-UUID values), and abort-on-failure
- Fixed migration 0019 SQL: added `::uuid` cast on SELECT results so resolved UUIDs can be assigned to uuid-typed columns, and added `USING` clause for explicit type conversion
- Added 8 unit tests for the resolution script (resolve, skip, fail, empty, mixed scenarios)
- Extended no-legacy tests to verify schema has no orgs/users tables and no appId/keySource

## Deployment order
1. **Pre-deploy:** Run `scripts/migrate-clerk-to-client-ids.ts` against prod to resolve Clerk IDs → client-service UUIDs in orgs/users tables
2. **Deploy:** Migration 0019 auto-runs at startup — backfills campaigns, drops lookup tables

## Test plan
- [x] `pnpm test:unit` — 48 tests pass (6 files)
- [x] `pnpm run build` — compiles + generates OpenAPI spec
- [ ] Run resolution script against prod with CLIENT_SERVICE_URL + CLIENT_SERVICE_API_KEY
- [ ] Deploy and verify service starts (migration 0019 succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)