### PR TITLE
feat: discovery endpoints for outlets and journalists

### DIFF
--- a/drizzle/0022_purple_screwball.sql
+++ b/drizzle/0022_purple_screwball.sql
@@ -1,0 +1,47 @@
+CREATE TABLE IF NOT EXISTS "discovered_journalists" (
+	"id" text PRIMARY KEY NOT NULL,
+	"campaign_id" text NOT NULL,
+	"first_name" text,
+	"last_name" text,
+	"email" text,
+	"outlet_name" text,
+	"title" text,
+	"beat" text,
+	"linkedin_url" text,
+	"twitter_handle" text,
+	"location" text,
+	"domain_rating" numeric(5, 1),
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "discovered_outlets" (
+	"id" text PRIMARY KEY NOT NULL,
+	"campaign_id" text NOT NULL,
+	"name" text NOT NULL,
+	"type" text,
+	"url" text,
+	"domain_rating" numeric(5, 1),
+	"monthly_traffic" integer,
+	"topics" text[] DEFAULT '{}' NOT NULL,
+	"country" text,
+	"language" text,
+	"contact_email" text,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "discovered_journalists" ADD CONSTRAINT "discovered_journalists_campaign_id_campaigns_id_fk" FOREIGN KEY ("campaign_id") REFERENCES "public"."campaigns"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "discovered_outlets" ADD CONSTRAINT "discovered_outlets_campaign_id_campaigns_id_fk" FOREIGN KEY ("campaign_id") REFERENCES "public"."campaigns"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_discovered_journalists_campaign" ON "discovered_journalists" USING btree ("campaign_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_discovered_outlets_campaign" ON "discovered_outlets" USING btree ("campaign_id");

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,467 @@
+{
+  "id": "81410aae-4111-45b3-b73a-56f7fc36d16c",
+  "prevId": "fbd43045-aac5-4dcb-80ed-09e7b86b296f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_url": {
+          "name": "brand_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_outcome": {
+          "name": "target_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_for_target": {
+          "name": "value_for_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_daily_usd": {
+          "name": "max_budget_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_weekly_usd": {
+          "name": "max_budget_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_monthly_usd": {
+          "name": "max_budget_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_budget_total_usd": {
+          "name": "max_budget_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_leads": {
+          "name": "max_leads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ongoing'"
+        },
+        "to_resume_at": {
+          "name": "to_resume_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_frequency": {
+          "name": "notify_frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_channel": {
+          "name": "notify_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_destination": {
+          "name": "notify_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_campaigns_org": {
+          "name": "idx_campaigns_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_campaigns_org_name": {
+          "name": "uniq_campaigns_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovered_journalists": {
+      "name": "discovered_journalists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outlet_name": {
+          "name": "outlet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beat": {
+          "name": "beat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_handle": {
+          "name": "twitter_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_rating": {
+          "name": "domain_rating",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discovered_journalists_campaign": {
+          "name": "idx_discovered_journalists_campaign",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovered_journalists_campaign_id_campaigns_id_fk": {
+          "name": "discovered_journalists_campaign_id_campaigns_id_fk",
+          "tableFrom": "discovered_journalists",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovered_outlets": {
+      "name": "discovered_outlets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_rating": {
+          "name": "domain_rating",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_traffic": {
+          "name": "monthly_traffic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discovered_outlets_campaign": {
+          "name": "idx_discovered_outlets_campaign",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovered_outlets_campaign_id_campaigns_id_fk": {
+          "name": "discovered_outlets_campaign_id_campaigns_id_fk",
+          "tableFrom": "discovered_outlets",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1772870400000,
       "tag": "0021_unique_campaign_name_per_org",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1774159510636,
+      "tag": "0022_purple_screwball",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -488,6 +488,291 @@
           "orgId",
           "success"
         ]
+      },
+      "DiscoveredOutlet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "domainRating": {
+            "type": "number",
+            "nullable": true
+          },
+          "monthlyTraffic": {
+            "type": "number",
+            "nullable": true
+          },
+          "topics": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "language": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "url",
+          "domainRating",
+          "monthlyTraffic",
+          "topics",
+          "country",
+          "language",
+          "contactEmail",
+          "notes",
+          "createdAt"
+        ]
+      },
+      "PaginationMeta": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "limit",
+          "offset"
+        ]
+      },
+      "CreateDiscoveredOutletsBody": {
+        "type": "object",
+        "properties": {
+          "outlets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateDiscoveredOutletBody"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "outlets"
+        ]
+      },
+      "CreateDiscoveredOutletBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "domainRating": {
+            "type": "number",
+            "nullable": true
+          },
+          "monthlyTraffic": {
+            "type": "integer",
+            "nullable": true
+          },
+          "topics": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "language": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "DiscoveredJournalist": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "outletName": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "beat": {
+            "type": "string",
+            "nullable": true
+          },
+          "linkedinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "twitterHandle": {
+            "type": "string",
+            "nullable": true
+          },
+          "location": {
+            "type": "string",
+            "nullable": true
+          },
+          "domainRating": {
+            "type": "number",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "firstName",
+          "lastName",
+          "email",
+          "outletName",
+          "title",
+          "beat",
+          "linkedinUrl",
+          "twitterHandle",
+          "location",
+          "domainRating",
+          "notes",
+          "createdAt"
+        ]
+      },
+      "CreateDiscoveredJournalistsBody": {
+        "type": "object",
+        "properties": {
+          "journalists": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateDiscoveredJournalistBody"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "journalists"
+        ]
+      },
+      "CreateDiscoveredJournalistBody": {
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "outletName": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "beat": {
+            "type": "string",
+            "nullable": true
+          },
+          "linkedinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "twitterHandle": {
+            "type": "string",
+            "nullable": true
+          },
+          "location": {
+            "type": "string",
+            "nullable": true
+          },
+          "domainRating": {
+            "type": "number",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          }
+        }
       }
     },
     "parameters": {}
@@ -1259,6 +1544,298 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EndRunResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/campaigns/{id}/discovered-outlets": {
+      "get": {
+        "tags": [
+          "Discovery"
+        ],
+        "summary": "List discovered outlets for a campaign",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "description": "Max results per page (1-200, default 50)"
+            },
+            "required": false,
+            "description": "Max results per page (1-200, default 50)",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "description": "Number of results to skip (default 0)"
+            },
+            "required": false,
+            "description": "Number of results to skip (default 0)",
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of discovered outlets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "outlets": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DiscoveredOutlet"
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "outlets",
+                    "pagination"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Campaign not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Discovery"
+        ],
+        "summary": "Store discovered outlets for a campaign",
+        "description": "Called by workflow-service to persist outlet discovery results.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDiscoveredOutletsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Outlets created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "outlets": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DiscoveredOutlet"
+                      }
+                    }
+                  },
+                  "required": [
+                    "outlets"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Campaign not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/campaigns/{id}/discovered-journalists": {
+      "get": {
+        "tags": [
+          "Discovery"
+        ],
+        "summary": "List discovered journalists for a campaign",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "description": "Max results per page (1-200, default 50)"
+            },
+            "required": false,
+            "description": "Max results per page (1-200, default 50)",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "description": "Number of results to skip (default 0)"
+            },
+            "required": false,
+            "description": "Number of results to skip (default 0)",
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of discovered journalists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "journalists": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DiscoveredJournalist"
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "journalists",
+                    "pagination"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Campaign not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Discovery"
+        ],
+        "summary": "Store discovered journalists for a campaign",
+        "description": "Called by workflow-service to persist journalist discovery results.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDiscoveredJournalistsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Journalists created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "journalists": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DiscoveredJournalist"
+                      }
+                    }
+                  },
+                  "required": [
+                    "journalists"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Campaign not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -17,6 +17,11 @@ import {
   StartRunResponse,
   EndRunBody,
   EndRunResponse,
+  DiscoveredOutletSchema,
+  DiscoveredJournalistSchema,
+  CreateDiscoveredOutletsBody,
+  CreateDiscoveredJournalistsBody,
+  PaginationQuery,
 } from "../src/schemas.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -244,6 +249,111 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Run finalized", content: { "application/json": { schema: EndRunResponse } } },
+  },
+});
+
+// === DISCOVERY ===
+
+const PaginationParams = z.object({
+  limit: z.number().int().optional().openapi({ description: "Max results per page (1-200, default 50)" }),
+  offset: z.number().int().optional().openapi({ description: "Number of results to skip (default 0)" }),
+}).openapi("PaginationParams");
+
+const PaginationMeta = z.object({
+  total: z.number().int(),
+  limit: z.number().int(),
+  offset: z.number().int(),
+}).openapi("PaginationMeta");
+
+registry.registerPath({
+  method: "get",
+  path: "/campaigns/{id}/discovered-outlets",
+  tags: ["Discovery"],
+  summary: "List discovered outlets for a campaign",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    query: PaginationParams,
+  },
+  responses: {
+    200: {
+      description: "Paginated list of discovered outlets",
+      content: {
+        "application/json": {
+          schema: z.object({
+            outlets: z.array(DiscoveredOutletSchema),
+            pagination: PaginationMeta,
+          }),
+        },
+      },
+    },
+    404: { description: "Campaign not found", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/campaigns/{id}/discovered-outlets",
+  tags: ["Discovery"],
+  summary: "Store discovered outlets for a campaign",
+  description: "Called by workflow-service to persist outlet discovery results.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: { content: { "application/json": { schema: CreateDiscoveredOutletsBody } } },
+  },
+  responses: {
+    201: {
+      description: "Outlets created",
+      content: { "application/json": { schema: z.object({ outlets: z.array(DiscoveredOutletSchema) }) } },
+    },
+    404: { description: "Campaign not found", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/campaigns/{id}/discovered-journalists",
+  tags: ["Discovery"],
+  summary: "List discovered journalists for a campaign",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    query: PaginationParams,
+  },
+  responses: {
+    200: {
+      description: "Paginated list of discovered journalists",
+      content: {
+        "application/json": {
+          schema: z.object({
+            journalists: z.array(DiscoveredJournalistSchema),
+            pagination: PaginationMeta,
+          }),
+        },
+      },
+    },
+    404: { description: "Campaign not found", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/campaigns/{id}/discovered-journalists",
+  tags: ["Discovery"],
+  summary: "Store discovered journalists for a campaign",
+  description: "Called by workflow-service to persist journalist discovery results.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: { content: { "application/json": { schema: CreateDiscoveredJournalistsBody } } },
+  },
+  responses: {
+    201: {
+      description: "Journalists created",
+      content: { "application/json": { schema: z.object({ journalists: z.array(DiscoveredJournalistSchema) }) } },
+    },
+    404: { description: "Campaign not found", content: { "application/json": { schema: ErrorResponse } } },
   },
 });
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -62,3 +62,56 @@ export const campaigns = pgTable(
 
 export type Campaign = typeof campaigns.$inferSelect;
 export type NewCampaign = typeof campaigns.$inferInsert;
+
+// Discovered outlets table
+export const discoveredOutlets = pgTable(
+  "discovered_outlets",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    campaignId: text("campaign_id").notNull().references(() => campaigns.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    type: text("type"),
+    url: text("url"),
+    domainRating: decimal("domain_rating", { precision: 5, scale: 1 }),
+    monthlyTraffic: integer("monthly_traffic"),
+    topics: text("topics").array().notNull().default([]),
+    country: text("country"),
+    language: text("language"),
+    contactEmail: text("contact_email"),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_discovered_outlets_campaign").on(table.campaignId),
+  ]
+);
+
+export type DiscoveredOutlet = typeof discoveredOutlets.$inferSelect;
+export type NewDiscoveredOutlet = typeof discoveredOutlets.$inferInsert;
+
+// Discovered journalists table
+export const discoveredJournalists = pgTable(
+  "discovered_journalists",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    campaignId: text("campaign_id").notNull().references(() => campaigns.id, { onDelete: "cascade" }),
+    firstName: text("first_name"),
+    lastName: text("last_name"),
+    email: text("email"),
+    outletName: text("outlet_name"),
+    title: text("title"),
+    beat: text("beat"),
+    linkedinUrl: text("linkedin_url"),
+    twitterHandle: text("twitter_handle"),
+    location: text("location"),
+    domainRating: decimal("domain_rating", { precision: 5, scale: 1 }),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_discovered_journalists_campaign").on(table.campaignId),
+  ]
+);
+
+export type DiscoveredJournalist = typeof discoveredJournalists.$inferSelect;
+export type NewDiscoveredJournalist = typeof discoveredJournalists.$inferInsert;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import healthRoutes from "./routes/health.js";
 import campaignsRoutes from "./routes/campaigns.js";
 import statsRoutes from "./routes/stats.js";
 import internalRoutes from "./routes/internal.js";
+import discoveryRoutes from "./routes/discovery.js";
 import { startScheduler } from "./lib/scheduler.js";
 const app = express();
 const PORT = process.env.PORT || 3003;
@@ -36,6 +37,7 @@ app.use(healthRoutes);
 app.use(campaignsRoutes);
 app.use(statsRoutes);
 app.use(internalRoutes);
+app.use(discoveryRoutes);
 
 // OpenAPI spec endpoint
 app.get("/openapi.json", (_req, res) => {

--- a/src/routes/discovery.ts
+++ b/src/routes/discovery.ts
@@ -1,0 +1,245 @@
+import { Router } from "express";
+import { eq, and, count } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { campaigns, discoveredOutlets, discoveredJournalists } from "../db/schema.js";
+import { requireApiKey, serviceAuth, type AuthenticatedRequest } from "../middleware/auth.js";
+import { validateBody, validateQuery } from "../middleware/validate.js";
+import {
+  CreateDiscoveredOutletsBody,
+  CreateDiscoveredJournalistsBody,
+  PaginationQuery,
+} from "../schemas.js";
+
+const router = Router();
+
+// === Discovered Outlets ===
+
+/**
+ * POST /campaigns/:id/discovered-outlets
+ * Called by workflow-service to store discovery results
+ */
+router.post(
+  "/campaigns/:id/discovered-outlets",
+  requireApiKey,
+  serviceAuth,
+  validateBody(CreateDiscoveredOutletsBody),
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const { id } = req.params;
+      const { outlets } = req.body;
+
+      const campaign = await db.query.campaigns.findFirst({
+        where: and(eq(campaigns.id, id), eq(campaigns.orgId, req.orgId!)),
+      });
+      if (!campaign) {
+        return res.status(404).json({ error: "Campaign not found" });
+      }
+
+      const inserted = await db
+        .insert(discoveredOutlets)
+        .values(
+          outlets.map((o: typeof outlets[number]) => ({
+            campaignId: id,
+            name: o.name,
+            type: o.type ?? null,
+            url: o.url ?? null,
+            domainRating: o.domainRating != null ? String(o.domainRating) : null,
+            monthlyTraffic: o.monthlyTraffic ?? null,
+            topics: o.topics ?? [],
+            country: o.country ?? null,
+            language: o.language ?? null,
+            contactEmail: o.contactEmail ?? null,
+            notes: o.notes ?? null,
+          }))
+        )
+        .returning();
+
+      res.status(201).json({ outlets: inserted.map(formatOutlet) });
+    } catch (error) {
+      console.error("[Discovery] Create outlets error:", error);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+);
+
+/**
+ * GET /campaigns/:id/discovered-outlets
+ * Returns paginated list of discovered outlets for a campaign
+ */
+router.get(
+  "/campaigns/:id/discovered-outlets",
+  requireApiKey,
+  serviceAuth,
+  validateQuery(PaginationQuery),
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const { id } = req.params;
+      const { limit, offset } = PaginationQuery.parse(req.query);
+
+      const campaign = await db.query.campaigns.findFirst({
+        where: and(eq(campaigns.id, id), eq(campaigns.orgId, req.orgId!)),
+      });
+      if (!campaign) {
+        return res.status(404).json({ error: "Campaign not found" });
+      }
+
+      const [rows, [{ total }]] = await Promise.all([
+        db
+          .select()
+          .from(discoveredOutlets)
+          .where(eq(discoveredOutlets.campaignId, id))
+          .limit(limit)
+          .offset(offset)
+          .orderBy(discoveredOutlets.createdAt),
+        db
+          .select({ total: count() })
+          .from(discoveredOutlets)
+          .where(eq(discoveredOutlets.campaignId, id)),
+      ]);
+
+      res.json({
+        outlets: rows.map(formatOutlet),
+        pagination: { total, limit, offset },
+      });
+    } catch (error) {
+      console.error("[Discovery] List outlets error:", error);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+);
+
+// === Discovered Journalists ===
+
+/**
+ * POST /campaigns/:id/discovered-journalists
+ * Called by workflow-service to store discovery results
+ */
+router.post(
+  "/campaigns/:id/discovered-journalists",
+  requireApiKey,
+  serviceAuth,
+  validateBody(CreateDiscoveredJournalistsBody),
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const { id } = req.params;
+      const { journalists } = req.body;
+
+      const campaign = await db.query.campaigns.findFirst({
+        where: and(eq(campaigns.id, id), eq(campaigns.orgId, req.orgId!)),
+      });
+      if (!campaign) {
+        return res.status(404).json({ error: "Campaign not found" });
+      }
+
+      const inserted = await db
+        .insert(discoveredJournalists)
+        .values(
+          journalists.map((j: typeof journalists[number]) => ({
+            campaignId: id,
+            firstName: j.firstName ?? null,
+            lastName: j.lastName ?? null,
+            email: j.email ?? null,
+            outletName: j.outletName ?? null,
+            title: j.title ?? null,
+            beat: j.beat ?? null,
+            linkedinUrl: j.linkedinUrl ?? null,
+            twitterHandle: j.twitterHandle ?? null,
+            location: j.location ?? null,
+            domainRating: j.domainRating != null ? String(j.domainRating) : null,
+            notes: j.notes ?? null,
+          }))
+        )
+        .returning();
+
+      res.status(201).json({ journalists: inserted.map(formatJournalist) });
+    } catch (error) {
+      console.error("[Discovery] Create journalists error:", error);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+);
+
+/**
+ * GET /campaigns/:id/discovered-journalists
+ * Returns paginated list of discovered journalists for a campaign
+ */
+router.get(
+  "/campaigns/:id/discovered-journalists",
+  requireApiKey,
+  serviceAuth,
+  validateQuery(PaginationQuery),
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const { id } = req.params;
+      const { limit, offset } = PaginationQuery.parse(req.query);
+
+      const campaign = await db.query.campaigns.findFirst({
+        where: and(eq(campaigns.id, id), eq(campaigns.orgId, req.orgId!)),
+      });
+      if (!campaign) {
+        return res.status(404).json({ error: "Campaign not found" });
+      }
+
+      const [rows, [{ total }]] = await Promise.all([
+        db
+          .select()
+          .from(discoveredJournalists)
+          .where(eq(discoveredJournalists.campaignId, id))
+          .limit(limit)
+          .offset(offset)
+          .orderBy(discoveredJournalists.createdAt),
+        db
+          .select({ total: count() })
+          .from(discoveredJournalists)
+          .where(eq(discoveredJournalists.campaignId, id)),
+      ]);
+
+      res.json({
+        journalists: rows.map(formatJournalist),
+        pagination: { total, limit, offset },
+      });
+    } catch (error) {
+      console.error("[Discovery] List journalists error:", error);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+);
+
+// === Formatters ===
+
+function formatOutlet(row: typeof discoveredOutlets.$inferSelect) {
+  return {
+    id: row.id,
+    name: row.name,
+    type: row.type,
+    url: row.url,
+    domainRating: row.domainRating ? parseFloat(row.domainRating) : null,
+    monthlyTraffic: row.monthlyTraffic,
+    topics: row.topics,
+    country: row.country,
+    language: row.language,
+    contactEmail: row.contactEmail,
+    notes: row.notes,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+function formatJournalist(row: typeof discoveredJournalists.$inferSelect) {
+  return {
+    id: row.id,
+    firstName: row.firstName,
+    lastName: row.lastName,
+    email: row.email,
+    outletName: row.outletName,
+    title: row.title,
+    beat: row.beat,
+    linkedinUrl: row.linkedinUrl,
+    twitterHandle: row.twitterHandle,
+    location: row.location,
+    domainRating: row.domainRating ? parseFloat(row.domainRating) : null,
+    notes: row.notes,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -147,3 +147,76 @@ export const EndRunBody = z.object({
 export const EndRunResponse = z.object({
   status: z.string(),
 }).openapi("EndRunResponse");
+
+// --- Discovery ---
+
+export const DiscoveredOutletSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string().nullable(),
+  url: z.string().nullable(),
+  domainRating: z.number().nullable(),
+  monthlyTraffic: z.number().nullable(),
+  topics: z.array(z.string()),
+  country: z.string().nullable(),
+  language: z.string().nullable(),
+  contactEmail: z.string().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+}).openapi("DiscoveredOutlet");
+
+export const DiscoveredJournalistSchema = z.object({
+  id: z.string(),
+  firstName: z.string().nullable(),
+  lastName: z.string().nullable(),
+  email: z.string().nullable(),
+  outletName: z.string().nullable(),
+  title: z.string().nullable(),
+  beat: z.string().nullable(),
+  linkedinUrl: z.string().nullable(),
+  twitterHandle: z.string().nullable(),
+  location: z.string().nullable(),
+  domainRating: z.number().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+}).openapi("DiscoveredJournalist");
+
+export const CreateDiscoveredOutletBody = z.object({
+  name: z.string().min(1, "name is required"),
+  type: z.string().nullable().optional(),
+  url: z.string().nullable().optional(),
+  domainRating: z.number().nullable().optional(),
+  monthlyTraffic: z.number().int().nullable().optional(),
+  topics: z.array(z.string()).optional().default([]),
+  country: z.string().nullable().optional(),
+  language: z.string().nullable().optional(),
+  contactEmail: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+}).openapi("CreateDiscoveredOutletBody");
+
+export const CreateDiscoveredOutletsBody = z.object({
+  outlets: z.array(CreateDiscoveredOutletBody).min(1, "At least one outlet is required"),
+}).openapi("CreateDiscoveredOutletsBody");
+
+export const CreateDiscoveredJournalistBody = z.object({
+  firstName: z.string().nullable().optional(),
+  lastName: z.string().nullable().optional(),
+  email: z.string().nullable().optional(),
+  outletName: z.string().nullable().optional(),
+  title: z.string().nullable().optional(),
+  beat: z.string().nullable().optional(),
+  linkedinUrl: z.string().nullable().optional(),
+  twitterHandle: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  domainRating: z.number().nullable().optional(),
+  notes: z.string().nullable().optional(),
+}).openapi("CreateDiscoveredJournalistBody");
+
+export const CreateDiscoveredJournalistsBody = z.object({
+  journalists: z.array(CreateDiscoveredJournalistBody).min(1, "At least one journalist is required"),
+}).openapi("CreateDiscoveredJournalistsBody");
+
+export const PaginationQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+}).openapi("PaginationQuery");

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,10 +1,12 @@
 import { db, sql } from "../../src/db/index.js";
-import { campaigns } from "../../src/db/schema.js";
+import { campaigns, discoveredOutlets, discoveredJournalists } from "../../src/db/schema.js";
 
 /**
  * Clean all test data from the database
  */
 export async function cleanTestData() {
+  await db.delete(discoveredOutlets);
+  await db.delete(discoveredJournalists);
   await db.delete(campaigns);
 }
 

--- a/tests/integration/discovery-routes.test.ts
+++ b/tests/integration/discovery-routes.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import app from "../../src/index.js";
+import { cleanTestData, insertTestCampaign, closeDb } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+const ORG_ID = "org_discovery_test";
+
+describe("Discovery Routes", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  // === Discovered Outlets ===
+
+  describe("POST /campaigns/:id/discovered-outlets", () => {
+    it("should store outlets for a campaign", async () => {
+      const campaign = await insertTestCampaign(ORG_ID, {
+        workflowName: "outlets-database-discovery-cedar",
+      });
+
+      const res = await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({
+          outlets: [
+            {
+              name: "TechCrunch",
+              type: "blog",
+              url: "https://techcrunch.com",
+              domainRating: 92,
+              monthlyTraffic: 5000000,
+              topics: ["tech", "startups"],
+              country: "US",
+              language: "en",
+              contactEmail: "tips@techcrunch.com",
+              notes: "Top-tier tech publication",
+            },
+            {
+              name: "Wired",
+              type: "magazine",
+              url: "https://wired.com",
+              domainRating: 91,
+              topics: ["tech", "science"],
+            },
+          ],
+        })
+        .expect(201);
+
+      expect(res.body.outlets).toHaveLength(2);
+      expect(res.body.outlets[0].name).toBe("TechCrunch");
+      expect(res.body.outlets[0].domainRating).toBe(92);
+      expect(res.body.outlets[0].topics).toEqual(["tech", "startups"]);
+      expect(res.body.outlets[0].id).toBeDefined();
+      expect(res.body.outlets[0].createdAt).toBeDefined();
+      expect(res.body.outlets[1].name).toBe("Wired");
+    });
+
+    it("should return 404 for non-existent campaign", async () => {
+      const res = await request(app)
+        .post(`/campaigns/${crypto.randomUUID()}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({ outlets: [{ name: "Test" }] })
+        .expect(404);
+
+      expect(res.body.error).toBe("Campaign not found");
+    });
+
+    it("should reject empty outlets array", async () => {
+      const campaign = await insertTestCampaign(ORG_ID);
+
+      await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({ outlets: [] })
+        .expect(400);
+    });
+
+    it("should reject when outlets is missing", async () => {
+      const campaign = await insertTestCampaign(ORG_ID);
+
+      await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({})
+        .expect(400);
+    });
+
+    it("should not allow cross-org access", async () => {
+      const campaign = await insertTestCampaign(ORG_ID);
+
+      await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "other_org")
+        .send({ outlets: [{ name: "Test" }] })
+        .expect(404);
+    });
+  });
+
+  describe("GET /campaigns/:id/discovered-outlets", () => {
+    it("should return paginated outlets", async () => {
+      const campaign = await insertTestCampaign(ORG_ID, {
+        workflowName: "outlets-database-discovery-cedar",
+      });
+
+      // Insert 3 outlets
+      await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({
+          outlets: [
+            { name: "Outlet A", topics: ["tech"] },
+            { name: "Outlet B", topics: ["finance"] },
+            { name: "Outlet C", topics: ["health"] },
+          ],
+        })
+        .expect(201);
+
+      // Get first page
+      const res = await request(app)
+        .get(`/campaigns/${campaign.id}/discovered-outlets?limit=2&offset=0`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .expect(200);
+
+      expect(res.body.outlets).toHaveLength(2);
+      expect(res.body.pagination).toEqual({ total: 3, limit: 2, offset: 0 });
+
+      // Get second page
+      const res2 = await request(app)
+        .get(`/campaigns/${campaign.id}/discovered-outlets?limit=2&offset=2`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .expect(200);
+
+      expect(res2.body.outlets).toHaveLength(1);
+      expect(res2.body.pagination).toEqual({ total: 3, limit: 2, offset: 2 });
+    });
+
+    it("should return empty array for campaign with no outlets", async () => {
+      const campaign = await insertTestCampaign(ORG_ID);
+
+      const res = await request(app)
+        .get(`/campaigns/${campaign.id}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .expect(200);
+
+      expect(res.body.outlets).toEqual([]);
+      expect(res.body.pagination.total).toBe(0);
+    });
+
+    it("should return 404 for non-existent campaign", async () => {
+      await request(app)
+        .get(`/campaigns/${crypto.randomUUID()}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .expect(404);
+    });
+
+    it("should use default pagination", async () => {
+      const campaign = await insertTestCampaign(ORG_ID);
+
+      const res = await request(app)
+        .get(`/campaigns/${campaign.id}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .expect(200);
+
+      expect(res.body.pagination.limit).toBe(50);
+      expect(res.body.pagination.offset).toBe(0);
+    });
+  });
+
+  // === Discovered Journalists ===
+
+  describe("POST /campaigns/:id/discovered-journalists", () => {
+    it("should store journalists for a campaign", async () => {
+      const campaign = await insertTestCampaign(ORG_ID, {
+        workflowName: "journalists-database-discovery-cedar",
+      });
+
+      const res = await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-journalists`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({
+          journalists: [
+            {
+              firstName: "Jane",
+              lastName: "Doe",
+              email: "jane@techcrunch.com",
+              outletName: "TechCrunch",
+              title: "Senior Reporter",
+              beat: "AI",
+              linkedinUrl: "https://linkedin.com/in/janedoe",
+              twitterHandle: "@janedoe",
+              location: "San Francisco, US",
+              domainRating: 92,
+              notes: "Covers AI startups",
+            },
+            {
+              firstName: "John",
+              lastName: "Smith",
+              email: "john@wired.com",
+              outletName: "Wired",
+            },
+          ],
+        })
+        .expect(201);
+
+      expect(res.body.journalists).toHaveLength(2);
+      expect(res.body.journalists[0].firstName).toBe("Jane");
+      expect(res.body.journalists[0].domainRating).toBe(92);
+      expect(res.body.journalists[0].id).toBeDefined();
+      expect(res.body.journalists[0].createdAt).toBeDefined();
+      expect(res.body.journalists[1].firstName).toBe("John");
+    });
+
+    it("should return 404 for non-existent campaign", async () => {
+      await request(app)
+        .post(`/campaigns/${crypto.randomUUID()}/discovered-journalists`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({ journalists: [{ firstName: "Test" }] })
+        .expect(404);
+    });
+
+    it("should reject empty journalists array", async () => {
+      const campaign = await insertTestCampaign(ORG_ID);
+
+      await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-journalists`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({ journalists: [] })
+        .expect(400);
+    });
+  });
+
+  describe("GET /campaigns/:id/discovered-journalists", () => {
+    it("should return paginated journalists", async () => {
+      const campaign = await insertTestCampaign(ORG_ID, {
+        workflowName: "journalists-database-discovery-cedar",
+      });
+
+      // Insert journalists
+      await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-journalists`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({
+          journalists: [
+            { firstName: "Alice", lastName: "A" },
+            { firstName: "Bob", lastName: "B" },
+            { firstName: "Charlie", lastName: "C" },
+          ],
+        })
+        .expect(201);
+
+      const res = await request(app)
+        .get(`/campaigns/${campaign.id}/discovered-journalists?limit=2&offset=0`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .expect(200);
+
+      expect(res.body.journalists).toHaveLength(2);
+      expect(res.body.pagination).toEqual({ total: 3, limit: 2, offset: 0 });
+    });
+
+    it("should return empty array for campaign with no journalists", async () => {
+      const campaign = await insertTestCampaign(ORG_ID);
+
+      const res = await request(app)
+        .get(`/campaigns/${campaign.id}/discovered-journalists`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .expect(200);
+
+      expect(res.body.journalists).toEqual([]);
+      expect(res.body.pagination.total).toBe(0);
+    });
+
+    it("should cascade delete when campaign is deleted", async () => {
+      const campaign = await insertTestCampaign(ORG_ID);
+
+      // Add outlets and journalists
+      await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({ outlets: [{ name: "Test Outlet", topics: [] }] })
+        .expect(201);
+
+      await request(app)
+        .post(`/campaigns/${campaign.id}/discovered-journalists`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .send({ journalists: [{ firstName: "Test" }] })
+        .expect(201);
+
+      // Delete campaign
+      await request(app)
+        .delete(`/campaigns/${campaign.id}`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .expect(200);
+
+      // Verify data is gone (campaign not found)
+      await request(app)
+        .get(`/campaigns/${campaign.id}/discovered-outlets`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", ORG_ID)
+        .expect(404);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added `discovered_outlets` and `discovered_journalists` DB tables with FK cascade delete to campaigns
- `POST /campaigns/:id/discovered-outlets` and `POST /campaigns/:id/discovered-journalists` — write endpoints for workflow-service to store discovery results (batch insert)
- `GET /campaigns/:id/discovered-outlets` and `GET /campaigns/:id/discovered-journalists` — paginated read endpoints (limit/offset) for the dashboard, matching the schemas from api-service PR #161
- Drizzle migration, OpenAPI spec, and 15 integration tests

## Test plan
- [x] All 15 new integration tests pass (POST create, GET pagination, 404s, cross-org isolation, cascade delete)
- [x] All existing tests pass (2 pre-existing failures in campaign-crud unrelated to this change)
- [x] Build compiles cleanly
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)