### PR TITLE
feat: accept and forward workflow tracking headers

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1038,6 +1038,40 @@
             "apiKeyAuth": []
           }
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID (injected by workflow-service)"
+            },
+            "required": false,
+            "description": "Campaign ID (injected by workflow-service)",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID (injected by workflow-service)"
+            },
+            "required": false,
+            "description": "Brand ID (injected by workflow-service)",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name (injected by workflow-service)"
+            },
+            "required": false,
+            "description": "Workflow name (injected by workflow-service)",
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1081,6 +1115,40 @@
         "security": [
           {
             "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID (injected by workflow-service)"
+            },
+            "required": false,
+            "description": "Campaign ID (injected by workflow-service)",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID (injected by workflow-service)"
+            },
+            "required": false,
+            "description": "Brand ID (injected by workflow-service)",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name (injected by workflow-service)"
+            },
+            "required": false,
+            "description": "Workflow name (injected by workflow-service)",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1136,6 +1204,40 @@
         "security": [
           {
             "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID (injected by workflow-service)"
+            },
+            "required": false,
+            "description": "Campaign ID (injected by workflow-service)",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID (injected by workflow-service)"
+            },
+            "required": false,
+            "description": "Brand ID (injected by workflow-service)",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name (injected by workflow-service)"
+            },
+            "required": false,
+            "description": "Workflow name (injected by workflow-service)",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "requestBody": {

--- a/packages/runs-client/src/index.ts
+++ b/packages/runs-client/src/index.ts
@@ -29,6 +29,9 @@ export interface IdentityHeaders {
   orgId: string;
   userId?: string;
   runId?: string;
+  campaignId?: string;
+  brandId?: string;
+  workflowName?: string;
 }
 
 export interface CreateRunParams {
@@ -88,6 +91,9 @@ function buildIdentityHeaders(identity?: IdentityHeaders): Record<string, string
   if (identity?.orgId) h["x-org-id"] = identity.orgId;
   if (identity?.userId) h["x-user-id"] = identity.userId;
   if (identity?.runId) h["x-run-id"] = identity.runId;
+  if (identity?.campaignId) h["x-campaign-id"] = identity.campaignId;
+  if (identity?.brandId) h["x-brand-id"] = identity.brandId;
+  if (identity?.workflowName) h["x-workflow-name"] = identity.workflowName;
   return h;
 }
 

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -188,6 +188,12 @@ registry.registerPath({
 
 // === PIPELINE (called by DAG via workflow-service) ===
 
+const TrackingHeaders = z.object({
+  "x-campaign-id": z.string().uuid().optional().openapi({ description: "Campaign ID (injected by workflow-service)" }),
+  "x-brand-id": z.string().uuid().optional().openapi({ description: "Brand ID (injected by workflow-service)" }),
+  "x-workflow-name": z.string().optional().openapi({ description: "Workflow name (injected by workflow-service)" }),
+}).openapi("TrackingHeaders");
+
 registry.registerPath({
   method: "post",
   path: "/gate-check",
@@ -195,7 +201,10 @@ registry.registerPath({
   summary: "Check if a campaign can run a new iteration",
   description: "Validates budget limits (daily/weekly/monthly/total) via runs-service stats/budget, volume limits (maxLeads), campaign status, and consecutive failures. Auto-stops the campaign if total budget or maxLeads is exceeded. Called as the first DAG node.",
   security: [{ [apiKeyAuth.name]: [] }],
-  request: { body: { content: { "application/json": { schema: GateCheckBody } } } },
+  request: {
+    headers: TrackingHeaders,
+    body: { content: { "application/json": { schema: GateCheckBody } } },
+  },
   responses: {
     200: { description: "Gate check result", content: { "application/json": { schema: GateCheckResponse } } },
     404: { description: "Campaign or org not found", content: { "application/json": { schema: ErrorResponse } } },
@@ -209,7 +218,10 @@ registry.registerPath({
   summary: "Create a run and return campaign data for downstream nodes",
   description: "Creates a new run in runs-service and returns all campaign data needed by downstream DAG nodes (brand-profile, fetch-lead, email-generate, etc.).",
   security: [{ [apiKeyAuth.name]: [] }],
-  request: { body: { content: { "application/json": { schema: StartRunBody } } } },
+  request: {
+    headers: TrackingHeaders,
+    body: { content: { "application/json": { schema: StartRunBody } } },
+  },
   responses: {
     200: { description: "Run created, campaign data returned", content: { "application/json": { schema: StartRunResponse } } },
     400: { description: "Missing brandUrl or brandId", content: { "application/json": { schema: ErrorResponse } } },
@@ -224,7 +236,10 @@ registry.registerPath({
   summary: "Finalize run and re-trigger workflow if campaign is ongoing",
   description: "Finds any running runs for the campaign and marks them as completed or failed. Then re-triggers the workflow if the campaign is still ongoing. Does not require runId — finds running runs via runs-service.",
   security: [{ [apiKeyAuth.name]: [] }],
-  request: { body: { content: { "application/json": { schema: EndRunBody } } } },
+  request: {
+    headers: TrackingHeaders,
+    body: { content: { "application/json": { schema: EndRunBody } } },
+  },
   responses: {
     200: { description: "Run finalized", content: { "application/json": { schema: EndRunResponse } } },
   },

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -12,6 +12,7 @@ export interface GateCheckInput {
   userId?: string;
   runId?: string;
   brandId: string;
+  workflowName?: string;
   status: string;
   maxBudgetDailyUsd: string | null;
   maxBudgetWeeklyUsd: string | null;
@@ -37,6 +38,9 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     orgId: campaign.orgId,
     userId: campaign.userId,
     runId: campaign.runId,
+    campaignId: campaign.campaignId,
+    brandId: campaign.brandId || undefined,
+    workflowName: campaign.workflowName,
   };
 
   // Fetch all runs for this campaign (needed for stale cleanup, running check, consecutive failures)
@@ -174,6 +178,9 @@ async function fetchLeadStats(
   };
   if (identity.userId) headers["x-user-id"] = identity.userId;
   if (identity.runId) headers["x-run-id"] = identity.runId;
+  if (identity.campaignId) headers["x-campaign-id"] = identity.campaignId;
+  if (identity.brandId) headers["x-brand-id"] = identity.brandId;
+  if (identity.workflowName) headers["x-workflow-name"] = identity.workflowName;
 
   const params = new URLSearchParams({ brandId, campaignId });
   const res = await fetch(`${url}/stats?${params}`, { headers });

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -19,6 +19,7 @@ export async function resumeDueCampaigns(): Promise<number> {
       orgId: campaigns.orgId,
       createdByUserId: campaigns.createdByUserId,
       workflowName: campaigns.workflowName,
+      brandId: campaigns.brandId,
     })
     .from(campaigns)
     .where(
@@ -53,6 +54,7 @@ export async function resumeDueCampaigns(): Promise<number> {
         orgId: campaign.orgId,
         userId: campaign.createdByUserId ?? undefined,
         runId: run.id,
+        brandId: campaign.brandId ?? undefined,
       }).catch((err) => {
         console.error(`[Scheduler] Failed to re-trigger campaign ${campaign.id}:`, err);
       });

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -7,7 +7,7 @@
  */
 export async function executeCampaignWorkflow(
   workflowName: string,
-  inputs: { campaignId: string; orgId: string; userId?: string; runId?: string },
+  inputs: { campaignId: string; orgId: string; userId?: string; runId?: string; brandId?: string },
 ): Promise<void> {
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
@@ -29,6 +29,9 @@ export async function executeCampaignWorkflow(
   };
   if (inputs.userId) headers["x-user-id"] = inputs.userId;
   if (inputs.runId) headers["x-run-id"] = inputs.runId;
+  if (inputs.campaignId) headers["x-campaign-id"] = inputs.campaignId;
+  if (inputs.brandId) headers["x-brand-id"] = inputs.brandId;
+  headers["x-workflow-name"] = workflowName;
 
   const res = await fetch(executeUrl, {
     method: "POST",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,6 +4,9 @@ export interface AuthenticatedRequest extends Request {
   userId?: string;
   orgId?: string;
   runId?: string;
+  campaignId?: string;
+  brandId?: string;
+  workflowName?: string;
 }
 
 /**
@@ -46,6 +49,26 @@ export function requireOrg(
   if (!req.orgId) {
     return res.status(400).json({ error: "Organization context required" });
   }
+  next();
+}
+
+/**
+ * Reads optional tracking headers injected by workflow-service:
+ * x-campaign-id, x-brand-id, x-workflow-name
+ */
+export function trackingHeaders(
+  req: AuthenticatedRequest,
+  _res: Response,
+  next: NextFunction
+) {
+  const campaignId = req.headers["x-campaign-id"] as string | undefined;
+  const brandId = req.headers["x-brand-id"] as string | undefined;
+  const workflowName = req.headers["x-workflow-name"] as string | undefined;
+
+  if (campaignId) req.campaignId = campaignId;
+  if (brandId) req.brandId = brandId;
+  if (workflowName) req.workflowName = workflowName;
+
   next();
 }
 

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -269,6 +269,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       orgId: req.orgId!,
       userId: req.userId,
       runId: req.runId,
+      brandId: campaign.brandId || undefined,
     }).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
@@ -321,6 +322,7 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         orgId: req.orgId!,
         userId: req.userId,
         runId: req.runId,
+        brandId: updated.brandId || undefined,
       }).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
-import { requireApiKey } from "../middleware/auth.js";
+import { requireApiKey, trackingHeaders, type AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun, type IdentityHeaders } from "@mcpfactory/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
@@ -28,7 +28,7 @@ const router = Router();
  *   404 — campaign not found
  *   500 — internal error
  */
-router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (req, res) => {
+router.post("/gate-check", requireApiKey, trackingHeaders, validateBody(GateCheckBody), async (req: AuthenticatedRequest, res) => {
   try {
     const { campaignId, orgId } = req.body;
     console.log(`[Gate Check] Received request: campaignId=${campaignId}, orgId=${orgId}`);
@@ -47,7 +47,8 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
       orgId,
       userId: req.headers["x-user-id"] as string | undefined,
       runId: req.headers["x-run-id"] as string | undefined,
-      brandId: campaign.brandId || "",
+      brandId: req.brandId || campaign.brandId || "",
+      workflowName: req.workflowName || campaign.workflowName,
       status: campaign.status,
       maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
       maxBudgetWeeklyUsd: campaign.maxBudgetWeeklyUsd,
@@ -95,7 +96,7 @@ router.post("/gate-check", requireApiKey, validateBody(GateCheckBody), async (re
  *   404 — campaign not found
  *   500 — internal error
  */
-router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req, res) => {
+router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunBody), async (req: AuthenticatedRequest, res) => {
   try {
     const { campaignId, orgId } = req.body;
     console.log(`[Start Run] Received request: campaignId=${campaignId}, orgId=${orgId}`);
@@ -178,7 +179,7 @@ router.post("/start-run", requireApiKey, validateBody(StartRunBody), async (req,
  * the error path (onError → end-run-error) including cases where
  * no run was created (gate-check blocked).
  */
-router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res) => {
+router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody), async (req: AuthenticatedRequest, res) => {
   try {
     const { campaignId, orgId, success, leadFound } = req.body;
     console.log(`[End Run] Received request: campaignId=${campaignId}, orgId=${orgId}, success=${success}, leadFound=${leadFound}`);
@@ -188,6 +189,9 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
       orgId: (req.headers["x-org-id"] as string) || orgId,
       userId: req.headers["x-user-id"] as string | undefined,
       runId: req.headers["x-run-id"] as string | undefined,
+      campaignId: req.campaignId,
+      brandId: req.brandId,
+      workflowName: req.workflowName,
     };
 
     // Find and update running runs for this campaign
@@ -246,6 +250,7 @@ router.post("/end-run", requireApiKey, validateBody(EndRunBody), async (req, res
         orgId,
         userId: identity.userId,
         runId: identity.runId,
+        brandId: req.brandId || freshCampaign.brandId || undefined,
       }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -65,10 +65,11 @@ describe("Workflow trigger", () => {
       expect(mockExecuteCampaignWorkflow).toHaveBeenCalledOnce();
       expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
         "sales-email-cold-outreach",
-        {
+        expect.objectContaining({
           campaignId,
           orgId: "org_activation_test",
-        },
+          brandId: validBody.brandId,
+        }),
       );
     });
 
@@ -126,10 +127,10 @@ describe("Workflow trigger", () => {
       expect(mockExecuteCampaignWorkflow).toHaveBeenCalledOnce();
       expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
         "sales-email-cold-outreach",
-        {
+        expect.objectContaining({
           campaignId,
           orgId: "org_activation_test",
-        },
+        }),
       );
     });
 

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { trackingHeaders, type AuthenticatedRequest } from "../../src/middleware/auth.js";
+import type { Response, NextFunction } from "express";
+
+function createMockReq(headers: Record<string, string> = {}): AuthenticatedRequest {
+  return {
+    headers,
+  } as unknown as AuthenticatedRequest;
+}
+
+describe("trackingHeaders middleware", () => {
+  it("should read x-campaign-id, x-brand-id, x-workflow-name from headers", () => {
+    const req = createMockReq({
+      "x-campaign-id": "camp-123",
+      "x-brand-id": "brand-456",
+      "x-workflow-name": "sales-email-cold-outreach",
+    });
+
+    let nextCalled = false;
+    trackingHeaders(req, {} as Response, (() => { nextCalled = true; }) as NextFunction);
+
+    expect(req.campaignId).toBe("camp-123");
+    expect(req.brandId).toBe("brand-456");
+    expect(req.workflowName).toBe("sales-email-cold-outreach");
+    expect(nextCalled).toBe(true);
+  });
+
+  it("should not set properties when headers are absent", () => {
+    const req = createMockReq({});
+
+    let nextCalled = false;
+    trackingHeaders(req, {} as Response, (() => { nextCalled = true; }) as NextFunction);
+
+    expect(req.campaignId).toBeUndefined();
+    expect(req.brandId).toBeUndefined();
+    expect(req.workflowName).toBeUndefined();
+    expect(nextCalled).toBe(true);
+  });
+
+  it("should handle partial headers", () => {
+    const req = createMockReq({
+      "x-campaign-id": "camp-789",
+    });
+
+    trackingHeaders(req, {} as Response, (() => {}) as NextFunction);
+
+    expect(req.campaignId).toBe("camp-789");
+    expect(req.brandId).toBeUndefined();
+    expect(req.workflowName).toBeUndefined();
+  });
+});

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -60,6 +60,45 @@ describe("Workflow module", () => {
       expect(opts.headers["x-run-id"]).toBe("run-parent-456");
     });
 
+    it("should set tracking headers (x-campaign-id, x-brand-id, x-workflow-name) when provided", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-123", status: "queued" }),
+      });
+
+      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
+      await executeCampaignWorkflow("sales-email-cold-outreach", {
+        campaignId: "campaign-1",
+        orgId: "org_test",
+        brandId: "brand-abc",
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(opts.headers["x-campaign-id"]).toBe("campaign-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-abc");
+      expect(opts.headers["x-workflow-name"]).toBe("sales-email-cold-outreach");
+    });
+
+    it("should always set x-workflow-name even without brandId", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-123", status: "queued" }),
+      });
+
+      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
+      await executeCampaignWorkflow("pr-outreach", {
+        campaignId: "campaign-2",
+        orgId: "org_test",
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(opts.headers["x-campaign-id"]).toBe("campaign-2");
+      expect(opts.headers["x-brand-id"]).toBeUndefined();
+      expect(opts.headers["x-workflow-name"]).toBe("pr-outreach");
+    });
+
     it("should not throw when execution fails", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,


### PR DESCRIPTION
## Summary
- Read optional `x-campaign-id`, `x-brand-id`, `x-workflow-name` headers injected by workflow-service on all DAG HTTP calls
- Forward these headers to all downstream services (runs-service, workflow-service, lead-service)
- Document headers in OpenAPI spec for pipeline endpoints (`/gate-check`, `/start-run`, `/end-run`)
- No DB changes needed — campaigns table already stores `brandId` and `workflowName`

## Why
Workflow-service now injects these headers at the infrastructure level so tracking data (campaignId, brandId) propagates without relying on LLM-generated DAG input mappings, which sometimes forgot to pass them.

## Test plan
- [x] New unit tests for `trackingHeaders` middleware (3 tests)
- [x] New unit tests for tracking headers in workflow execution (2 tests)  
- [x] Existing tests updated and passing (workflow-activation assertions)
- [x] Build succeeds, `openapi.json` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)