### PR TITLE
fix: add targetAudience to /start-run response

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -407,6 +407,10 @@
             "type": "string",
             "nullable": true
           },
+          "targetAudience": {
+            "type": "string",
+            "nullable": true
+          },
           "targetOutcome": {
             "type": "string",
             "nullable": true
@@ -432,6 +436,7 @@
           "brandDomain",
           "workflowName",
           "userId",
+          "targetAudience",
           "targetOutcome",
           "valueForTarget",
           "searchParams"

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -158,6 +158,7 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
       brandDomain,
       workflowName: campaign.workflowName,
       userId: campaign.createdByUserId ?? null,
+      targetAudience: campaign.targetAudience ?? null,
       targetOutcome: campaign.targetOutcome,
       valueForTarget: campaign.valueForTarget,
       searchParams,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -132,6 +132,7 @@ export const StartRunResponse = z.object({
   brandDomain: z.string(),
   workflowName: z.string(),
   userId: z.string().nullable(),
+  targetAudience: z.string().nullable(),
   targetOutcome: z.string().nullable(),
   valueForTarget: z.string().nullable(),
   searchParams: z.record(z.string(), z.unknown()).nullable(),

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -300,6 +300,7 @@ describe("Pipeline routes", () => {
       expect(res.body.brandUrl).toBe("https://example.com");
       expect(res.body.brandDomain).toBe("example.com");
       expect(res.body.workflowName).toBe("sales-email-cold-outreach");
+      expect(res.body.targetAudience).toBeNull();
       expect(res.body.targetOutcome).toBe("Book demos");
       expect(res.body.valueForTarget).toBe("Analytics platform");
       expect(res.body).not.toHaveProperty("appId");
@@ -344,6 +345,8 @@ describe("Pipeline routes", () => {
         targetOutcome: "Book demo meetings",
         valueForTarget: "Reduce outbound prospecting time by 80%",
       });
+      // targetAudience must also be a top-level field (used by discovery workflows)
+      expect(res.body.targetAudience).toBe("VPs of Sales at B2B SaaS companies");
     });
 
     it("should have null searchParams when no user context is set", async () => {


### PR DESCRIPTION
## Summary
- Adds `targetAudience` as a top-level field in the `/start-run` response payload and `StartRunResponse` OpenAPI schema
- The field was already stored in the campaign model and included inside `searchParams`, but discovery workflows need it as a direct top-level field
- Regenerated `openapi.json`

## Test plan
- [x] Added assertion in existing searchParams test to verify `targetAudience` is returned as top-level field
- [x] Added assertion in 200 response test to verify `targetAudience` is null when not set
- [x] All passing tests still pass (pre-existing import resolution failures in integration tests are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)