### PR TITLE
fix: remove orgId from workflow-service request body

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -34,7 +34,6 @@ export async function executeCampaignWorkflow(
     method: "POST",
     headers,
     body: JSON.stringify({
-      orgId: inputs.orgId,
       inputs: {
         campaignId: inputs.campaignId,
         orgId: inputs.orgId,

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -32,7 +32,7 @@ describe("Workflow module", () => {
 
       const body = JSON.parse(opts.body);
       expect(body).not.toHaveProperty("appId");
-      expect(body.orgId).toBe("org_test");
+      expect(body).not.toHaveProperty("orgId");
       expect(body.inputs).toEqual({
         campaignId: "campaign-1",
         orgId: "org_test",


### PR DESCRIPTION
## Summary
- Removed top-level `orgId` from the POST body sent to `POST /workflows/by-name/{name}/execute` — workflow-service now reads identity exclusively from the `x-org-id` header
- Kept `orgId` inside `inputs` (workflow DAG data) since downstream nodes still need it
- Updated unit test assertion to verify `orgId` is no longer in the body

## Test plan
- [x] Unit tests pass (`pnpm test:unit` — 22/22 pass, 1 pre-existing failure unrelated)
- [x] No functional change — workflow-service was already stripping the field via Zod

🤖 Generated with [Claude Code](https://claude.com/claude-code)