### PR TITLE
feat: backfill feature_slug for existing campaigns

### DIFF
--- a/drizzle/0024_backfill_feature_slug.sql
+++ b/drizzle/0024_backfill_feature_slug.sql
@@ -1,0 +1,5 @@
+UPDATE "campaigns"
+SET "feature_slug" = 'sales-cold-email-outreach',
+    "updated_at" = NOW()
+WHERE "workflow_name" LIKE 'sales-email-cold-outreach-%'
+  AND "feature_slug" IS NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1774333106520,
       "tag": "0023_slim_iron_patriot",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1774600000000,
+      "tag": "0024_backfill_feature_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/backfill-feature-slug.test.ts
+++ b/tests/unit/backfill-feature-slug.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("0024_backfill_feature_slug migration", () => {
+  const sql = readFileSync(
+    resolve(__dirname, "../../drizzle/0024_backfill_feature_slug.sql"),
+    "utf-8"
+  );
+
+  it("updates feature_slug for sales-email-cold-outreach workflows", () => {
+    expect(sql).toContain("UPDATE \"campaigns\"");
+    expect(sql).toContain("\"feature_slug\" = 'sales-cold-email-outreach'");
+    expect(sql).toContain("\"workflow_name\" LIKE 'sales-email-cold-outreach-%'");
+  });
+
+  it("only backfills rows where feature_slug is null", () => {
+    expect(sql).toContain("\"feature_slug\" IS NULL");
+  });
+
+  it("does not drop or alter any columns", () => {
+    expect(sql.toUpperCase()).not.toContain("DROP");
+    expect(sql.toUpperCase()).not.toContain("ALTER");
+    expect(sql.toUpperCase()).not.toContain("DELETE");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds migration `0024_backfill_feature_slug.sql` that sets `feature_slug = 'sales-cold-email-outreach'` on all campaigns where `workflow_name LIKE 'sales-email-cold-outreach-%'` and `feature_slug IS NULL`
- `featureSlug` persistence on creation was already working (schema + route already support it)
- Adds unit test validating the migration SQL content

## Context
The features-service slug is `sales-cold-email-outreach` (auto-generated from "Sales Cold Email Outreach"), which differs from the historical workflow name prefix `sales-email-cold-outreach-*`. This backfill bridges existing campaigns so the dashboard can filter by `featureSlug` instead of `workflowName.startsWith()`.

## Test plan
- [x] Unit test validates migration SQL correctness
- [ ] After deploy, verify with: `SELECT id, workflow_name, feature_slug FROM campaigns WHERE workflow_name LIKE 'sales-email-cold-outreach-%'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)