### PR TITLE
fix: pass runId to workflow-service on re-trigger and scheduler

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -2,6 +2,7 @@ import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { eq, and, lte, isNotNull } from "drizzle-orm";
 import { executeCampaignWorkflow } from "./workflows.js";
+import { createRun } from "@mcpfactory/runs-client";
 
 const SCHEDULER_INTERVAL_MS = 60_000; // 1 minute
 
@@ -40,10 +41,18 @@ export async function resumeDueCampaigns(): Promise<number> {
         .where(eq(campaigns.id, campaign.id));
 
       console.log(`[Scheduler] Re-triggering campaign ${campaign.id} (workflow=${campaign.workflowName})`);
+      const run = await createRun({
+        orgId: campaign.orgId,
+        serviceName: "campaign-service",
+        taskName: "scheduler-resume",
+        userId: campaign.createdByUserId ?? undefined,
+        campaignId: campaign.id,
+      });
       executeCampaignWorkflow(campaign.workflowName, {
         campaignId: campaign.id,
         orgId: campaign.orgId,
         userId: campaign.createdByUserId ?? undefined,
+        runId: run.id,
       }).catch((err) => {
         console.error(`[Scheduler] Failed to re-trigger campaign ${campaign.id}:`, err);
       });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -245,6 +245,7 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
         campaignId,
         orgId,
         userId: identity.userId,
+        runId: identity.runId,
       }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -556,9 +556,11 @@ describe("Pipeline routes", () => {
         workflowName: "sales-email-cold-outreach",
       });
 
+      const runId = crypto.randomUUID();
       await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
+        .set("x-run-id", runId)
         .send({
           campaignId: campaign.id,
           orgId,
@@ -571,10 +573,40 @@ describe("Pipeline routes", () => {
 
       expect(mockExecute).toHaveBeenCalledWith(
         "sales-email-cold-outreach",
-        {
+        expect.objectContaining({
           campaignId: campaign.id,
           orgId,
-        },
+          runId,
+        }),
+      );
+    });
+
+    it("should forward x-run-id header to re-triggered workflow", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandUrl: "https://example.com",
+        brandId,
+        status: "ongoing",
+        workflowName: "sales-email-cold-outreach",
+      });
+
+      const parentRunId = crypto.randomUUID();
+      await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .set("x-run-id", parentRunId)
+        .send({
+          campaignId: campaign.id,
+          orgId,
+          success: false,
+        })
+        .expect(200);
+
+      // Wait for async re-trigger
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        "sales-email-cold-outreach",
+        expect.objectContaining({ runId: parentRunId }),
       );
     });
 

--- a/tests/integration/scheduler-resume.test.ts
+++ b/tests/integration/scheduler-resume.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 
-const mockExecute = vi.hoisted(() => vi.fn());
+const { mockExecute, mockCreateRun } = vi.hoisted(() => ({
+  mockExecute: vi.fn(),
+  mockCreateRun: vi.fn(),
+}));
 
 vi.mock("../../src/lib/workflows.js", () => ({
   executeCampaignWorkflow: mockExecute,
@@ -8,7 +11,7 @@ vi.mock("../../src/lib/workflows.js", () => ({
 
 vi.mock("@mcpfactory/runs-client", () => ({
   listRuns: vi.fn().mockResolvedValue({ runs: [] }),
-  createRun: vi.fn(),
+  createRun: mockCreateRun,
   updateRun: vi.fn(),
   getStatsBudget: vi.fn(),
 }));
@@ -26,6 +29,7 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
     await cleanTestData();
     vi.clearAllMocks();
     mockExecute.mockResolvedValue(undefined);
+    mockCreateRun.mockResolvedValue({ id: "scheduler-run-123" });
   });
 
   afterAll(async () => {
@@ -59,13 +63,24 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
     });
     expect(updated!.toResumeAt).toBeNull();
 
-    // Should have triggered workflow
+    // Should have created a run for the scheduler
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId,
+        serviceName: "campaign-service",
+        taskName: "scheduler-resume",
+        campaignId: campaign.id,
+      }),
+    );
+
+    // Should have triggered workflow with the scheduler run ID
     expect(mockExecute).toHaveBeenCalledWith(
       "sales-email-cold-outreach",
-      {
+      expect.objectContaining({
         campaignId: campaign.id,
         orgId,
-      },
+        runId: "scheduler-run-123",
+      }),
     );
   });
 

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const {
   mockExecuteCampaignWorkflow,
+  mockCreateRun,
   mockDbValues,
   mockDbUpdate,
   mockSet,
@@ -18,6 +19,7 @@ const {
 
   return {
     mockExecuteCampaignWorkflow: vi.fn(),
+    mockCreateRun: vi.fn(),
     mockDbValues,
     mockDbUpdate,
     mockSet,
@@ -27,6 +29,10 @@ const {
 
 vi.mock("../../src/lib/workflows.js", () => ({
   executeCampaignWorkflow: mockExecuteCampaignWorkflow,
+}));
+
+vi.mock("@mcpfactory/runs-client", () => ({
+  createRun: mockCreateRun,
 }));
 
 vi.mock("../../src/db/index.js", () => ({
@@ -65,6 +71,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
     vi.clearAllMocks();
     mockDbValues.length = 0;
     mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
+    mockCreateRun.mockResolvedValue({ id: "scheduler-run-123" });
   });
 
   it("should return 0 when no campaigns are due", async () => {
@@ -87,11 +94,20 @@ describe("Scheduler - resumeDueCampaigns", () => {
     expect(mockSet).toHaveBeenCalledWith(
       expect.objectContaining({ toResumeAt: null }),
     );
+    expect(mockCreateRun).toHaveBeenCalledWith({
+      orgId: "org-ext-1",
+      serviceName: "campaign-service",
+      taskName: "scheduler-resume",
+      userId: undefined,
+      campaignId: "campaign-1",
+    });
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
       "sales-email-cold-outreach",
       {
         campaignId: "campaign-1",
         orgId: "org-ext-1",
+        userId: undefined,
+        runId: "scheduler-run-123",
       },
     );
   });

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -39,6 +39,27 @@ describe("Workflow module", () => {
       });
     });
 
+    it("should set x-run-id header when runId is provided", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-123", status: "queued" }),
+      });
+
+      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
+      await executeCampaignWorkflow("sales-email-cold-outreach", {
+        campaignId: "campaign-1",
+        orgId: "org_test",
+        userId: "user_test",
+        runId: "run-parent-456",
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(opts.headers["x-org-id"]).toBe("org_test");
+      expect(opts.headers["x-user-id"]).toBe("user_test");
+      expect(opts.headers["x-run-id"]).toBe("run-parent-456");
+    });
+
     it("should not throw when execution fails", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,


### PR DESCRIPTION
## Summary
- **End-run re-trigger** was missing `x-run-id` header when calling workflow-service, causing `400: x-org-id, x-user-id, and x-run-id headers are required`
- **Scheduler resume** had the same issue — now creates a tracking run via runs-client before triggering the workflow
- Added regression tests for both paths

## Test plan
- [x] Unit test: `workflows.test.ts` — verifies `x-run-id` header is set when `runId` is provided
- [x] Unit test: `scheduler.test.ts` — verifies `createRun` is called and `runId` is forwarded
- [x] Integration test: `internal-routes.test.ts` — verifies end-run re-trigger forwards `x-run-id`
- [x] Integration test: `scheduler-resume.test.ts` — verifies scheduler creates run and passes ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)