### PR TITLE
fix: prevent concurrent workflow re-triggers in end-run

### DIFF
--- a/drizzle/0022_add_last_triggered_at.sql
+++ b/drizzle/0022_add_last_triggered_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "campaigns" ADD COLUMN "last_triggered_at" TIMESTAMP WITH TIME ZONE;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,6 +45,7 @@ export const campaigns = pgTable(
     // Status: 'ongoing' or 'stopped'
     status: text("status").notNull().default("ongoing"),
     toResumeAt: timestamp("to_resume_at", { withTimezone: true }),
+    lastTriggeredAt: timestamp("last_triggered_at", { withTimezone: true }),
 
     // Notifications (legacy - to be replaced by reportingFrequency)
     notifyFrequency: text("notify_frequency"),  // 'daily', 'weekly', 'per_reply'

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -35,9 +35,9 @@ export async function resumeDueCampaigns(): Promise<number> {
 
   for (const campaign of dueCampaigns) {
     try {
-      // Clear toResumeAt before re-triggering (prevent double-fire)
+      // Clear toResumeAt and set lastTriggeredAt before re-triggering (prevent double-fire)
       await db.update(campaigns)
-        .set({ toResumeAt: null, updatedAt: new Date() })
+        .set({ toResumeAt: null, lastTriggeredAt: new Date(), updatedAt: new Date() })
         .where(eq(campaigns.id, campaign.id));
 
       console.log(`[Scheduler] Re-triggering campaign ${campaign.id} (workflow=${campaign.workflowName})`);

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -8,7 +8,7 @@
 export async function executeCampaignWorkflow(
   workflowName: string,
   inputs: { campaignId: string; orgId: string; userId?: string; runId?: string },
-): Promise<void> {
+): Promise<string | null> {
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
 
@@ -16,7 +16,7 @@ export async function executeCampaignWorkflow(
 
   if (!url || !apiKey) {
     console.warn("[Workflow] WORKFLOW_SERVICE_URL or WORKFLOW_SERVICE_API_KEY not set, skipping workflow execution");
-    return;
+    return null;
   }
 
   const executeUrl = `${url}/workflows/by-name/${workflowName}/execute`;
@@ -44,9 +44,10 @@ export async function executeCampaignWorkflow(
   if (!res.ok) {
     const body = await res.text();
     console.error(`[Workflow] Execution failed (${res.status}): ${body}`);
-    return;
+    return null;
   }
 
   const data = await res.json() as { id?: string; status?: string };
   console.log(`[Workflow] ${workflowName} started successfully: workflowRunId=${data.id}, status=${data.status}`);
+  return data.id ?? null;
 }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -259,6 +259,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         notifyChannel,
         notifyDestination,
         status: "ongoing",
+        lastTriggeredAt: new Date(),
       })
       .returning();
 
@@ -315,6 +316,9 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
 
     // Trigger workflow on activation
     if (req.body.status === "activate") {
+      await db.update(campaigns)
+        .set({ lastTriggeredAt: new Date() })
+        .where(eq(campaigns.id, id));
       console.log(`[Campaign Service] Activation triggered: campaignId=${updated.id}, workflowName=${updated.workflowName}, orgId=${req.orgId}`);
       executeCampaignWorkflow(updated.workflowName, {
         campaignId: updated.id,

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and } from "drizzle-orm";
+import { eq, and, or, isNull, lte } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
@@ -227,21 +227,32 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
       return;
     }
 
-    // Re-trigger if campaign is still ongoing
+    // Re-trigger if campaign is still ongoing.
+    // Atomic guard: only one concurrent end-run can claim the re-trigger.
+    // Uses lastTriggeredAt with a 10-second dedup window to prevent the
+    // infinite loop where concurrent workflows each re-trigger a new pair.
+    const RE_TRIGGER_DEDUP_MS = 10_000;
     try {
-      // Re-fetch campaign for fresh status (may have been auto-stopped by gate-check)
-      const freshCampaign = await db.query.campaigns.findFirst({
-        where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
-      });
-      console.log(`[End Run] Campaign status for re-trigger: ${freshCampaign?.status || "NOT FOUND"}, workflowName=${freshCampaign?.workflowName || "N/A"}`);
-      if (freshCampaign?.status !== "ongoing") {
-        console.log(`[End Run] Campaign ${campaignId} is not ongoing — skipping re-trigger`);
+      const [claimed] = await db.update(campaigns)
+        .set({ lastTriggeredAt: new Date(), updatedAt: new Date() })
+        .where(and(
+          eq(campaigns.id, campaignId),
+          eq(campaigns.orgId, orgId),
+          eq(campaigns.status, "ongoing"),
+          or(
+            isNull(campaigns.lastTriggeredAt),
+            lte(campaigns.lastTriggeredAt, new Date(Date.now() - RE_TRIGGER_DEDUP_MS)),
+          ),
+        ))
+        .returning();
+
+      if (!claimed) {
+        console.log(`[End Run] Campaign ${campaignId} — skipping re-trigger (already triggered recently or not ongoing)`);
         return;
       }
 
-      // Fire-and-forget: gate-check in the next workflow execution will validate limits
-      console.log(`[End Run] Re-triggering workflow=${freshCampaign.workflowName} for campaign ${campaignId}`);
-      executeCampaignWorkflow(freshCampaign.workflowName, {
+      console.log(`[End Run] Re-triggering workflow=${claimed.workflowName} for campaign ${campaignId}`);
+      executeCampaignWorkflow(claimed.workflowName, {
         campaignId,
         orgId,
         userId: identity.userId,

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -29,6 +29,7 @@ export async function insertTestCampaign(
     targetOutcome?: string;
     valueForTarget?: string;
     toResumeAt?: Date | null;
+    lastTriggeredAt?: Date | null;
     createdByUserId?: string;
   } = {}
 ) {
@@ -50,6 +51,7 @@ export async function insertTestCampaign(
       targetOutcome: data.targetOutcome || null,
       valueForTarget: data.valueForTarget || null,
       toResumeAt: data.toResumeAt ?? null,
+      lastTriggeredAt: data.lastTriggeredAt ?? null,
       createdByUserId: data.createdByUserId || null,
     })
     .returning();

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -702,6 +702,87 @@ describe("Pipeline routes", () => {
       );
     });
 
+    it("should NOT re-trigger if campaign was triggered recently (dedup guard)", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandUrl: "https://example.com",
+        brandId,
+        status: "ongoing",
+        lastTriggeredAt: new Date(), // triggered just now
+      });
+
+      mockListRuns.mockResolvedValue({ runs: [] });
+
+      await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          campaignId: campaign.id,
+          orgId,
+          success: true,
+        })
+        .expect(200);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it("should re-trigger if lastTriggeredAt is old enough (outside dedup window)", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandUrl: "https://example.com",
+        brandId,
+        status: "ongoing",
+        lastTriggeredAt: new Date(Date.now() - 30_000), // 30s ago, outside 10s window
+      });
+
+      mockListRuns.mockResolvedValue({ runs: [] });
+
+      await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          campaignId: campaign.id,
+          orgId,
+          success: true,
+        })
+        .expect(200);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        "sales-email-cold-outreach",
+        expect.objectContaining({ campaignId: campaign.id }),
+      );
+    });
+
+    it("should update lastTriggeredAt in DB when re-trigger succeeds", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandUrl: "https://example.com",
+        brandId,
+        status: "ongoing",
+        lastTriggeredAt: null,
+      });
+
+      mockListRuns.mockResolvedValue({ runs: [] });
+
+      await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .send({
+          campaignId: campaign.id,
+          orgId,
+          success: true,
+        })
+        .expect(200);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.lastTriggeredAt).not.toBeNull();
+    });
+
     it("should not pass appId to listRuns", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",


### PR DESCRIPTION
## Summary
- Add `lastTriggeredAt` timestamp column to campaigns table
- Use atomic `UPDATE ... WHERE` guard in end-run handler with 10s dedup window — only one concurrent end-run can claim the re-trigger per cycle
- Set `lastTriggeredAt` on campaign creation, activation, and scheduler resume to prevent races between end-run and scheduler

## Problem
Two workflow runs for the same campaign would finish concurrently. Both called `/end-run`, both re-triggered a new workflow. This created an infinite loop: each cycle produced 1 success + 1 duplicate failure → 2 new triggers → repeat until gate-check auto-stopped after 3 consecutive failures.

## How it works
Before re-triggering, the handler atomically updates `lastTriggeredAt` only if it's NULL or older than 10 seconds. If another end-run (or the scheduler) already claimed the trigger within that window, the UPDATE matches 0 rows and the re-trigger is skipped.

## Test plan
- [x] New test: end-run skips re-trigger when `lastTriggeredAt` is recent (dedup guard)
- [x] New test: end-run re-triggers when `lastTriggeredAt` is old enough (outside window)
- [x] New test: end-run updates `lastTriggeredAt` in DB on successful re-trigger
- [x] All existing 27 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)