### PR TITLE
feat: require brandId on workflow execution

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -36,6 +36,11 @@ export async function resumeDueCampaigns(): Promise<number> {
 
   for (const campaign of dueCampaigns) {
     try {
+      if (!campaign.brandId) {
+        console.warn(`[Scheduler] Campaign ${campaign.id} has no brandId — skipping resume`);
+        continue;
+      }
+
       // Clear toResumeAt before re-triggering (prevent double-fire)
       await db.update(campaigns)
         .set({ toResumeAt: null, updatedAt: new Date() })
@@ -52,9 +57,9 @@ export async function resumeDueCampaigns(): Promise<number> {
       executeCampaignWorkflow(campaign.workflowName, {
         campaignId: campaign.id,
         orgId: campaign.orgId,
+        brandId: campaign.brandId,
         userId: campaign.createdByUserId ?? undefined,
         runId: run.id,
-        brandId: campaign.brandId ?? undefined,
       }).catch((err) => {
         console.error(`[Scheduler] Failed to re-trigger campaign ${campaign.id}:`, err);
       });

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -7,7 +7,7 @@
  */
 export async function executeCampaignWorkflow(
   workflowName: string,
-  inputs: { campaignId: string; orgId: string; userId?: string; runId?: string; brandId?: string },
+  inputs: { campaignId: string; orgId: string; brandId: string; userId?: string; runId?: string },
 ): Promise<void> {
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
@@ -27,10 +27,10 @@ export async function executeCampaignWorkflow(
     "x-api-key": apiKey,
     "x-org-id": inputs.orgId,
   };
+  headers["x-brand-id"] = inputs.brandId;
   if (inputs.userId) headers["x-user-id"] = inputs.userId;
   if (inputs.runId) headers["x-run-id"] = inputs.runId;
   if (inputs.campaignId) headers["x-campaign-id"] = inputs.campaignId;
-  if (inputs.brandId) headers["x-brand-id"] = inputs.brandId;
   headers["x-workflow-name"] = workflowName;
 
   const res = await fetch(executeUrl, {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -161,9 +161,9 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     executeCampaignWorkflow(campaign.workflowName, {
       campaignId: campaign.id,
       orgId: req.orgId!,
+      brandId: campaign.brandId!,
       userId: req.userId,
       runId: req.runId,
-      brandId: campaign.brandId || undefined,
     }).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
@@ -210,13 +210,16 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
 
     // Trigger workflow on activation
     if (req.body.status === "activate") {
+      if (!updated.brandId) {
+        return res.status(400).json({ error: "Cannot activate campaign without brandId" });
+      }
       console.log(`[Campaign Service] Launching workflow run from CAMPAIGN ACTIVATION — workflow=${updated.workflowName}, campaignId=${updated.id}`);
       executeCampaignWorkflow(updated.workflowName, {
         campaignId: updated.id,
         orgId: req.orgId!,
+        brandId: updated.brandId,
         userId: req.userId,
         runId: req.runId,
-        brandId: updated.brandId || undefined,
       }).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -243,14 +243,20 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
         return;
       }
 
+      const resolvedBrandId = req.brandId || freshCampaign.brandId;
+      if (!resolvedBrandId) {
+        console.warn(`[End Run] Campaign ${campaignId} has no brandId — skipping re-trigger`);
+        return;
+      }
+
       // Fire-and-forget: gate-check in the next workflow execution will validate limits
       console.log(`[Campaign Service] Launching workflow run from END-RUN handler — workflow=${freshCampaign.workflowName}, campaignId=${campaignId}, previousRunSuccess=${success}`);
       executeCampaignWorkflow(freshCampaign.workflowName, {
         campaignId,
         orgId,
+        brandId: resolvedBrandId,
         userId: identity.userId,
         runId: identity.runId,
-        brandId: req.brandId || freshCampaign.brandId || undefined,
       }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -40,7 +40,7 @@ export async function insertTestCampaign(
       workflowName: data.workflowName || "sales-email-cold-outreach",
       status: data.status || "ongoing",
       brandUrl: data.brandUrl || null,
-      brandId: data.brandId || null,
+      brandId: "brandId" in data ? (data.brandId || null) : crypto.randomUUID(),
       maxBudgetDailyUsd: data.maxBudgetDailyUsd || "10.00",
       maxBudgetWeeklyUsd: data.maxBudgetWeeklyUsd || null,
       maxBudgetMonthlyUsd: data.maxBudgetMonthlyUsd || null,

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -50,9 +50,10 @@ describe("Campaign Service Database", () => {
       expect(campaign.brandId).toBe(brandId);
     });
 
-    it("should store null brandId when not provided", async () => {
+    it("should store null brandId when explicitly set to undefined", async () => {
       const campaign = await insertTestCampaign("org_1", {
         name: "No Brand Campaign",
+        brandId: undefined,
       });
 
       expect(campaign.brandId).toBeNull();
@@ -61,7 +62,7 @@ describe("Campaign Service Database", () => {
     it("should query campaigns by brandId", async () => {
       const brandId = crypto.randomUUID();
       await insertTestCampaign("org_1", { name: "With Brand", brandId });
-      await insertTestCampaign("org_1", { name: "Without Brand" });
+      await insertTestCampaign("org_1", { name: "Without Brand", brandId: undefined });
 
       const results = await db
         .select()

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -15,6 +15,7 @@ const {
     id: string;
     orgId: string;
     workflowName: string;
+    brandId?: string | null;
   }> = [];
 
   return {
@@ -85,6 +86,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       id: "campaign-1",
       orgId: "org-ext-1",
       workflowName: "sales-email-cold-outreach",
+      brandId: "brand-123",
     });
 
     const count = await resumeDueCampaigns();
@@ -106,10 +108,26 @@ describe("Scheduler - resumeDueCampaigns", () => {
       {
         campaignId: "campaign-1",
         orgId: "org-ext-1",
+        brandId: "brand-123",
         userId: undefined,
         runId: "scheduler-run-123",
       },
     );
+  });
+
+  it("should skip campaigns without brandId", async () => {
+    mockDbValues.push({
+      id: "campaign-no-brand",
+      orgId: "org-ext-1",
+      workflowName: "sales-email-cold-outreach",
+      brandId: null,
+    });
+
+    const count = await resumeDueCampaigns();
+
+    expect(count).toBe(1);
+    expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
+    expect(mockCreateRun).not.toHaveBeenCalled();
   });
 
   it("should handle multiple due campaigns", async () => {
@@ -118,11 +136,13 @@ describe("Scheduler - resumeDueCampaigns", () => {
         id: "campaign-1",
         orgId: "org-ext-1",
         workflowName: "sales-email-cold-outreach",
+        brandId: "brand-1",
       },
       {
         id: "campaign-2",
         orgId: "org-ext-2",
         workflowName: "pr-email-cold-outreach",
+        brandId: "brand-2",
       },
     );
 
@@ -138,11 +158,13 @@ describe("Scheduler - resumeDueCampaigns", () => {
         id: "campaign-1",
         orgId: "org-ext-1",
         workflowName: "sales-email-cold-outreach",
+        brandId: "brand-1",
       },
       {
         id: "campaign-2",
         orgId: "org-ext-2",
         workflowName: "pr-email-cold-outreach",
+        brandId: "brand-2",
       },
     );
 

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -23,6 +23,7 @@ describe("Workflow module", () => {
       await executeCampaignWorkflow("sales-email-cold-outreach", {
         campaignId: "campaign-1",
         orgId: "org_test",
+        brandId: "brand-abc",
       });
 
       expect(mockFetch).toHaveBeenCalledOnce();
@@ -49,6 +50,7 @@ describe("Workflow module", () => {
       await executeCampaignWorkflow("sales-email-cold-outreach", {
         campaignId: "campaign-1",
         orgId: "org_test",
+        brandId: "brand-abc",
         userId: "user_test",
         runId: "run-parent-456",
       });
@@ -80,7 +82,7 @@ describe("Workflow module", () => {
       expect(opts.headers["x-workflow-name"]).toBe("sales-email-cold-outreach");
     });
 
-    it("should always set x-workflow-name even without brandId", async () => {
+    it("should always set x-brand-id header (required)", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ id: "run-123", status: "queued" }),
@@ -90,12 +92,13 @@ describe("Workflow module", () => {
       await executeCampaignWorkflow("pr-outreach", {
         campaignId: "campaign-2",
         orgId: "org_test",
+        brandId: "brand-xyz",
       });
 
       expect(mockFetch).toHaveBeenCalledOnce();
       const [, opts] = mockFetch.mock.calls[0];
       expect(opts.headers["x-campaign-id"]).toBe("campaign-2");
-      expect(opts.headers["x-brand-id"]).toBeUndefined();
+      expect(opts.headers["x-brand-id"]).toBe("brand-xyz");
       expect(opts.headers["x-workflow-name"]).toBe("pr-outreach");
     });
 
@@ -111,6 +114,7 @@ describe("Workflow module", () => {
         executeCampaignWorkflow("sales-email-cold-outreach", {
           campaignId: "campaign-1",
           orgId: "org_test",
+          brandId: "brand-abc",
         })
       ).resolves.not.toThrow();
     });
@@ -124,6 +128,7 @@ describe("Workflow module", () => {
         executeCampaignWorkflow("any-workflow", {
           campaignId: "campaign-1",
           orgId: "org_test",
+          brandId: "brand-abc",
         })
       ).resolves.not.toThrow();
       expect(mockFetch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Make `brandId` a required parameter in `executeCampaignWorkflow` and always send `x-brand-id` header (no longer conditional)
- Guard all 4 call sites: campaign creation, activation (returns 400 if missing), end-run re-trigger (skips if missing), scheduler resume (skips if missing)
- Adapts to workflow-service breaking change requiring `x-brand-id` on all auth'd endpoints

## Test plan
- [x] Unit tests updated: `workflows.test.ts` (brandId now required in all calls), `scheduler.test.ts` (new test for skipping campaigns without brandId)
- [x] Integration tests pass: `workflow-activation.test.ts`, `internal-routes.test.ts`, `scheduler-resume.test.ts`
- [x] Verified 38 campaigns without brandId in prod are all `stopped` — no ongoing campaigns affected
- [x] 2 pre-existing test failures in `campaign-crud.test.ts` (duplicate name constraint) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)