### PR TITLE
fix: send tracking fields as headers in createRun

### DIFF
--- a/packages/runs-client/src/index.ts
+++ b/packages/runs-client/src/index.ts
@@ -131,11 +131,11 @@ async function runsRequest<T>(
  * parentRunId is sent as x-run-id header.
  */
 export async function createRun(params: CreateRunParams): Promise<Run> {
-  const { orgId, userId, parentRunId, ...body } = params;
+  const { orgId, userId, parentRunId, brandId, campaignId, workflowName, ...body } = params;
   return runsRequest<Run>("/v1/runs", {
     method: "POST",
     body,
-    identity: { orgId, userId, runId: parentRunId },
+    identity: { orgId, userId, runId: parentRunId, brandId, campaignId, workflowName },
   });
 }
 

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -53,6 +53,8 @@ export async function resumeDueCampaigns(): Promise<number> {
         taskName: "scheduler-resume",
         userId: campaign.createdByUserId ?? undefined,
         campaignId: campaign.id,
+        brandId: campaign.brandId ?? undefined,
+        workflowName: campaign.workflowName,
       });
       executeCampaignWorkflow(campaign.workflowName, {
         campaignId: campaign.id,

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { createRun } from "@mcpfactory/runs-client";
+
+describe("runs-client createRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "run-1" }),
+    });
+  });
+
+  it("should send brandId, campaignId, workflowName as headers, not in body", async () => {
+    await createRun({
+      orgId: "org-1",
+      userId: "user-1",
+      serviceName: "campaign-service",
+      taskName: "test-task",
+      brandId: "brand-1",
+      campaignId: "campaign-1",
+      workflowName: "sales-email-cold-outreach",
+      parentRunId: "parent-run-1",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+
+    expect(url).toContain("/v1/runs");
+    expect(options.method).toBe("POST");
+
+    // Headers should contain tracking fields
+    expect(options.headers["x-org-id"]).toBe("org-1");
+    expect(options.headers["x-user-id"]).toBe("user-1");
+    expect(options.headers["x-run-id"]).toBe("parent-run-1");
+    expect(options.headers["x-brand-id"]).toBe("brand-1");
+    expect(options.headers["x-campaign-id"]).toBe("campaign-1");
+    expect(options.headers["x-workflow-name"]).toBe("sales-email-cold-outreach");
+
+    // Body should only contain serviceName and taskName
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({
+      serviceName: "campaign-service",
+      taskName: "test-task",
+    });
+    expect(body).not.toHaveProperty("brandId");
+    expect(body).not.toHaveProperty("campaignId");
+    expect(body).not.toHaveProperty("workflowName");
+  });
+
+  it("should omit undefined tracking headers", async () => {
+    await createRun({
+      orgId: "org-1",
+      serviceName: "campaign-service",
+      taskName: "test-task",
+    });
+
+    const [, options] = mockFetch.mock.calls[0];
+
+    expect(options.headers).not.toHaveProperty("x-brand-id");
+    expect(options.headers).not.toHaveProperty("x-campaign-id");
+    expect(options.headers).not.toHaveProperty("x-workflow-name");
+    expect(options.headers).not.toHaveProperty("x-user-id");
+    expect(options.headers).not.toHaveProperty("x-run-id");
+  });
+});

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -102,6 +102,8 @@ describe("Scheduler - resumeDueCampaigns", () => {
       taskName: "scheduler-resume",
       userId: undefined,
       campaignId: "campaign-1",
+      brandId: "brand-123",
+      workflowName: "sales-email-cold-outreach",
     });
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
       "sales-email-cold-outreach",


### PR DESCRIPTION
## Summary
- **runs-client `createRun()`**: Extract `brandId`, `campaignId`, `workflowName` from the body and send them as `x-brand-id`, `x-campaign-id`, `x-workflow-name` headers instead (body is being deprecated)
- **scheduler**: Add missing `brandId` and `workflowName` to the `createRun()` call for scheduled campaign resumes
- Adds unit tests for runs-client header behavior

## Test plan
- [x] Unit test: `createRun` sends tracking fields as headers, not in body
- [x] Unit test: undefined tracking fields are omitted from headers
- [x] Unit test: scheduler passes `brandId` and `workflowName` to `createRun`
- [x] All existing tests pass (2 pre-existing failures in campaign-crud unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)