### PR TITLE
feat: add /stats/ canonical endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -889,6 +889,144 @@
         }
       }
     },
+    "/stats": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "summary": "Campaign stats from own DB (query params)",
+        "description": "Returns campaign counts, status breakdown, and configured budget totals. New canonical path for POST /campaigns/stats. Requires API key.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "orgId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "campaignId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Campaign stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stats/batch-budget": {
+      "post": {
+        "tags": [
+          "Stats"
+        ],
+        "summary": "Get cost data for multiple campaigns",
+        "description": "Returns budget usage (totalCostInUsdCents) per campaign via runs-service. New canonical path for POST /campaigns/batch-budget-usage.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchBudgetUsageBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Stats per campaign",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string"
+                          },
+                          "maxLeads": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "maxBudgetTotalUsd": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "totalCostInUsdCents": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "results"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/campaigns/list": {
       "get": {
         "tags": [

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -8,6 +8,7 @@ import {
   CreateCampaignBody,
   UpdateCampaignBody,
   StatsFilterBody,
+  StatsFilterQuery,
   StatsResponse,
   BatchBudgetUsageBody,
   ErrorResponse,
@@ -140,6 +141,51 @@ registry.registerPath({
   request: { body: { content: { "application/json": { schema: StatsFilterBody } } } },
   responses: {
     200: { description: "Campaign stats", content: { "application/json": { schema: StatsResponse } } },
+    400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+// === STATS (new canonical paths) ===
+
+registry.registerPath({
+  method: "get",
+  path: "/stats",
+  tags: ["Stats"],
+  summary: "Campaign stats from own DB (query params)",
+  description: "Returns campaign counts, status breakdown, and configured budget totals. New canonical path for POST /campaigns/stats. Requires API key.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: { query: StatsFilterQuery },
+  responses: {
+    200: { description: "Campaign stats", content: { "application/json": { schema: StatsResponse } } },
+    400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/stats/batch-budget",
+  tags: ["Stats"],
+  summary: "Get cost data for multiple campaigns",
+  description: "Returns budget usage (totalCostInUsdCents) per campaign via runs-service. New canonical path for POST /campaigns/batch-budget-usage.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: { body: { content: { "application/json": { schema: BatchBudgetUsageBody } } } },
+  responses: {
+    200: {
+      description: "Stats per campaign",
+      content: {
+        "application/json": {
+          schema: z.object({
+            results: z.record(z.string(), z.object({
+              status: z.string().optional(),
+              maxLeads: z.number().nullable().optional(),
+              maxBudgetTotalUsd: z.string().nullable().optional(),
+              totalCostInUsdCents: z.string().nullable().optional(),
+              error: z.string().optional(),
+            })),
+          }),
+        },
+      },
+    },
     400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const __dirname = dirname(__filename);
 const openapiPath = join(__dirname, "..", "openapi.json");
 import healthRoutes from "./routes/health.js";
 import campaignsRoutes from "./routes/campaigns.js";
+import statsRoutes from "./routes/stats.js";
 import internalRoutes from "./routes/internal.js";
 import { startScheduler } from "./lib/scheduler.js";
 const app = express();
@@ -33,6 +34,7 @@ app.use(express.json());
 // Routes
 app.use(healthRoutes);
 app.use(campaignsRoutes);
+app.use(statsRoutes);
 app.use(internalRoutes);
 
 // OpenAPI spec endpoint

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -12,3 +12,14 @@ export function validateBody(schema: z.ZodType) {
     next();
   };
 }
+
+export function validateQuery(schema: z.ZodType) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.query);
+    if (!result.success) {
+      const firstError = result.error.issues[0];
+      return res.status(400).json({ error: firstError.message });
+    }
+    next();
+  };
+}

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,0 +1,126 @@
+import { Router } from "express";
+import { eq, and, inArray } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { campaigns } from "../db/schema.js";
+import { requireApiKey } from "../middleware/auth.js";
+import { validateBody, validateQuery } from "../middleware/validate.js";
+import { getStatsBudget } from "@mcpfactory/runs-client";
+import { BatchBudgetUsageBody, StatsFilterQuery } from "../schemas.js";
+
+const router = Router();
+
+/**
+ * POST /stats/batch-budget - Get cost and run data for multiple campaigns
+ *
+ * New canonical path for POST /campaigns/batch-budget-usage.
+ */
+router.post("/stats/batch-budget", requireApiKey, validateBody(BatchBudgetUsageBody), async (req, res) => {
+  try {
+    const { campaignIds } = req.body;
+
+    const campaignRows = await db
+      .select({
+        id: campaigns.id,
+        orgId: campaigns.orgId,
+        status: campaigns.status,
+        maxLeads: campaigns.maxLeads,
+        maxBudgetTotalUsd: campaigns.maxBudgetTotalUsd,
+      })
+      .from(campaigns)
+      .where(inArray(campaigns.id, campaignIds));
+
+    const campaignMap = new Map(
+      campaignRows.map(r => [r.id, r])
+    );
+
+    const results: Record<string, unknown> = {};
+
+    await Promise.all(
+      campaignIds.map(async (campaignId: string) => {
+        const row = campaignMap.get(campaignId);
+        if (!row) {
+          results[campaignId] = { error: "Campaign not found" };
+          return;
+        }
+
+        try {
+          const budgetResult = await getStatsBudget({
+            orgId: row.orgId,
+            campaignId,
+            windows: [{ label: "total" }],
+          });
+
+          const totalWindow = budgetResult.windows.find(w => w.label === "total");
+          const totalCostCents = totalWindow ? parseFloat(totalWindow.totalCostInUsdCents) || 0 : 0;
+
+          results[campaignId] = {
+            status: row.status,
+            maxLeads: row.maxLeads,
+            maxBudgetTotalUsd: row.maxBudgetTotalUsd,
+            totalCostInUsdCents: totalCostCents > 0 ? String(totalCostCents) : null,
+          };
+        } catch (err) {
+          console.warn(`[Campaign Service] Batch budget failed for campaign ${campaignId}:`, err);
+          results[campaignId] = { error: "Failed to fetch stats" };
+        }
+      })
+    );
+
+    res.json({ results });
+  } catch (error) {
+    console.error("[Campaign Service] Batch budget error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * GET /stats - Campaign stats from own DB (query-param filters)
+ *
+ * New canonical path for POST /campaigns/stats.
+ * Accepts orgId, brandId, campaignId as query params.
+ */
+router.get("/stats", requireApiKey, validateQuery(StatsFilterQuery), async (req, res) => {
+  try {
+    const { orgId, brandId, campaignId } = req.query as {
+      orgId?: string;
+      brandId?: string;
+      campaignId?: string;
+    };
+
+    const conditions = [];
+    if (orgId) conditions.push(eq(campaigns.orgId, orgId));
+    if (brandId) conditions.push(eq(campaigns.brandId, brandId));
+    if (campaignId) conditions.push(eq(campaigns.id, campaignId));
+
+    const where = conditions.length === 1 ? conditions[0] : and(...conditions);
+
+    const matching = await db
+      .select()
+      .from(campaigns)
+      .where(where);
+
+    const byStatus: Record<string, number> = {};
+    let budgetTotalUsd = 0;
+    let maxLeadsTotal = 0;
+
+    for (const c of matching) {
+      byStatus[c.status] = (byStatus[c.status] || 0) + 1;
+      if (c.maxBudgetTotalUsd) budgetTotalUsd += parseFloat(c.maxBudgetTotalUsd);
+      if (c.maxLeads) maxLeadsTotal += c.maxLeads;
+    }
+
+    res.json({
+      stats: {
+        totalCampaigns: matching.length,
+        byStatus,
+        budgetTotalUsd: budgetTotalUsd > 0 ? budgetTotalUsd : null,
+        maxLeadsTotal: maxLeadsTotal > 0 ? maxLeadsTotal : null,
+      },
+    });
+  } catch (error) {
+    console.error("[Campaign Service] Stats error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -90,6 +90,15 @@ export const StatsFilterBody = z.object({
   { message: "At least one filter required: orgId, brandId, or campaignId" }
 ).openapi("StatsFilterBody");
 
+export const StatsFilterQuery = z.object({
+  orgId: z.string().optional(),
+  brandId: z.string().optional(),
+  campaignId: z.string().optional(),
+}).refine(
+  (data) => data.orgId || data.brandId || data.campaignId,
+  { message: "At least one filter required: orgId, brandId, or campaignId" }
+).openapi("StatsFilterQuery");
+
 export const StatsResponse = z.object({
   stats: z.object({
     totalCampaigns: z.number(),

--- a/tests/integration/stats-routes.test.ts
+++ b/tests/integration/stats-routes.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+
+const { mockGetStatsBudget } = vi.hoisted(() => ({
+  mockGetStatsBudget: vi.fn(),
+}));
+
+vi.mock("@mcpfactory/runs-client", () => ({
+  listRuns: vi.fn(),
+  createRun: vi.fn(),
+  updateRun: vi.fn(),
+  getStatsBudget: mockGetStatsBudget,
+}));
+
+import app from "../../src/index.js";
+import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+
+describe("Stats Routes", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+    mockGetStatsBudget.mockResolvedValue({ windows: [] });
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /stats/batch-budget", () => {
+    it("should return cost total for each campaign", async () => {
+      const campaign = await insertTestCampaign("org_stats_1", {
+        status: "ongoing",
+        maxBudgetTotalUsd: "50.00",
+        maxLeads: 100,
+      });
+
+      mockGetStatsBudget.mockResolvedValue({
+        windows: [{ label: "total", totalCostInUsdCents: "1234", actualCostInUsdCents: "1234", provisionedCostInUsdCents: "0" }],
+      });
+
+      const res = await request(app)
+        .post("/stats/batch-budget")
+        .set("x-api-key", API_KEY)
+        .send({ campaignIds: [campaign.id] })
+        .expect(200);
+
+      const result = res.body.results[campaign.id];
+      expect(result.status).toBe("ongoing");
+      expect(result.maxLeads).toBe(100);
+      expect(result.maxBudgetTotalUsd).toBe("50.00");
+      expect(result.totalCostInUsdCents).toBe("1234");
+    });
+
+    it("should call getStatsBudget with correct params", async () => {
+      const campaign = await insertTestCampaign("org_stats_params", {});
+
+      await request(app)
+        .post("/stats/batch-budget")
+        .set("x-api-key", API_KEY)
+        .send({ campaignIds: [campaign.id] })
+        .expect(200);
+
+      expect(mockGetStatsBudget).toHaveBeenCalledWith({
+        orgId: "org_stats_params",
+        campaignId: campaign.id,
+        windows: [{ label: "total" }],
+      });
+    });
+
+    it("should handle not-found campaign gracefully", async () => {
+      const fakeId = crypto.randomUUID();
+
+      const res = await request(app)
+        .post("/stats/batch-budget")
+        .set("x-api-key", API_KEY)
+        .send({ campaignIds: [fakeId] })
+        .expect(200);
+
+      expect(res.body.results[fakeId]).toEqual({ error: "Campaign not found" });
+    });
+
+    it("should handle getStatsBudget failure gracefully", async () => {
+      const campaign = await insertTestCampaign("org_stats_err", {});
+
+      mockGetStatsBudget.mockRejectedValue(new Error("runs-service down"));
+
+      const res = await request(app)
+        .post("/stats/batch-budget")
+        .set("x-api-key", API_KEY)
+        .send({ campaignIds: [campaign.id] })
+        .expect(200);
+
+      expect(res.body.results[campaign.id]).toEqual({ error: "Failed to fetch stats" });
+    });
+
+    it("should return null totalCostInUsdCents when no windows returned", async () => {
+      const campaign = await insertTestCampaign("org_stats_empty", {});
+
+      const res = await request(app)
+        .post("/stats/batch-budget")
+        .set("x-api-key", API_KEY)
+        .send({ campaignIds: [campaign.id] })
+        .expect(200);
+
+      expect(res.body.results[campaign.id].totalCostInUsdCents).toBeNull();
+    });
+
+    it("should handle multiple campaigns in batch", async () => {
+      const c1 = await insertTestCampaign("org_stats_multi", { status: "ongoing" });
+      const c2 = await insertTestCampaign("org_stats_multi", { status: "stopped" });
+
+      mockGetStatsBudget
+        .mockResolvedValueOnce({
+          windows: [{ label: "total", totalCostInUsdCents: "100", actualCostInUsdCents: "100", provisionedCostInUsdCents: "0" }],
+        })
+        .mockResolvedValueOnce({
+          windows: [{ label: "total", totalCostInUsdCents: "200", actualCostInUsdCents: "200", provisionedCostInUsdCents: "0" }],
+        });
+
+      const res = await request(app)
+        .post("/stats/batch-budget")
+        .set("x-api-key", API_KEY)
+        .send({ campaignIds: [c1.id, c2.id] })
+        .expect(200);
+
+      expect(res.body.results[c1.id].status).toBe("ongoing");
+      expect(res.body.results[c1.id].totalCostInUsdCents).toBe("100");
+      expect(res.body.results[c2.id].status).toBe("stopped");
+      expect(res.body.results[c2.id].totalCostInUsdCents).toBe("200");
+    });
+
+    it("should reject empty campaignIds array", async () => {
+      await request(app)
+        .post("/stats/batch-budget")
+        .set("x-api-key", API_KEY)
+        .send({ campaignIds: [] })
+        .expect(400);
+    });
+
+    it("should reject missing body", async () => {
+      await request(app)
+        .post("/stats/batch-budget")
+        .set("x-api-key", API_KEY)
+        .send({})
+        .expect(400);
+    });
+  });
+
+  describe("GET /stats", () => {
+    it("should return stats filtered by orgId", async () => {
+      await insertTestCampaign("org_stats_get", { status: "ongoing", maxBudgetTotalUsd: "100.00", maxLeads: 50 });
+      await insertTestCampaign("org_stats_get", { status: "stopped", maxBudgetTotalUsd: "200.00", maxLeads: 30 });
+      await insertTestCampaign("org_other", { status: "ongoing" });
+
+      const res = await request(app)
+        .get("/stats?orgId=org_stats_get")
+        .set("x-api-key", API_KEY)
+        .expect(200);
+
+      expect(res.body.stats.totalCampaigns).toBe(2);
+      expect(res.body.stats.byStatus).toEqual({ ongoing: 1, stopped: 1 });
+      expect(res.body.stats.budgetTotalUsd).toBe(300);
+      expect(res.body.stats.maxLeadsTotal).toBe(80);
+    });
+
+    it("should return stats filtered by brandId", async () => {
+      const brandId = crypto.randomUUID();
+      await insertTestCampaign("org_brand_stat", { status: "ongoing", brandId });
+      await insertTestCampaign("org_brand_stat", { status: "ongoing" }); // no brandId
+
+      const res = await request(app)
+        .get(`/stats?brandId=${brandId}`)
+        .set("x-api-key", API_KEY)
+        .expect(200);
+
+      expect(res.body.stats.totalCampaigns).toBe(1);
+    });
+
+    it("should return stats filtered by campaignId", async () => {
+      const c = await insertTestCampaign("org_cid_stat", { status: "ongoing", maxLeads: 42 });
+      await insertTestCampaign("org_cid_stat", { status: "ongoing" });
+
+      const res = await request(app)
+        .get(`/stats?campaignId=${c.id}`)
+        .set("x-api-key", API_KEY)
+        .expect(200);
+
+      expect(res.body.stats.totalCampaigns).toBe(1);
+      expect(res.body.stats.maxLeadsTotal).toBe(42);
+    });
+
+    it("should reject request with no filter params", async () => {
+      await request(app)
+        .get("/stats")
+        .set("x-api-key", API_KEY)
+        .expect(400);
+    });
+
+    it("should return null budgetTotalUsd when no budgets set", async () => {
+      await insertTestCampaign("org_no_budget", { status: "ongoing" });
+
+      const res = await request(app)
+        .get("/stats?orgId=org_no_budget")
+        .set("x-api-key", API_KEY)
+        .expect(200);
+
+      expect(res.body.stats.budgetTotalUsd).toBeNull();
+    });
+
+    it("should return empty stats when no campaigns match", async () => {
+      const res = await request(app)
+        .get("/stats?orgId=nonexistent_org")
+        .set("x-api-key", API_KEY)
+        .expect(200);
+
+      expect(res.body.stats.totalCampaigns).toBe(0);
+      expect(res.body.stats.byStatus).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /stats/batch-budget` as new canonical path for `POST /campaigns/batch-budget-usage`
- Adds `GET /stats?orgId=X&brandId=Y` as new canonical path for `POST /campaigns/stats` (switched from POST to GET with query params)
- Old endpoints remain live for parallel migration — api-service switches over, then we remove the old paths
- Includes `validateQuery` middleware, `StatsFilterQuery` schema, 14 integration tests, and updated OpenAPI spec

## Test plan
- [x] 14 integration tests covering both new endpoints (happy path, errors, edge cases)
- [x] Full test suite passes (2 pre-existing failures in campaign-crud unrelated)
- [ ] Deploy to staging, verify `POST /stats/batch-budget` returns same data as `POST /campaigns/batch-budget-usage`
- [ ] Verify `GET /stats?orgId=X` returns same data as `POST /campaigns/stats`
- [ ] Switch api-service to new paths, then remove old endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)