### PR TITLE
fix: forward x-org-id, x-user-id, x-run-id headers to downstream services

### DIFF
--- a/packages/runs-client/src/index.ts
+++ b/packages/runs-client/src/index.ts
@@ -24,6 +24,13 @@ export interface Run {
   updatedAt: string;
 }
 
+/** Identity headers forwarded to runs-service on every request. */
+export interface IdentityHeaders {
+  orgId: string;
+  userId?: string;
+  runId?: string;
+}
+
 export interface CreateRunParams {
   orgId: string;
   serviceName: string;
@@ -76,15 +83,24 @@ export interface StatsBudgetResponse {
 
 // ─── HTTP helpers ────────────────────────────────────────────────────────────
 
+function buildIdentityHeaders(identity?: IdentityHeaders): Record<string, string> {
+  const h: Record<string, string> = {};
+  if (identity?.orgId) h["x-org-id"] = identity.orgId;
+  if (identity?.userId) h["x-user-id"] = identity.userId;
+  if (identity?.runId) h["x-run-id"] = identity.runId;
+  return h;
+}
+
 async function runsRequest<T>(
   path: string,
-  options: { method?: string; body?: unknown } = {}
+  options: { method?: string; body?: unknown; identity?: IdentityHeaders } = {}
 ): Promise<T> {
-  const { method = "GET", body } = options;
+  const { method = "GET", body, identity } = options;
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "X-API-Key": RUNS_SERVICE_API_KEY,
+    ...buildIdentityHeaders(identity),
   };
 
   const response = await fetch(`${RUNS_SERVICE_URL}${path}`, {
@@ -105,11 +121,15 @@ async function runsRequest<T>(
 
 /**
  * Create a new run in runs-service.
+ * orgId/userId are sent as x-org-id/x-user-id headers.
+ * parentRunId is sent as x-run-id header.
  */
 export async function createRun(params: CreateRunParams): Promise<Run> {
+  const { orgId, userId, parentRunId, ...body } = params;
   return runsRequest<Run>("/v1/runs", {
     method: "POST",
-    body: params,
+    body,
+    identity: { orgId, userId, runId: parentRunId },
   });
 }
 
@@ -118,46 +138,53 @@ export async function createRun(params: CreateRunParams): Promise<Run> {
  */
 export async function updateRun(
   runId: string,
-  status: "completed" | "failed"
+  status: "completed" | "failed",
+  identity?: IdentityHeaders,
 ): Promise<Run> {
   return runsRequest<Run>(`/v1/runs/${runId}`, {
     method: "PATCH",
     body: { status },
+    identity,
   });
 }
 
 /**
  * List runs with filters.
+ * orgId is sent as x-org-id header (not query param).
  */
 export async function listRuns(
   params: ListRunsParams
 ): Promise<{ runs: Run[]; limit: number; offset: number }> {
+  const { orgId, ...rest } = params;
   const searchParams = new URLSearchParams();
-  searchParams.set("orgId", params.orgId);
-  if (params.userId) searchParams.set("userId", params.userId);
-  if (params.brandId) searchParams.set("brandId", params.brandId);
-  if (params.campaignId) searchParams.set("campaignId", params.campaignId);
-  if (params.serviceName) searchParams.set("serviceName", params.serviceName);
-  if (params.taskName) searchParams.set("taskName", params.taskName);
-  if (params.status) searchParams.set("status", params.status);
-  if (params.parentRunId) searchParams.set("parentRunId", params.parentRunId);
-  if (params.startedAfter) searchParams.set("startedAfter", params.startedAfter);
-  if (params.startedBefore) searchParams.set("startedBefore", params.startedBefore);
-  if (params.limit) searchParams.set("limit", String(params.limit));
-  if (params.offset) searchParams.set("offset", String(params.offset));
+  if (rest.userId) searchParams.set("userId", rest.userId);
+  if (rest.brandId) searchParams.set("brandId", rest.brandId);
+  if (rest.campaignId) searchParams.set("campaignId", rest.campaignId);
+  if (rest.serviceName) searchParams.set("serviceName", rest.serviceName);
+  if (rest.taskName) searchParams.set("taskName", rest.taskName);
+  if (rest.status) searchParams.set("status", rest.status);
+  if (rest.parentRunId) searchParams.set("parentRunId", rest.parentRunId);
+  if (rest.startedAfter) searchParams.set("startedAfter", rest.startedAfter);
+  if (rest.startedBefore) searchParams.set("startedBefore", rest.startedBefore);
+  if (rest.limit) searchParams.set("limit", String(rest.limit));
+  if (rest.offset) searchParams.set("offset", String(rest.offset));
 
+  const qs = searchParams.toString();
   return runsRequest<{ runs: Run[]; limit: number; offset: number }>(
-    `/v1/runs?${searchParams.toString()}`
+    qs ? `/v1/runs?${qs}` : "/v1/runs",
+    { identity: { orgId } },
   );
 }
 
 /**
  * Get aggregated costs across temporal windows.
- * Used for budget checks — returns actual + provisioned costs per window.
+ * orgId is sent as x-org-id header (not in body).
  */
 export async function getStatsBudget(params: StatsBudgetParams): Promise<StatsBudgetResponse> {
+  const { orgId, ...body } = params;
   return runsRequest<StatsBudgetResponse>("/v1/stats/budget", {
     method: "POST",
-    body: params,
+    body,
+    identity: { orgId },
   });
 }

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -1,4 +1,4 @@
-import { listRuns, updateRun, getStatsBudget, type Run, type BudgetWindow } from "@mcpfactory/runs-client";
+import { listRuns, updateRun, getStatsBudget, type Run, type BudgetWindow, type IdentityHeaders } from "@mcpfactory/runs-client";
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { eq } from "drizzle-orm";
@@ -9,6 +9,8 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 export interface GateCheckInput {
   campaignId: string;
   orgId: string;
+  userId?: string;
+  runId?: string;
   brandId: string;
   status: string;
   maxBudgetDailyUsd: string | null;
@@ -31,6 +33,12 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     return { allowed: false, reason: "Campaign is not ongoing" };
   }
 
+  const identity: IdentityHeaders = {
+    orgId: campaign.orgId,
+    userId: campaign.userId,
+    runId: campaign.runId,
+  };
+
   // Fetch all runs for this campaign (needed for stale cleanup, running check, consecutive failures)
   const { runs } = await listRuns({
     orgId: campaign.orgId,
@@ -43,7 +51,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   for (const run of runs) {
     if (run.status === "running" && (now - new Date(run.startedAt).getTime()) > STALE_THRESHOLD_MS) {
       try {
-        await updateRun(run.id, "failed");
+        await updateRun(run.id, "failed", identity);
         run.status = "failed"; // update in-memory
       } catch (err) {
         console.error(`[Gate Check] Failed to clean stale run ${run.id}:`, err);
@@ -110,7 +118,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     const completedRuns = runs.filter((r: Run) => r.status === "completed");
     let totalServed: number;
     try {
-      const leadStats = await fetchLeadStats(campaign.orgId, campaign.campaignId, campaign.brandId);
+      const leadStats = await fetchLeadStats(campaign.orgId, campaign.campaignId, campaign.brandId, identity);
       totalServed = Math.max(leadStats.totalServed, completedRuns.length);
     } catch (err: unknown) {
       if (err instanceof Error && "status" in err && (err as { status: number }).status === 404) {
@@ -154,18 +162,21 @@ async function fetchLeadStats(
   orgId: string,
   campaignId: string,
   brandId: string,
+  identity: IdentityHeaders,
 ): Promise<{ totalServed: number }> {
   const url = process.env.LEAD_SERVICE_URL;
   const apiKey = process.env.LEAD_SERVICE_API_KEY;
   if (!url || !apiKey) throw new Error("Lead service not configured");
 
+  const headers: Record<string, string> = {
+    "x-api-key": apiKey,
+    "x-org-id": identity.orgId,
+  };
+  if (identity.userId) headers["x-user-id"] = identity.userId;
+  if (identity.runId) headers["x-run-id"] = identity.runId;
+
   const params = new URLSearchParams({ brandId, campaignId });
-  const res = await fetch(`${url}/stats?${params}`, {
-    headers: {
-      "x-api-key": apiKey,
-      "x-org-id": orgId,
-    },
-  });
+  const res = await fetch(`${url}/stats?${params}`, { headers });
 
   if (!res.ok) {
     const err = new Error(`Lead stats failed: ${res.status}`) as Error & { status: number };

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -16,6 +16,7 @@ export async function resumeDueCampaigns(): Promise<number> {
     .select({
       id: campaigns.id,
       orgId: campaigns.orgId,
+      createdByUserId: campaigns.createdByUserId,
       workflowName: campaigns.workflowName,
     })
     .from(campaigns)
@@ -42,6 +43,7 @@ export async function resumeDueCampaigns(): Promise<number> {
       executeCampaignWorkflow(campaign.workflowName, {
         campaignId: campaign.id,
         orgId: campaign.orgId,
+        userId: campaign.createdByUserId ?? undefined,
       }).catch((err) => {
         console.error(`[Scheduler] Failed to re-trigger campaign ${campaign.id}:`, err);
       });

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -7,7 +7,7 @@
  */
 export async function executeCampaignWorkflow(
   workflowName: string,
-  inputs: { campaignId: string; orgId: string },
+  inputs: { campaignId: string; orgId: string; userId?: string; runId?: string },
 ): Promise<void> {
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
@@ -22,12 +22,17 @@ export async function executeCampaignWorkflow(
   const executeUrl = `${url}/workflows/by-name/${workflowName}/execute`;
   console.log(`[Workflow] POST ${executeUrl}`);
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "x-org-id": inputs.orgId,
+  };
+  if (inputs.userId) headers["x-user-id"] = inputs.userId;
+  if (inputs.runId) headers["x-run-id"] = inputs.runId;
+
   const res = await fetch(executeUrl, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": apiKey,
-    },
+    headers,
     body: JSON.stringify({
       orgId: inputs.orgId,
       inputs: {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -267,6 +267,8 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     executeCampaignWorkflow(campaign.workflowName, {
       campaignId: campaign.id,
       orgId: req.orgId!,
+      userId: req.userId,
+      runId: req.runId,
     }).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
@@ -314,6 +316,8 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
       executeCampaignWorkflow(updated.workflowName, {
         campaignId: updated.id,
         orgId: req.orgId!,
+        userId: req.userId,
+        runId: req.runId,
       }).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -4,7 +4,7 @@ import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
-import { createRun, listRuns, updateRun } from "@mcpfactory/runs-client";
+import { createRun, listRuns, updateRun, type IdentityHeaders } from "@mcpfactory/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
 import { executeCampaignWorkflow } from "../lib/workflows.js";
 import { extractDomain } from "../lib/domain.js";
@@ -45,6 +45,8 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
     const result = await runGateChecks({
       campaignId,
       orgId,
+      userId: req.headers["x-user-id"] as string | undefined,
+      runId: req.headers["x-run-id"] as string | undefined,
       brandId: campaign.brandId || "",
       status: campaign.status,
       maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
@@ -182,6 +184,11 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
     console.log(`[End Run] Received request: campaignId=${campaignId}, orgId=${orgId}, success=${success}, leadFound=${leadFound}`);
 
     const status = success === true ? "completed" : "failed";
+    const identity: IdentityHeaders = {
+      orgId: (req.headers["x-org-id"] as string) || orgId,
+      userId: req.headers["x-user-id"] as string | undefined,
+      runId: req.headers["x-run-id"] as string | undefined,
+    };
 
     // Find and update running runs for this campaign
     try {
@@ -195,7 +202,7 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
       if (runningRuns.length > 0) {
         for (const run of runningRuns) {
           console.log(`[End Run] Updating run ${run.id} to status=${status}`);
-          await updateRun(run.id, status);
+          await updateRun(run.id, status, identity);
         }
       } else {
         console.log(`[End Run] No running runs found for campaign ${campaignId} — skipping run update`);
@@ -234,7 +241,11 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
 
       // Fire-and-forget: gate-check in the next workflow execution will validate limits
       console.log(`[End Run] Re-triggering workflow=${freshCampaign.workflowName} for campaign ${campaignId}`);
-      executeCampaignWorkflow(freshCampaign.workflowName, { campaignId, orgId }).catch((err) => {
+      executeCampaignWorkflow(freshCampaign.workflowName, {
+        campaignId,
+        orgId,
+        userId: identity.userId,
+      }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });
     } catch (err) {

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -497,7 +497,7 @@ describe("Pipeline routes", () => {
         .expect(200);
 
       expect(res.body.status).toBe("completed");
-      expect(mockUpdateRun).toHaveBeenCalledWith("run-123", "completed");
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-123", "completed", expect.objectContaining({ orgId }));
     });
 
     it("should find and mark running run as failed when success is false", async () => {
@@ -523,7 +523,7 @@ describe("Pipeline routes", () => {
         .expect(200);
 
       expect(res.body.status).toBe("failed");
-      expect(mockUpdateRun).toHaveBeenCalledWith("run-456", "failed");
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-456", "failed", expect.objectContaining({ orgId }));
     });
 
     it("should skip run update when no running runs exist (gate-check blocked)", async () => {
@@ -625,7 +625,7 @@ describe("Pipeline routes", () => {
         .expect(200);
 
       expect(res.body.status).toBe("completed");
-      expect(mockUpdateRun).toHaveBeenCalledWith("run-789", "completed");
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-789", "completed", expect.objectContaining({ orgId }));
 
       // Wait for async auto-stop
       await new Promise((r) => setTimeout(r, 100));

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -117,7 +117,7 @@ describe("Gate Check", () => {
 
       await runGateChecks(makeCampaign());
 
-      expect(mockUpdateRun).toHaveBeenCalledWith("stale-run-1", "failed");
+      expect(mockUpdateRun).toHaveBeenCalledWith("stale-run-1", "failed", expect.objectContaining({ orgId: "org-1" }));
     });
 
     it("should NOT mark recent running runs as stale", async () => {


### PR DESCRIPTION
## Summary
- **runs-client**: Moved `orgId`/`userId`/`parentRunId` from request body/query to `x-org-id`/`x-user-id`/`x-run-id` headers, matching the updated runs-service spec
- **workflow-service calls**: Added `x-org-id`, `x-user-id`, `x-run-id` header forwarding to `executeCampaignWorkflow`
- **lead-service calls**: Added missing `x-user-id` and `x-run-id` headers to `fetchLeadStats`
- **All callers updated**: Internal routes, campaign routes, and scheduler now pass identity context through to downstream calls

## Test plan
- [x] All 125 existing tests pass
- [x] Updated test assertions for `updateRun` to expect new identity parameter
- [ ] Verify in staging that runs-service, workflow-service, and lead-service accept the forwarded headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)