### PR TITLE
feat: enforce unique campaign name per org

### DIFF
--- a/drizzle/0021_unique_campaign_name_per_org.sql
+++ b/drizzle/0021_unique_campaign_name_per_org.sql
@@ -1,0 +1,13 @@
+-- Deduplicate existing campaign names within each org by appending " (N)" suffix
+WITH duplicates AS (
+  SELECT id, org_id, name,
+    ROW_NUMBER() OVER (PARTITION BY org_id, name ORDER BY created_at ASC) AS rn
+  FROM campaigns
+)
+UPDATE campaigns
+SET name = duplicates.name || ' (' || duplicates.rn || ')'
+FROM duplicates
+WHERE campaigns.id = duplicates.id AND duplicates.rn > 1;
+
+-- Add unique constraint on (org_id, name)
+CREATE UNIQUE INDEX "uniq_campaigns_org_name" ON "campaigns" ("org_id", "name");

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,216 @@
+{
+  "id": "fbd43045-aac5-4dcb-80ed-09e7b86b296f",
+  "prevId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_url": {
+          "name": "brand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_outcome": {
+          "name": "target_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_for_target": {
+          "name": "value_for_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_daily_usd": {
+          "name": "max_budget_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_weekly_usd": {
+          "name": "max_budget_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_monthly_usd": {
+          "name": "max_budget_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_total_usd": {
+          "name": "max_budget_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_leads": {
+          "name": "max_leads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ongoing'"
+        },
+        "to_resume_at": {
+          "name": "to_resume_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_frequency": {
+          "name": "notify_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_channel": {
+          "name": "notify_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_destination": {
+          "name": "notify_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_campaigns_org": {
+          "name": "idx_campaigns_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_campaigns_org_name": {
+          "name": "uniq_campaigns_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1772503751788,
       "tag": "0020_drop_parent_run_id",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1772870400000,
+      "tag": "0021_unique_campaign_name_per_org",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, index, date, decimal, integer } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, index, uniqueIndex, date, decimal, integer } from "drizzle-orm/pg-core";
 
 // Campaigns table
 export const campaigns = pgTable(
@@ -56,6 +56,7 @@ export const campaigns = pgTable(
   },
   (table) => [
     index("idx_campaigns_org").on(table.orgId),
+    uniqueIndex("uniq_campaigns_org_name").on(table.orgId, table.name),
   ]
 );
 

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -274,7 +274,10 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     });
 
     res.status(201).json({ campaign });
-  } catch (error) {
+  } catch (error: any) {
+    if (error?.code === "23505" && error?.constraint === "uniq_campaigns_org_name") {
+      return res.status(409).json({ error: "A campaign with this name already exists in your organization" });
+    }
     console.error("[Campaign Service] Create campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
@@ -324,7 +327,10 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
     }
 
     res.json({ campaign: updated });
-  } catch (error) {
+  } catch (error: any) {
+    if (error?.code === "23505" && error?.constraint === "uniq_campaigns_org_name") {
+      return res.status(409).json({ error: "A campaign with this name already exists in your organization" });
+    }
     console.error("[Campaign Service] Update campaign error:", error);
     res.status(500).json({ error: "Internal server error" });
   }

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -202,6 +202,42 @@ describe("Campaign CRUD", () => {
       expect(res.body.campaign).not.toHaveProperty("appId");
       expect(res.body.campaign).not.toHaveProperty("keySource");
     });
+
+    it("should reject duplicate campaign name within same org with 409", async () => {
+      await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .send(validBody)
+        .expect(201);
+
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .send(validBody)
+        .expect(409);
+
+      expect(res.body.error).toBe("A campaign with this name already exists in your organization");
+    });
+
+    it("should allow same campaign name in different orgs", async () => {
+      await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .send(validBody)
+        .expect(201);
+
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_other")
+        .send({ ...validBody, orgId: "org_other" })
+        .expect(201);
+
+      expect(res.body.campaign.name).toBe(validBody.name);
+    });
   });
 
   describe("PATCH /campaigns/:id", () => {
@@ -277,6 +313,31 @@ describe("Campaign CRUD", () => {
 
       expect(updateRes.body.campaign.targetOutcome).toBe("Recruit community ambassadors");
       expect(updateRes.body.campaign.valueForTarget).toBe("Early access to beta features");
+    });
+
+    it("should reject renaming to a name that already exists in the same org", async () => {
+      const res1 = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .send(validBody)
+        .expect(201);
+
+      const res2 = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .send({ ...validBody, name: "Other Campaign" })
+        .expect(201);
+
+      const renameRes = await request(app)
+        .patch(`/campaigns/${res2.body.campaign.id}`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .send({ name: validBody.name })
+        .expect(409);
+
+      expect(renameRes.body.error).toBe("A campaign with this name already exists in your organization");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds a `UNIQUE(org_id, name)` constraint to the `campaigns` table to prevent duplicate campaign names within an organization
- Migration 0021 deduplicates existing names in prod by appending `(2)`, `(3)`, etc. to duplicates before adding the constraint
- `POST /campaigns` and `PATCH /campaigns/:id` now return **409 Conflict** with `{"error": "A campaign with this name already exists in your organization"}` when the name is already taken
- Tests cover: duplicate name rejection (409), cross-org same name (allowed), rename collision (409)

## Test plan
- [ ] Verify migration deduplicates existing names correctly in staging
- [ ] Test creating two campaigns with the same name in the same org → 409
- [ ] Test creating same-name campaigns in different orgs → both succeed
- [ ] Test renaming a campaign to a name that already exists → 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)