### PR TITLE
feat: propagate x-feature-slug header downstream

### DIFF
--- a/packages/runs-client/src/index.ts
+++ b/packages/runs-client/src/index.ts
@@ -32,6 +32,7 @@ export interface IdentityHeaders {
   campaignId?: string;
   brandId?: string;
   workflowName?: string;
+  featureSlug?: string;
 }
 
 export interface CreateRunParams {
@@ -43,6 +44,7 @@ export interface CreateRunParams {
   campaignId?: string;
   parentRunId?: string;
   workflowName?: string;
+  featureSlug?: string;
 }
 
 export interface ListRunsParams {
@@ -94,6 +96,7 @@ function buildIdentityHeaders(identity?: IdentityHeaders): Record<string, string
   if (identity?.campaignId) h["x-campaign-id"] = identity.campaignId;
   if (identity?.brandId) h["x-brand-id"] = identity.brandId;
   if (identity?.workflowName) h["x-workflow-name"] = identity.workflowName;
+  if (identity?.featureSlug) h["x-feature-slug"] = identity.featureSlug;
   return h;
 }
 
@@ -131,11 +134,11 @@ async function runsRequest<T>(
  * parentRunId is sent as x-run-id header.
  */
 export async function createRun(params: CreateRunParams): Promise<Run> {
-  const { orgId, userId, parentRunId, brandId, campaignId, workflowName, ...body } = params;
+  const { orgId, userId, parentRunId, brandId, campaignId, workflowName, featureSlug, ...body } = params;
   return runsRequest<Run>("/v1/runs", {
     method: "POST",
     body,
-    identity: { orgId, userId, runId: parentRunId, brandId, campaignId, workflowName },
+    identity: { orgId, userId, runId: parentRunId, brandId, campaignId, workflowName, featureSlug },
   });
 }
 

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -7,7 +7,7 @@
  */
 export async function executeCampaignWorkflow(
   workflowName: string,
-  inputs: { campaignId: string; orgId: string; brandId: string; userId?: string; runId?: string },
+  inputs: { campaignId: string; orgId: string; brandId: string; userId?: string; runId?: string; featureSlug?: string },
 ): Promise<void> {
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
@@ -31,6 +31,7 @@ export async function executeCampaignWorkflow(
   if (inputs.userId) headers["x-user-id"] = inputs.userId;
   if (inputs.runId) headers["x-run-id"] = inputs.runId;
   if (inputs.campaignId) headers["x-campaign-id"] = inputs.campaignId;
+  if (inputs.featureSlug) headers["x-feature-slug"] = inputs.featureSlug;
   headers["x-workflow-name"] = workflowName;
 
   const res = await fetch(executeUrl, {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -7,6 +7,7 @@ export interface AuthenticatedRequest extends Request {
   campaignId?: string;
   brandId?: string;
   workflowName?: string;
+  featureSlug?: string;
 }
 
 /**
@@ -64,10 +65,12 @@ export function trackingHeaders(
   const campaignId = req.headers["x-campaign-id"] as string | undefined;
   const brandId = req.headers["x-brand-id"] as string | undefined;
   const workflowName = req.headers["x-workflow-name"] as string | undefined;
+  const featureSlug = req.headers["x-feature-slug"] as string | undefined;
 
   if (campaignId) req.campaignId = campaignId;
   if (brandId) req.brandId = brandId;
   if (workflowName) req.workflowName = workflowName;
+  if (featureSlug) req.featureSlug = featureSlug;
 
   next();
 }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -169,6 +169,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       brandId: campaign.brandId!,
       userId: req.userId,
       runId: req.runId,
+      featureSlug: campaign.featureSlug || undefined,
     }).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
@@ -225,6 +226,7 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         brandId: updated.brandId,
         userId: req.userId,
         runId: req.runId,
+        featureSlug: updated.featureSlug || undefined,
       }).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -118,9 +118,12 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
       return res.status(400).json({ error: "Campaign has no brandId" });
     }
 
+    // Resolve featureSlug from header (workflow context) or campaign record
+    const featureSlug = req.featureSlug || campaign.featureSlug || undefined;
+
     // Create run in runs-service (x-run-id from caller becomes parentRunId)
     const parentRunId = req.headers["x-run-id"] as string | undefined;
-    console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId} (parentRunId=${parentRunId || "none"})...`);
+    console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId} (parentRunId=${parentRunId || "none"}, featureSlug=${featureSlug || "none"})...`);
     const run = await createRun({
       orgId,
       serviceName: "campaign-service",
@@ -130,6 +133,7 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
       userId: campaign.createdByUserId || undefined,
       parentRunId: parentRunId || undefined,
       workflowName: campaign.workflowName,
+      featureSlug,
     });
     console.log(`[Start Run] Run created: runId=${run.id}`);
 
@@ -200,6 +204,7 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
       campaignId: req.campaignId,
       brandId: req.brandId,
       workflowName: req.workflowName,
+      featureSlug: req.featureSlug,
     };
 
     // Find and update running runs for this campaign
@@ -265,6 +270,7 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
         brandId: resolvedBrandId,
         userId: identity.userId,
         runId: identity.runId,
+        featureSlug: identity.featureSlug || freshCampaign.featureSlug || undefined,
       }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -434,6 +434,43 @@ describe("Pipeline routes", () => {
       );
     });
 
+    it("should pass featureSlug to createRun", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandUrl: "https://example.com",
+        brandId,
+        featureSlug: "sales-cold-email-v1",
+      });
+
+      await request(app)
+        .post("/start-run")
+        .set("x-api-key", API_KEY)
+        .send({ campaignId: campaign.id, orgId })
+        .expect(200);
+
+      expect(mockCreateRun).toHaveBeenCalledWith(
+        expect.objectContaining({ featureSlug: "sales-cold-email-v1" }),
+      );
+    });
+
+    it("should prefer x-feature-slug header over campaign.featureSlug", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandUrl: "https://example.com",
+        brandId,
+        featureSlug: "old-slug",
+      });
+
+      await request(app)
+        .post("/start-run")
+        .set("x-api-key", API_KEY)
+        .set("x-feature-slug", "header-slug")
+        .send({ campaignId: campaign.id, orgId })
+        .expect(200);
+
+      expect(mockCreateRun).toHaveBeenCalledWith(
+        expect.objectContaining({ featureSlug: "header-slug" }),
+      );
+    });
+
     it("should return featureSlug and featureInputs when set", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -25,6 +25,18 @@ describe("trackingHeaders middleware", () => {
     expect(nextCalled).toBe(true);
   });
 
+  it("should read x-feature-slug from headers", () => {
+    const req = createMockReq({
+      "x-feature-slug": "sales-cold-email-v1",
+      "x-campaign-id": "camp-123",
+    });
+
+    trackingHeaders(req, {} as Response, (() => {}) as NextFunction);
+
+    expect(req.featureSlug).toBe("sales-cold-email-v1");
+    expect(req.campaignId).toBe("camp-123");
+  });
+
   it("should not set properties when headers are absent", () => {
     const req = createMockReq({});
 
@@ -34,6 +46,7 @@ describe("trackingHeaders middleware", () => {
     expect(req.campaignId).toBeUndefined();
     expect(req.brandId).toBeUndefined();
     expect(req.workflowName).toBeUndefined();
+    expect(req.featureSlug).toBeUndefined();
     expect(nextCalled).toBe(true);
   });
 

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -102,6 +102,43 @@ describe("Workflow module", () => {
       expect(opts.headers["x-workflow-name"]).toBe("pr-outreach");
     });
 
+    it("should set x-feature-slug header when featureSlug is provided", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-123", status: "queued" }),
+      });
+
+      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
+      await executeCampaignWorkflow("sales-email-cold-outreach", {
+        campaignId: "campaign-1",
+        orgId: "org_test",
+        brandId: "brand-abc",
+        featureSlug: "sales-cold-email-v1",
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(opts.headers["x-feature-slug"]).toBe("sales-cold-email-v1");
+    });
+
+    it("should not set x-feature-slug header when featureSlug is not provided", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "run-123", status: "queued" }),
+      });
+
+      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
+      await executeCampaignWorkflow("sales-email-cold-outreach", {
+        campaignId: "campaign-1",
+        orgId: "org_test",
+        brandId: "brand-abc",
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(opts.headers).not.toHaveProperty("x-feature-slug");
+    });
+
     it("should not throw when execution fails", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,


### PR DESCRIPTION
## Summary

- Accepts `x-feature-slug` header in `trackingHeaders` middleware (same pattern as `x-campaign-id`, `x-brand-id`)
- Propagates it to workflow-service via `executeCampaignWorkflow` on campaign creation, activation, start-run, and end-run re-trigger
- Propagates it to runs-service via `createRun` and `IdentityHeaders` in runs-client
- Resolves featureSlug from header (priority) or campaign record fallback

## Test plan

- [x] `trackingHeaders` reads `x-feature-slug` and sets `req.featureSlug`
- [x] `trackingHeaders` does not set `featureSlug` when header absent
- [x] `executeCampaignWorkflow` sets `x-feature-slug` header when provided
- [x] `executeCampaignWorkflow` omits `x-feature-slug` when not provided
- [x] `start-run` passes `featureSlug` to `createRun`
- [x] `start-run` prefers `x-feature-slug` header over `campaign.featureSlug`
- [x] All 155 tests pass (2 pre-existing failures from PR #90 unique constraint handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)