### PR TITLE
chore: remove legacy stats endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -327,20 +327,6 @@
           "stats"
         ]
       },
-      "StatsFilterBody": {
-        "type": "object",
-        "properties": {
-          "orgId": {
-            "type": "string"
-          },
-          "brandId": {
-            "type": "string"
-          },
-          "campaignId": {
-            "type": "string"
-          }
-        }
-      },
       "BatchBudgetUsageBody": {
         "type": "object",
         "properties": {
@@ -844,58 +830,13 @@
         }
       }
     },
-    "/campaigns/stats": {
-      "post": {
-        "tags": [
-          "Campaigns"
-        ],
-        "summary": "Campaign stats from own DB",
-        "description": "Returns campaign counts, status breakdown, and configured budget totals (not actual costs). Requires API key.",
-        "security": [
-          {
-            "apiKeyAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StatsFilterBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Campaign stats",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/stats": {
       "get": {
         "tags": [
           "Stats"
         ],
         "summary": "Campaign stats from own DB (query params)",
-        "description": "Returns campaign counts, status breakdown, and configured budget totals. New canonical path for POST /campaigns/stats. Requires API key.",
+        "description": "Returns campaign counts, status breakdown, and configured budget totals. Requires API key.",
         "security": [
           {
             "apiKeyAuth": []
@@ -957,7 +898,7 @@
           "Stats"
         ],
         "summary": "Get cost data for multiple campaigns",
-        "description": "Returns budget usage (totalCostInUsdCents) per campaign via runs-service. New canonical path for POST /campaigns/batch-budget-usage.",
+        "description": "Returns budget usage (totalCostInUsdCents) per campaign via runs-service.",
         "security": [
           {
             "apiKeyAuth": []
@@ -1081,82 +1022,6 @@
                   "required": [
                     "campaigns"
                   ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/campaigns/batch-budget-usage": {
-      "post": {
-        "tags": [
-          "Scheduler"
-        ],
-        "summary": "Get cost data for multiple campaigns",
-        "description": "Returns budget usage (totalCostInUsdCents) per campaign via runs-service stats/budget endpoint",
-        "security": [
-          {
-            "apiKeyAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BatchBudgetUsageBody"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Stats per campaign",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "results": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "status": {
-                            "type": "string"
-                          },
-                          "maxLeads": {
-                            "type": "number",
-                            "nullable": true
-                          },
-                          "maxBudgetTotalUsd": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "totalCostInUsdCents": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "error": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "results"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -7,7 +7,6 @@ import {
   CampaignSchema,
   CreateCampaignBody,
   UpdateCampaignBody,
-  StatsFilterBody,
   StatsFilterQuery,
   StatsResponse,
   BatchBudgetUsageBody,
@@ -131,28 +130,14 @@ registry.registerPath({
   },
 });
 
-registry.registerPath({
-  method: "post",
-  path: "/campaigns/stats",
-  tags: ["Campaigns"],
-  summary: "Campaign stats from own DB",
-  description: "Returns campaign counts, status breakdown, and configured budget totals (not actual costs). Requires API key.",
-  security: [{ [apiKeyAuth.name]: [] }],
-  request: { body: { content: { "application/json": { schema: StatsFilterBody } } } },
-  responses: {
-    200: { description: "Campaign stats", content: { "application/json": { schema: StatsResponse } } },
-    400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
-  },
-});
-
-// === STATS (new canonical paths) ===
+// === STATS ===
 
 registry.registerPath({
   method: "get",
   path: "/stats",
   tags: ["Stats"],
   summary: "Campaign stats from own DB (query params)",
-  description: "Returns campaign counts, status breakdown, and configured budget totals. New canonical path for POST /campaigns/stats. Requires API key.",
+  description: "Returns campaign counts, status breakdown, and configured budget totals. Requires API key.",
   security: [{ [apiKeyAuth.name]: [] }],
   request: { query: StatsFilterQuery },
   responses: {
@@ -166,7 +151,7 @@ registry.registerPath({
   path: "/stats/batch-budget",
   tags: ["Stats"],
   summary: "Get cost data for multiple campaigns",
-  description: "Returns budget usage (totalCostInUsdCents) per campaign via runs-service. New canonical path for POST /campaigns/batch-budget-usage.",
+  description: "Returns budget usage (totalCostInUsdCents) per campaign via runs-service.",
   security: [{ [apiKeyAuth.name]: [] }],
   request: { body: { content: { "application/json": { schema: BatchBudgetUsageBody } } } },
   responses: {
@@ -200,35 +185,6 @@ registry.registerPath({
   security: [{ [apiKeyAuth.name]: [] }],
   responses: {
     200: { description: "All campaigns with org info", content: { "application/json": { schema: z.object({ campaigns: z.array(CampaignSchema.extend({ externalOrgId: z.string(), brandDomain: z.string().nullable(), brandName: z.string().nullable() })) }) } } },
-  },
-});
-
-registry.registerPath({
-  method: "post",
-  path: "/campaigns/batch-budget-usage",
-  tags: ["Scheduler"],
-  summary: "Get cost data for multiple campaigns",
-  description: "Returns budget usage (totalCostInUsdCents) per campaign via runs-service stats/budget endpoint",
-  security: [{ [apiKeyAuth.name]: [] }],
-  request: { body: { content: { "application/json": { schema: BatchBudgetUsageBody } } } },
-  responses: {
-    200: {
-      description: "Stats per campaign",
-      content: {
-        "application/json": {
-          schema: z.object({
-            results: z.record(z.string(), z.object({
-              status: z.string().optional(),
-              maxLeads: z.number().nullable().optional(),
-              maxBudgetTotalUsd: z.string().nullable().optional(),
-              totalCostInUsdCents: z.string().nullable().optional(),
-              error: z.string().optional(),
-            })),
-          }),
-        },
-      },
-    },
-    400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
   },
 });
 

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -1,12 +1,11 @@
 import { Router } from "express";
-import { eq, and, desc, inArray } from "drizzle-orm";
+import { eq, and, desc } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { normalizeUrl, extractDomain } from "../lib/domain.js";
-import { getStatsBudget } from "@mcpfactory/runs-client";
-import { CreateCampaignBody, UpdateCampaignBody, StatsFilterBody, BatchBudgetUsageBody } from "../schemas.js";
+import { CreateCampaignBody, UpdateCampaignBody } from "../schemas.js";
 import { executeCampaignWorkflow } from "../lib/workflows.js";
 
 const router = Router();
@@ -48,111 +47,6 @@ router.get("/campaigns/list", requireApiKey, async (_req, res) => {
     res.json({ campaigns: enrichedCampaigns });
   } catch (error) {
     console.error("[Campaign Service] List all campaigns error:", error);
-    res.status(500).json({ error: "Internal server error" });
-  }
-});
-
-/**
- * POST /campaigns/batch-budget-usage - Get cost and run data for multiple campaigns
- */
-router.post("/campaigns/batch-budget-usage", requireApiKey, validateBody(BatchBudgetUsageBody), async (req, res) => {
-  try {
-    const { campaignIds } = req.body;
-
-    const campaignRows = await db
-      .select({
-        id: campaigns.id,
-        orgId: campaigns.orgId,
-        status: campaigns.status,
-        maxLeads: campaigns.maxLeads,
-        maxBudgetTotalUsd: campaigns.maxBudgetTotalUsd,
-      })
-      .from(campaigns)
-      .where(inArray(campaigns.id, campaignIds));
-
-    const campaignMap = new Map(
-      campaignRows.map(r => [r.id, r])
-    );
-
-    const results: Record<string, unknown> = {};
-
-    await Promise.all(
-      campaignIds.map(async (campaignId: string) => {
-        const row = campaignMap.get(campaignId);
-        if (!row) {
-          results[campaignId] = { error: "Campaign not found" };
-          return;
-        }
-
-        try {
-          const budgetResult = await getStatsBudget({
-            orgId: row.orgId,
-            campaignId,
-            windows: [{ label: "total" }],
-          });
-
-          const totalWindow = budgetResult.windows.find(w => w.label === "total");
-          const totalCostCents = totalWindow ? parseFloat(totalWindow.totalCostInUsdCents) || 0 : 0;
-
-          results[campaignId] = {
-            status: row.status,
-            maxLeads: row.maxLeads,
-            maxBudgetTotalUsd: row.maxBudgetTotalUsd,
-            totalCostInUsdCents: totalCostCents > 0 ? String(totalCostCents) : null,
-          };
-        } catch (err) {
-          console.warn(`[Campaign Service] Batch budget usage failed for campaign ${campaignId}:`, err);
-          results[campaignId] = { error: "Failed to fetch stats" };
-        }
-      })
-    );
-
-    res.json({ results });
-  } catch (error) {
-    console.error("[Campaign Service] Batch budget usage error:", error);
-    res.status(500).json({ error: "Internal server error" });
-  }
-});
-
-/**
- * POST /campaigns/stats - Campaign stats from own DB
- */
-router.post("/campaigns/stats", requireApiKey, validateBody(StatsFilterBody), async (req, res) => {
-  try {
-    const { orgId, brandId, campaignId } = req.body;
-
-    const conditions = [];
-    if (orgId) conditions.push(eq(campaigns.orgId, orgId));
-    if (brandId) conditions.push(eq(campaigns.brandId, brandId));
-    if (campaignId) conditions.push(eq(campaigns.id, campaignId));
-
-    const where = conditions.length === 1 ? conditions[0] : and(...conditions);
-
-    const matching = await db
-      .select()
-      .from(campaigns)
-      .where(where);
-
-    const byStatus: Record<string, number> = {};
-    let budgetTotalUsd = 0;
-    let maxLeadsTotal = 0;
-
-    for (const c of matching) {
-      byStatus[c.status] = (byStatus[c.status] || 0) + 1;
-      if (c.maxBudgetTotalUsd) budgetTotalUsd += parseFloat(c.maxBudgetTotalUsd);
-      if (c.maxLeads) maxLeadsTotal += c.maxLeads;
-    }
-
-    res.json({
-      stats: {
-        totalCampaigns: matching.length,
-        byStatus,
-        budgetTotalUsd: budgetTotalUsd > 0 ? budgetTotalUsd : null,
-        maxLeadsTotal: maxLeadsTotal > 0 ? maxLeadsTotal : null,
-      },
-    });
-  } catch (error) {
-    console.error("[Campaign Service] Stats error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -81,15 +81,6 @@ export const UpdateCampaignBody = z.object({
 
 // --- Stats ---
 
-export const StatsFilterBody = z.object({
-  orgId: z.string().optional(),
-  brandId: z.string().optional(),
-  campaignId: z.string().optional(),
-}).refine(
-  (data) => data.orgId || data.brandId || data.campaignId,
-  { message: "At least one filter required: orgId, brandId, or campaignId" }
-).openapi("StatsFilterBody");
-
 export const StatsFilterQuery = z.object({
   orgId: z.string().optional(),
   brandId: z.string().optional(),

--- a/tests/integration/scheduler-campaigns.test.ts
+++ b/tests/integration/scheduler-campaigns.test.ts
@@ -1,15 +1,11 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
 
-const { mockGetStatsBudget } = vi.hoisted(() => ({
-  mockGetStatsBudget: vi.fn(),
-}));
-
 vi.mock("@mcpfactory/runs-client", () => ({
   listRuns: vi.fn(),
   createRun: vi.fn(),
   updateRun: vi.fn(),
-  getStatsBudget: mockGetStatsBudget,
+  getStatsBudget: vi.fn().mockResolvedValue({ windows: [] }),
 }));
 
 import app from "../../src/index.js";
@@ -20,8 +16,6 @@ const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 describe("Scheduler Endpoints", () => {
   beforeEach(async () => {
     await cleanTestData();
-    vi.clearAllMocks();
-    mockGetStatsBudget.mockResolvedValue({ windows: [] });
   });
 
   afterAll(async () => {
@@ -60,114 +54,6 @@ describe("Scheduler Endpoints", () => {
         .expect(200);
 
       expect(res.body.campaigns).toHaveLength(0);
-    });
-  });
-
-  describe("POST /campaigns/batch-budget-usage", () => {
-    it("should return cost total from getStatsBudget for each campaign", async () => {
-      const campaign = await insertTestCampaign("org_batch", {
-        status: "ongoing",
-        maxBudgetTotalUsd: "50.00",
-        maxLeads: 100,
-      });
-
-      mockGetStatsBudget.mockResolvedValue({
-        windows: [{ label: "total", totalCostInUsdCents: "1234", actualCostInUsdCents: "1234", provisionedCostInUsdCents: "0" }],
-      });
-
-      const res = await request(app)
-        .post("/campaigns/batch-budget-usage")
-        .set("x-api-key", API_KEY)
-        .send({ campaignIds: [campaign.id] })
-        .expect(200);
-
-      const result = res.body.results[campaign.id];
-      expect(result.status).toBe("ongoing");
-      expect(result.maxLeads).toBe(100);
-      expect(result.maxBudgetTotalUsd).toBe("50.00");
-      expect(result.totalCostInUsdCents).toBe("1234");
-    });
-
-    it("should call getStatsBudget with correct params", async () => {
-      const campaign = await insertTestCampaign("org_batch_params", {});
-
-      mockGetStatsBudget.mockResolvedValue({ windows: [] });
-
-      await request(app)
-        .post("/campaigns/batch-budget-usage")
-        .set("x-api-key", API_KEY)
-        .send({ campaignIds: [campaign.id] })
-        .expect(200);
-
-      expect(mockGetStatsBudget).toHaveBeenCalledWith({
-        orgId: "org_batch_params",
-        campaignId: campaign.id,
-        windows: [{ label: "total" }],
-      });
-    });
-
-    it("should handle not-found campaign gracefully", async () => {
-      const fakeId = crypto.randomUUID();
-
-      const res = await request(app)
-        .post("/campaigns/batch-budget-usage")
-        .set("x-api-key", API_KEY)
-        .send({ campaignIds: [fakeId] })
-        .expect(200);
-
-      expect(res.body.results[fakeId]).toEqual({ error: "Campaign not found" });
-    });
-
-    it("should handle getStatsBudget failure gracefully", async () => {
-      const campaign = await insertTestCampaign("org_batch_err", {});
-
-      mockGetStatsBudget.mockRejectedValue(new Error("runs-service down"));
-
-      const res = await request(app)
-        .post("/campaigns/batch-budget-usage")
-        .set("x-api-key", API_KEY)
-        .send({ campaignIds: [campaign.id] })
-        .expect(200);
-
-      expect(res.body.results[campaign.id]).toEqual({ error: "Failed to fetch stats" });
-    });
-
-    it("should return null totalCostInUsdCents when no windows returned", async () => {
-      const campaign = await insertTestCampaign("org_batch_empty", {});
-
-      mockGetStatsBudget.mockResolvedValue({ windows: [] });
-
-      const res = await request(app)
-        .post("/campaigns/batch-budget-usage")
-        .set("x-api-key", API_KEY)
-        .send({ campaignIds: [campaign.id] })
-        .expect(200);
-
-      expect(res.body.results[campaign.id].totalCostInUsdCents).toBeNull();
-    });
-
-    it("should handle multiple campaigns in batch", async () => {
-      const c1 = await insertTestCampaign("org_multi", { status: "ongoing" });
-      const c2 = await insertTestCampaign("org_multi", { status: "stopped" });
-
-      mockGetStatsBudget
-        .mockResolvedValueOnce({
-          windows: [{ label: "total", totalCostInUsdCents: "100", actualCostInUsdCents: "100", provisionedCostInUsdCents: "0" }],
-        })
-        .mockResolvedValueOnce({
-          windows: [{ label: "total", totalCostInUsdCents: "200", actualCostInUsdCents: "200", provisionedCostInUsdCents: "0" }],
-        });
-
-      const res = await request(app)
-        .post("/campaigns/batch-budget-usage")
-        .set("x-api-key", API_KEY)
-        .send({ campaignIds: [c1.id, c2.id] })
-        .expect(200);
-
-      expect(res.body.results[c1.id].status).toBe("ongoing");
-      expect(res.body.results[c1.id].totalCostInUsdCents).toBe("100");
-      expect(res.body.results[c2.id].status).toBe("stopped");
-      expect(res.body.results[c2.id].totalCostInUsdCents).toBe("200");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Removes `POST /campaigns/batch-budget-usage` (replaced by `POST /stats/batch-budget` in PR #80)
- Removes `POST /campaigns/stats` (replaced by `GET /stats` in PR #80)
- Removes unused `StatsFilterBody` schema and legacy OpenAPI registrations
- Cleans up imports (`inArray`, `getStatsBudget` no longer needed in campaigns.ts)
- Migrates scheduler test file to drop legacy batch-budget tests (covered by stats-routes.test.ts)

## Test plan
- [x] Full test suite passes (141 pass, 2 pre-existing failures unrelated)
- [x] Build succeeds, OpenAPI spec regenerated without legacy paths
- [ ] Verify no callers still hit old paths before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)