### PR TITLE
feat: enforce all 7 tracking headers on workflow execution

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -20,6 +20,7 @@ export async function resumeDueCampaigns(): Promise<number> {
       createdByUserId: campaigns.createdByUserId,
       workflowName: campaigns.workflowName,
       brandId: campaigns.brandId,
+      featureSlug: campaigns.featureSlug,
     })
     .from(campaigns)
     .where(
@@ -36,8 +37,12 @@ export async function resumeDueCampaigns(): Promise<number> {
 
   for (const campaign of dueCampaigns) {
     try {
-      if (!campaign.brandId) {
-        console.warn(`[Scheduler] Campaign ${campaign.id} has no brandId — skipping resume`);
+      const missingFields: string[] = [];
+      if (!campaign.brandId) missingFields.push("brandId");
+      if (!campaign.createdByUserId) missingFields.push("createdByUserId");
+      if (!campaign.featureSlug) missingFields.push("featureSlug");
+      if (missingFields.length > 0) {
+        console.warn(`[Scheduler] Campaign ${campaign.id} missing required fields for workflow execution: ${missingFields.join(", ")} — skipping resume`);
         continue;
       }
 
@@ -47,21 +52,28 @@ export async function resumeDueCampaigns(): Promise<number> {
         .where(eq(campaigns.id, campaign.id));
 
       console.log(`[Campaign Service] Launching workflow run from SCHEDULER RESUME — workflow=${campaign.workflowName}, campaignId=${campaign.id}`);
+      // All three fields are validated non-null above
+      const brandId = campaign.brandId!;
+      const userId = campaign.createdByUserId!;
+      const featureSlug = campaign.featureSlug!;
+
       const run = await createRun({
         orgId: campaign.orgId,
         serviceName: "campaign-service",
         taskName: "scheduler-resume",
-        userId: campaign.createdByUserId ?? undefined,
+        userId,
         campaignId: campaign.id,
-        brandId: campaign.brandId ?? undefined,
+        brandId,
         workflowName: campaign.workflowName,
+        featureSlug,
       });
       executeCampaignWorkflow(campaign.workflowName, {
         campaignId: campaign.id,
         orgId: campaign.orgId,
-        brandId: campaign.brandId,
-        userId: campaign.createdByUserId ?? undefined,
+        brandId,
+        userId,
         runId: run.id,
+        featureSlug,
       }).catch((err) => {
         console.error(`[Scheduler] Failed to re-trigger campaign ${campaign.id}:`, err);
       });

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -1,13 +1,40 @@
+export interface WorkflowExecutionInputs {
+  campaignId: string;
+  orgId: string;
+  brandId: string;
+  userId: string;
+  runId: string;
+  featureSlug: string;
+}
+
+const REQUIRED_FIELDS: (keyof WorkflowExecutionInputs)[] = [
+  "campaignId", "orgId", "brandId", "userId", "runId", "featureSlug",
+];
+
+/**
+ * Validate that all required fields are present for workflow execution.
+ * Returns the list of missing field names, or an empty array if all present.
+ */
+export function validateWorkflowInputs(
+  inputs: Partial<WorkflowExecutionInputs>,
+): string[] {
+  return REQUIRED_FIELDS.filter((k) => !inputs[k]);
+}
+
 /**
  * Execute a campaign's workflow by name.
  *
  * Campaign-service no longer defines or deploys DAGs — workflow-service
  * owns workflow definitions. Campaign-service receives a workflowName
  * at campaign creation and uses it to trigger execution.
+ *
+ * All inputs are required — workflow-service rejects calls missing any
+ * of the 7 tracking headers (x-org-id, x-user-id, x-run-id, x-brand-id,
+ * x-campaign-id, x-workflow-name, x-feature-slug).
  */
 export async function executeCampaignWorkflow(
   workflowName: string,
-  inputs: { campaignId: string; orgId: string; brandId: string; userId?: string; runId?: string; featureSlug?: string },
+  inputs: WorkflowExecutionInputs,
 ): Promise<void> {
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
@@ -19,6 +46,12 @@ export async function executeCampaignWorkflow(
     return;
   }
 
+  // Defense-in-depth: validate all required fields even though callers should check first
+  const missing = validateWorkflowInputs(inputs);
+  if (missing.length > 0) {
+    throw new Error(`[Workflow] Cannot execute workflow — missing required fields: ${missing.join(", ")}`);
+  }
+
   const executeUrl = `${url}/workflows/by-name/${workflowName}/execute`;
   console.log(`[Workflow] POST ${executeUrl}`);
 
@@ -26,13 +59,13 @@ export async function executeCampaignWorkflow(
     "Content-Type": "application/json",
     "x-api-key": apiKey,
     "x-org-id": inputs.orgId,
+    "x-user-id": inputs.userId,
+    "x-run-id": inputs.runId,
+    "x-brand-id": inputs.brandId,
+    "x-campaign-id": inputs.campaignId,
+    "x-feature-slug": inputs.featureSlug,
+    "x-workflow-name": workflowName,
   };
-  headers["x-brand-id"] = inputs.brandId;
-  if (inputs.userId) headers["x-user-id"] = inputs.userId;
-  if (inputs.runId) headers["x-run-id"] = inputs.runId;
-  if (inputs.campaignId) headers["x-campaign-id"] = inputs.campaignId;
-  if (inputs.featureSlug) headers["x-feature-slug"] = inputs.featureSlug;
-  headers["x-workflow-name"] = workflowName;
 
   const res = await fetch(executeUrl, {
     method: "POST",

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -6,7 +6,7 @@ import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/
 import { validateBody } from "../middleware/validate.js";
 import { normalizeUrl, extractDomain } from "../lib/domain.js";
 import { CreateCampaignBody, UpdateCampaignBody } from "../schemas.js";
-import { executeCampaignWorkflow } from "../lib/workflows.js";
+import { executeCampaignWorkflow, validateWorkflowInputs } from "../lib/workflows.js";
 
 const router = Router();
 
@@ -127,6 +127,29 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     const normalizedBrandUrl = normalizeUrl(brandUrl);
     console.log(`[Campaign Service] Creating campaign with brandUrl: ${normalizedBrandUrl}`);
 
+    // Validate all required workflow fields BEFORE creating the campaign
+    const preCheckInputs = {
+      campaignId: "pending",  // will be assigned after insert
+      orgId: req.orgId!,
+      brandId: brandId || "",
+      userId: req.userId || "",
+      runId: req.runId || "",
+      featureSlug: featureSlug || "",
+    };
+    const missing = validateWorkflowInputs(preCheckInputs);
+    // campaignId is always "pending" here — exclude it from the check
+    const actualMissing = missing.filter((f) => f !== "campaignId");
+    if (actualMissing.length > 0) {
+      const headerMap: Record<string, string> = {
+        userId: "x-user-id", runId: "x-run-id", brandId: "brandId (body)",
+        featureSlug: "featureSlug (body)", orgId: "x-org-id",
+      };
+      const missingHeaders = actualMissing.map((f) => headerMap[f] || f);
+      return res.status(400).json({
+        error: `Cannot create campaign — missing required fields for workflow execution: ${missingHeaders.join(", ")}`,
+      });
+    }
+
     const [campaign] = await db
       .insert(campaigns)
       .values({
@@ -153,15 +176,16 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       .returning();
 
     // Trigger first workflow execution (fire-and-forget)
-    console.log(`[Campaign Service] Launching workflow run from CAMPAIGN CREATION — workflow=${campaign.workflowName}, campaignId=${campaign.id}`);
-    executeCampaignWorkflow(campaign.workflowName, {
+    const workflowInputs = {
       campaignId: campaign.id,
       orgId: req.orgId!,
       brandId: campaign.brandId!,
-      userId: req.userId,
-      runId: req.runId,
-      featureSlug: campaign.featureSlug || undefined,
-    }).catch((err) => {
+      userId: req.userId!,
+      runId: req.runId!,
+      featureSlug: campaign.featureSlug!,
+    };
+    console.log(`[Campaign Service] Launching workflow run from CAMPAIGN CREATION — workflow=${campaign.workflowName}, campaignId=${campaign.id}`);
+    executeCampaignWorkflow(campaign.workflowName, workflowInputs).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
 
@@ -193,6 +217,29 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
       return res.status(404).json({ error: "Campaign not found" });
     }
 
+    // Validate required workflow fields BEFORE activating
+    if (req.body.status === "activate") {
+      const preActivateInputs = {
+        campaignId: id,
+        orgId: req.orgId!,
+        brandId: existing.brandId || "",
+        userId: req.userId || "",
+        runId: req.runId || "",
+        featureSlug: existing.featureSlug || "",
+      };
+      const missingActivate = validateWorkflowInputs(preActivateInputs);
+      if (missingActivate.length > 0) {
+        const headerMap: Record<string, string> = {
+          userId: "x-user-id", runId: "x-run-id", brandId: "brandId",
+          featureSlug: "featureSlug", orgId: "x-org-id", campaignId: "campaignId",
+        };
+        const missingHeaders = missingActivate.map((f) => headerMap[f] || f);
+        return res.status(400).json({
+          error: `Cannot activate campaign — missing required fields for workflow execution: ${missingHeaders.join(", ")}`,
+        });
+      }
+    }
+
     const statusMap: Record<string, string> = { activate: "ongoing", stop: "stopped" };
     const updates = { ...req.body, updatedAt: new Date() };
     if (updates.status) {
@@ -207,18 +254,16 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
 
     // Trigger workflow on activation
     if (req.body.status === "activate") {
-      if (!updated.brandId) {
-        return res.status(400).json({ error: "Cannot activate campaign without brandId" });
-      }
-      console.log(`[Campaign Service] Launching workflow run from CAMPAIGN ACTIVATION — workflow=${updated.workflowName}, campaignId=${updated.id}`);
-      executeCampaignWorkflow(updated.workflowName, {
+      const activateInputs = {
         campaignId: updated.id,
         orgId: req.orgId!,
-        brandId: updated.brandId,
-        userId: req.userId,
-        runId: req.runId,
-        featureSlug: updated.featureSlug || undefined,
-      }).catch((err) => {
+        brandId: updated.brandId!,
+        userId: req.userId!,
+        runId: req.runId!,
+        featureSlug: updated.featureSlug!,
+      };
+      console.log(`[Campaign Service] Launching workflow run from CAMPAIGN ACTIVATION — workflow=${updated.workflowName}, campaignId=${updated.id}`);
+      executeCampaignWorkflow(updated.workflowName, activateInputs).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });
     }

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -6,7 +6,7 @@ import { requireApiKey, trackingHeaders, type AuthenticatedRequest } from "../mi
 import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun, type IdentityHeaders } from "@mcpfactory/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
-import { executeCampaignWorkflow } from "../lib/workflows.js";
+import { executeCampaignWorkflow, validateWorkflowInputs } from "../lib/workflows.js";
 import { extractDomain } from "../lib/domain.js";
 import { GateCheckBody, StartRunBody, EndRunBody } from "../schemas.js";
 
@@ -241,22 +241,26 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
         return;
       }
 
-      const resolvedBrandId = req.brandId || freshCampaign.brandId;
-      if (!resolvedBrandId) {
-        console.warn(`[End Run] Campaign ${campaignId} has no brandId — skipping re-trigger`);
+      const resolvedBrandId = req.brandId || freshCampaign.brandId || "";
+      const resolvedFeatureSlug = identity.featureSlug || freshCampaign.featureSlug || "";
+
+      const retriggerInputs = {
+        campaignId,
+        orgId,
+        brandId: resolvedBrandId,
+        userId: identity.userId || "",
+        runId: identity.runId || "",
+        featureSlug: resolvedFeatureSlug,
+      };
+      const missingRetrigger = validateWorkflowInputs(retriggerInputs);
+      if (missingRetrigger.length > 0) {
+        console.warn(`[End Run] Cannot re-trigger campaign ${campaignId} — missing required fields: ${missingRetrigger.join(", ")}`);
         return;
       }
 
       // Fire-and-forget: gate-check in the next workflow execution will validate limits
       console.log(`[Campaign Service] Launching workflow run from END-RUN handler — workflow=${freshCampaign.workflowName}, campaignId=${campaignId}, previousRunSuccess=${success}`);
-      executeCampaignWorkflow(freshCampaign.workflowName, {
-        campaignId,
-        orgId,
-        brandId: resolvedBrandId,
-        userId: identity.userId,
-        runId: identity.runId,
-        featureSlug: identity.featureSlug || freshCampaign.featureSlug || undefined,
-      }).catch((err) => {
+      executeCampaignWorkflow(freshCampaign.workflowName, retriggerInputs).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });
     } catch (err) {

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -21,16 +21,23 @@ describe("Campaign CRUD", () => {
     orgId: "org_test_crud",
     brandUrl: "https://example.com",
     brandId: crypto.randomUUID(),
+    featureSlug: "sales-cold-email-v1",
   };
+
+  /** Helper: create a campaign with all required headers */
+  function createCampaign(body: Record<string, unknown> = validBody, orgId = "org_test_crud") {
+    return request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", orgId)
+      .set("x-user-id", "user_test_crud")
+      .set("x-run-id", crypto.randomUUID())
+      .send(body);
+  }
 
   describe("POST /campaigns", () => {
     it("should create a campaign with all required fields", async () => {
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(validBody)
-        .expect(201);
+      const res = await createCampaign().expect(201);
 
       expect(res.body.campaign).toBeDefined();
       expect(res.body.campaign.name).toBe("Test Campaign");
@@ -41,65 +48,36 @@ describe("Campaign CRUD", () => {
     it("should reject when workflowName is missing", async () => {
       const { workflowName, ...body } = validBody;
 
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(body)
-        .expect(400);
-
+      const res = await createCampaign(body).expect(400);
       expect(res.body.error).toBeDefined();
     });
 
     it("should reject when brandId is missing", async () => {
       const { brandId, ...body } = validBody;
 
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(body)
-        .expect(400);
-
+      const res = await createCampaign(body).expect(400);
       expect(res.body.error).toBeDefined();
     });
 
     it("should reject when orgId is missing from body", async () => {
       const { orgId, ...body } = validBody;
 
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(body)
-        .expect(400);
-
+      const res = await createCampaign(body).expect(400);
       expect(res.body.error).toBeDefined();
     });
 
     it("should reject when brandId is not a valid UUID", async () => {
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({ ...validBody, brandId: "not-a-uuid" })
-        .expect(400);
-
+      const res = await createCampaign({ ...validBody, brandId: "not-a-uuid" }).expect(400);
       expect(res.body.error).toBeDefined();
     });
 
     it("should create a campaign with featureSlug and featureInputs", async () => {
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({
-          ...validBody,
-          name: "Feature Campaign",
-          featureSlug: "sales-cold-email-v1",
-          featureInputs: { targetAudience: "CTOs", targetOutcome: "Book demos" },
-        })
-        .expect(201);
+      const res = await createCampaign({
+        ...validBody,
+        name: "Feature Campaign",
+        featureSlug: "sales-cold-email-v1",
+        featureInputs: { targetAudience: "CTOs", targetOutcome: "Book demos" },
+      }).expect(201);
 
       expect(res.body.campaign.featureSlug).toBe("sales-cold-email-v1");
       expect(res.body.campaign.featureInputs).toEqual({
@@ -108,24 +86,39 @@ describe("Campaign CRUD", () => {
       });
     });
 
-    it("should create a campaign without featureSlug (backward compat)", async () => {
+    it("should reject campaign creation without featureSlug (required for workflow)", async () => {
+      const { featureSlug, ...bodyWithoutSlug } = validBody;
+
+      const res = await createCampaign(bodyWithoutSlug).expect(400);
+      expect(res.body.error).toContain("featureSlug");
+    });
+
+    it("should reject campaign creation without x-user-id header", async () => {
       const res = await request(app)
         .post("/campaigns")
         .set("x-api-key", API_KEY)
         .set("x-org-id", "org_test_crud")
+        .set("x-run-id", crypto.randomUUID())
         .send(validBody)
-        .expect(201);
+        .expect(400);
 
-      expect(res.body.campaign.featureSlug).toBeNull();
-      expect(res.body.campaign.featureInputs).toBeNull();
+      expect(res.body.error).toContain("x-user-id");
+    });
+
+    it("should reject campaign creation without x-run-id header", async () => {
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .set("x-user-id", "user_test")
+        .send(validBody)
+        .expect(400);
+
+      expect(res.body.error).toContain("x-run-id");
     });
 
     it("should reject Apollo fields that no longer exist", async () => {
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({ ...validBody, personTitles: ["CEO"] });
+      const res = await createCampaign({ ...validBody, personTitles: ["CEO"] });
 
       // Zod strips unknown fields by default, so it should still succeed
       // but the field should not appear in the response
@@ -134,12 +127,7 @@ describe("Campaign CRUD", () => {
     });
 
     it("should not have legacy fields on campaign", async () => {
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(validBody)
-        .expect(201);
+      const res = await createCampaign().expect(201);
 
       expect(res.body.campaign).not.toHaveProperty("urgency");
       expect(res.body.campaign).not.toHaveProperty("scarcity");
@@ -151,51 +139,23 @@ describe("Campaign CRUD", () => {
     });
 
     it("should reject duplicate campaign name within same org with 409", async () => {
-      await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(validBody)
-        .expect(201);
+      await createCampaign().expect(201);
 
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(validBody)
-        .expect(409);
-
+      const res = await createCampaign().expect(409);
       expect(res.body.error).toBe("A campaign with this name already exists in your organization");
     });
 
     it("should allow same campaign name in different orgs", async () => {
-      await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(validBody)
-        .expect(201);
+      await createCampaign().expect(201);
 
-      const res = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_other")
-        .send({ ...validBody, orgId: "org_other" })
-        .expect(201);
-
+      const res = await createCampaign({ ...validBody, orgId: "org_other" }, "org_other").expect(201);
       expect(res.body.campaign.name).toBe(validBody.name);
     });
   });
 
   describe("PATCH /campaigns/:id", () => {
     it("should accept activate", async () => {
-      const createRes = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(validBody)
-        .expect(201);
-
+      const createRes = await createCampaign().expect(201);
       const campaignId = createRes.body.campaign.id;
 
       // Stop first
@@ -206,11 +166,13 @@ describe("Campaign CRUD", () => {
         .send({ status: "stop" })
         .expect(200);
 
-      // Activate
+      // Activate — requires tracking headers
       const activateRes = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
         .set("x-org-id", "org_test_crud")
+        .set("x-user-id", "user_test_crud")
+        .set("x-run-id", crypto.randomUUID())
         .send({ status: "activate" })
         .expect(200);
 
@@ -218,16 +180,11 @@ describe("Campaign CRUD", () => {
     });
 
     it("should update featureInputs", async () => {
-      const createRes = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({
-          ...validBody,
-          featureSlug: "sales-cold-email-v1",
-          featureInputs: { targetAudience: "CTOs" },
-        })
-        .expect(201);
+      const createRes = await createCampaign({
+        ...validBody,
+        featureSlug: "sales-cold-email-v1",
+        featureInputs: { targetAudience: "CTOs" },
+      }).expect(201);
 
       const campaignId = createRes.body.campaign.id;
 
@@ -245,19 +202,9 @@ describe("Campaign CRUD", () => {
     });
 
     it("should reject renaming to a name that already exists in the same org", async () => {
-      const res1 = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send(validBody)
-        .expect(201);
+      await createCampaign().expect(201);
 
-      const res2 = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_test_crud")
-        .send({ ...validBody, name: "Other Campaign" })
-        .expect(201);
+      const res2 = await createCampaign({ ...validBody, name: "Other Campaign" }).expect(201);
 
       const renameRes = await request(app)
         .patch(`/campaigns/${res2.body.campaign.id}`)

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -22,9 +22,13 @@ vi.mock("@mcpfactory/runs-client", () => ({
   getStatsBudget: vi.fn(),
 }));
 
-vi.mock("../../src/lib/workflows.js", () => ({
-  executeCampaignWorkflow: mockExecute,
-}));
+vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
+  return {
+    ...original,
+    executeCampaignWorkflow: mockExecute,
+  };
+});
 
 vi.mock("../../src/lib/gate-check.js", () => ({
   runGateChecks: mockGateChecks,
@@ -599,13 +603,19 @@ describe("Pipeline routes", () => {
         brandId,
         status: "ongoing",
         workflowName: "sales-email-cold-outreach",
+        featureSlug: "sales-cold-email-v1",
       });
 
       const runId = crypto.randomUUID();
       await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
+        .set("x-org-id", orgId)
         .set("x-run-id", runId)
+        .set("x-user-id", "user_test")
+        .set("x-brand-id", brandId)
+        .set("x-campaign-id", campaign.id)
+        .set("x-feature-slug", "sales-cold-email-v1")
         .send({
           campaignId: campaign.id,
           orgId,
@@ -632,13 +642,19 @@ describe("Pipeline routes", () => {
         brandId,
         status: "ongoing",
         workflowName: "sales-email-cold-outreach",
+        featureSlug: "sales-cold-email-v1",
       });
 
       const parentRunId = crypto.randomUUID();
       await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
+        .set("x-org-id", orgId)
         .set("x-run-id", parentRunId)
+        .set("x-user-id", "user_test")
+        .set("x-brand-id", brandId)
+        .set("x-campaign-id", campaign.id)
+        .set("x-feature-slug", "sales-cold-email-v1")
         .send({
           campaignId: campaign.id,
           orgId,
@@ -716,6 +732,7 @@ describe("Pipeline routes", () => {
         brandUrl: "https://example.com",
         brandId,
         status: "ongoing",
+        featureSlug: "sales-cold-email-v1",
       });
 
       mockListRuns.mockResolvedValue({
@@ -727,6 +744,12 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
+        .set("x-org-id", orgId)
+        .set("x-user-id", "user_test")
+        .set("x-run-id", crypto.randomUUID())
+        .set("x-brand-id", brandId)
+        .set("x-campaign-id", campaign.id)
+        .set("x-feature-slug", "sales-cold-email-v1")
         .send({
           campaignId: campaign.id,
           orgId,

--- a/tests/integration/scheduler-resume.test.ts
+++ b/tests/integration/scheduler-resume.test.ts
@@ -5,9 +5,13 @@ const { mockExecute, mockCreateRun } = vi.hoisted(() => ({
   mockCreateRun: vi.fn(),
 }));
 
-vi.mock("../../src/lib/workflows.js", () => ({
-  executeCampaignWorkflow: mockExecute,
-}));
+vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
+  return {
+    ...original,
+    executeCampaignWorkflow: mockExecute,
+  };
+});
 
 vi.mock("@mcpfactory/runs-client", () => ({
   listRuns: vi.fn().mockResolvedValue({ runs: [] }),
@@ -52,6 +56,8 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
     const campaign = await insertTestCampaign(orgId, {
       status: "ongoing",
       toResumeAt: pastDate,
+      featureSlug: "sales-cold-email-v1",
+      createdByUserId: "user_scheduler_test",
     });
 
     const count = await resumeDueCampaigns();
@@ -115,11 +121,15 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
       name: "Campaign A",
       status: "ongoing",
       toResumeAt: pastDate,
+      featureSlug: "sales-cold-email-v1",
+      createdByUserId: "user_scheduler_test",
     });
     await insertTestCampaign(orgId, {
       name: "Campaign B",
       status: "ongoing",
       toResumeAt: pastDate,
+      featureSlug: "sales-cold-email-v1",
+      createdByUserId: "user_scheduler_test",
     });
 
     const count = await resumeDueCampaigns();

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -5,9 +5,13 @@ const { mockExecuteCampaignWorkflow } = vi.hoisted(() => ({
   mockExecuteCampaignWorkflow: vi.fn(),
 }));
 
-vi.mock("../../src/lib/workflows.js", () => ({
-  executeCampaignWorkflow: mockExecuteCampaignWorkflow,
-}));
+vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
+  return {
+    ...original,
+    executeCampaignWorkflow: mockExecuteCampaignWorkflow,
+  };
+});
 
 vi.mock("../../src/lib/gate-check.js", () => ({
   runGateChecks: vi.fn().mockResolvedValue({ allowed: true }),
@@ -31,7 +35,19 @@ const validBody = {
   orgId: "org_activation_test",
   brandUrl: "https://example.com",
   brandId: crypto.randomUUID(),
+  featureSlug: "sales-cold-email-v1",
 };
+
+/** Helper: create a campaign with all required headers */
+function createCampaign(body: Record<string, unknown> = validBody) {
+  return request(app)
+    .post("/campaigns")
+    .set("x-api-key", API_KEY)
+    .set("x-org-id", "org_activation_test")
+    .set("x-user-id", "user_activation_test")
+    .set("x-run-id", crypto.randomUUID())
+    .send(body);
+}
 
 describe("Workflow trigger", () => {
   beforeEach(async () => {
@@ -47,12 +63,7 @@ describe("Workflow trigger", () => {
 
   describe("on campaign creation", () => {
     it("should trigger workflow immediately when campaign is created", async () => {
-      const createRes = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_activation_test")
-        .send(validBody)
-        .expect(201);
+      const createRes = await createCampaign().expect(201);
 
       const campaignId = createRes.body.campaign.id;
 
@@ -66,6 +77,8 @@ describe("Workflow trigger", () => {
           campaignId,
           orgId: "org_activation_test",
           brandId: validBody.brandId,
+          userId: "user_activation_test",
+          featureSlug: "sales-cold-email-v1",
         }),
       );
     });
@@ -73,12 +86,7 @@ describe("Workflow trigger", () => {
     it("should still return 201 even if initial workflow execution fails", async () => {
       mockExecuteCampaignWorkflow.mockRejectedValue(new Error("Windmill down"));
 
-      const createRes = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_activation_test")
-        .send(validBody)
-        .expect(201);
+      const createRes = await createCampaign().expect(201);
 
       expect(createRes.body.campaign).toBeDefined();
       expect(createRes.body.campaign.status).toBe("ongoing");
@@ -88,13 +96,7 @@ describe("Workflow trigger", () => {
   describe("on PATCH activate", () => {
     it("should trigger workflow when status is set to activate", async () => {
       // Create campaign (triggers workflow once)
-      const createRes = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_activation_test")
-        .send(validBody)
-        .expect(201);
-
+      const createRes = await createCampaign().expect(201);
       const campaignId = createRes.body.campaign.id;
 
       // Stop it first so we can activate
@@ -108,11 +110,13 @@ describe("Workflow trigger", () => {
       vi.clearAllMocks();
       mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
 
-      // Activate (requires parentRunId)
+      // Activate (requires tracking headers)
       const activateRes = await request(app)
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
         .set("x-org-id", "org_activation_test")
+        .set("x-user-id", "user_activation_test")
+        .set("x-run-id", crypto.randomUUID())
         .send({ status: "activate" })
         .expect(200);
 
@@ -132,13 +136,7 @@ describe("Workflow trigger", () => {
     });
 
     it("should NOT trigger workflow on stop (only creation trigger)", async () => {
-      const createRes = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_activation_test")
-        .send(validBody)
-        .expect(201);
-
+      const createRes = await createCampaign().expect(201);
       const campaignId = createRes.body.campaign.id;
 
       // Clear mocks after creation trigger
@@ -159,13 +157,7 @@ describe("Workflow trigger", () => {
     });
 
     it("should NOT trigger workflow when updating non-status fields", async () => {
-      const createRes = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_activation_test")
-        .send(validBody)
-        .expect(201);
-
+      const createRes = await createCampaign().expect(201);
       const campaignId = createRes.body.campaign.id;
 
       // Clear mocks after creation trigger
@@ -186,13 +178,7 @@ describe("Workflow trigger", () => {
     });
 
     it("should still return 200 even if workflow execution fails on activate", async () => {
-      const createRes = await request(app)
-        .post("/campaigns")
-        .set("x-api-key", API_KEY)
-        .set("x-org-id", "org_activation_test")
-        .send(validBody)
-        .expect(201);
-
+      const createRes = await createCampaign().expect(201);
       const campaignId = createRes.body.campaign.id;
 
       // Stop then activate with failing mock
@@ -209,6 +195,8 @@ describe("Workflow trigger", () => {
         .patch(`/campaigns/${campaignId}`)
         .set("x-api-key", API_KEY)
         .set("x-org-id", "org_activation_test")
+        .set("x-user-id", "user_activation_test")
+        .set("x-run-id", crypto.randomUUID())
         .send({ status: "activate" })
         .expect(200);
 

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -16,6 +16,8 @@ const {
     orgId: string;
     workflowName: string;
     brandId?: string | null;
+    createdByUserId?: string | null;
+    featureSlug?: string | null;
   }> = [];
 
   return {
@@ -87,6 +89,8 @@ describe("Scheduler - resumeDueCampaigns", () => {
       orgId: "org-ext-1",
       workflowName: "sales-email-cold-outreach",
       brandId: "brand-123",
+      createdByUserId: "user-1",
+      featureSlug: "sales-cold-email-v1",
     });
 
     const count = await resumeDueCampaigns();
@@ -100,10 +104,11 @@ describe("Scheduler - resumeDueCampaigns", () => {
       orgId: "org-ext-1",
       serviceName: "campaign-service",
       taskName: "scheduler-resume",
-      userId: undefined,
+      userId: "user-1",
       campaignId: "campaign-1",
       brandId: "brand-123",
       workflowName: "sales-email-cold-outreach",
+      featureSlug: "sales-cold-email-v1",
     });
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
       "sales-email-cold-outreach",
@@ -111,8 +116,9 @@ describe("Scheduler - resumeDueCampaigns", () => {
         campaignId: "campaign-1",
         orgId: "org-ext-1",
         brandId: "brand-123",
-        userId: undefined,
+        userId: "user-1",
         runId: "scheduler-run-123",
+        featureSlug: "sales-cold-email-v1",
       },
     );
   });
@@ -123,6 +129,25 @@ describe("Scheduler - resumeDueCampaigns", () => {
       orgId: "org-ext-1",
       workflowName: "sales-email-cold-outreach",
       brandId: null,
+      createdByUserId: "user-1",
+      featureSlug: "sales-cold-email-v1",
+    });
+
+    const count = await resumeDueCampaigns();
+
+    expect(count).toBe(1);
+    expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
+    expect(mockCreateRun).not.toHaveBeenCalled();
+  });
+
+  it("should skip campaigns without createdByUserId or featureSlug", async () => {
+    mockDbValues.push({
+      id: "campaign-no-user",
+      orgId: "org-ext-1",
+      workflowName: "sales-email-cold-outreach",
+      brandId: "brand-1",
+      createdByUserId: null,
+      featureSlug: null,
     });
 
     const count = await resumeDueCampaigns();
@@ -139,12 +164,16 @@ describe("Scheduler - resumeDueCampaigns", () => {
         orgId: "org-ext-1",
         workflowName: "sales-email-cold-outreach",
         brandId: "brand-1",
+        createdByUserId: "user-1",
+        featureSlug: "sales-cold-email-v1",
       },
       {
         id: "campaign-2",
         orgId: "org-ext-2",
         workflowName: "pr-email-cold-outreach",
         brandId: "brand-2",
+        createdByUserId: "user-2",
+        featureSlug: "pr-media-pitch-v1",
       },
     );
 
@@ -161,12 +190,16 @@ describe("Scheduler - resumeDueCampaigns", () => {
         orgId: "org-ext-1",
         workflowName: "sales-email-cold-outreach",
         brandId: "brand-1",
+        createdByUserId: "user-1",
+        featureSlug: "sales-cold-email-v1",
       },
       {
         id: "campaign-2",
         orgId: "org-ext-2",
         workflowName: "pr-email-cold-outreach",
         brandId: "brand-2",
+        createdByUserId: "user-2",
+        featureSlug: "pr-media-pitch-v1",
       },
     );
 

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -3,6 +3,15 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+const VALID_INPUTS = {
+  campaignId: "campaign-1",
+  orgId: "org_test",
+  brandId: "brand-abc",
+  userId: "user_test",
+  runId: "run-parent-456",
+  featureSlug: "sales-cold-email-v1",
+} as const;
+
 describe("Workflow module", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -12,134 +21,69 @@ describe("Workflow module", () => {
     vi.restoreAllMocks();
   });
 
+  describe("validateWorkflowInputs", () => {
+    it("should return empty array when all fields are present", async () => {
+      const { validateWorkflowInputs } = await import("../../src/lib/workflows.js");
+      expect(validateWorkflowInputs(VALID_INPUTS)).toEqual([]);
+    });
+
+    it("should return missing field names", async () => {
+      const { validateWorkflowInputs } = await import("../../src/lib/workflows.js");
+      expect(validateWorkflowInputs({
+        campaignId: "c1",
+        orgId: "o1",
+        brandId: "b1",
+        userId: "",
+        runId: "",
+        featureSlug: "",
+      })).toEqual(["userId", "runId", "featureSlug"]);
+    });
+  });
+
   describe("executeCampaignWorkflow", () => {
-    it("should use workflowName directly in URL", async () => {
+    it("should use workflowName directly in URL and send all required headers", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ id: "run-123", status: "queued" }),
       });
 
       const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
-      await executeCampaignWorkflow("sales-email-cold-outreach", {
-        campaignId: "campaign-1",
-        orgId: "org_test",
-        brandId: "brand-abc",
-      });
+      await executeCampaignWorkflow("sales-email-cold-outreach", VALID_INPUTS);
 
       expect(mockFetch).toHaveBeenCalledOnce();
       const [url, opts] = mockFetch.mock.calls[0];
       expect(url).toBe("https://workflow.test.local/workflows/by-name/sales-email-cold-outreach/execute");
       expect(opts.method).toBe("POST");
 
+      // All 7 tracking headers must be present
+      expect(opts.headers["x-org-id"]).toBe("org_test");
+      expect(opts.headers["x-user-id"]).toBe("user_test");
+      expect(opts.headers["x-run-id"]).toBe("run-parent-456");
+      expect(opts.headers["x-brand-id"]).toBe("brand-abc");
+      expect(opts.headers["x-campaign-id"]).toBe("campaign-1");
+      expect(opts.headers["x-feature-slug"]).toBe("sales-cold-email-v1");
+      expect(opts.headers["x-workflow-name"]).toBe("sales-email-cold-outreach");
+
       const body = JSON.parse(opts.body);
       expect(body).not.toHaveProperty("appId");
-      expect(body).not.toHaveProperty("orgId");
       expect(body.inputs).toEqual({
         campaignId: "campaign-1",
         orgId: "org_test",
       });
     });
 
-    it("should set x-run-id header when runId is provided", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ id: "run-123", status: "queued" }),
-      });
-
+    it("should throw when required fields are missing", async () => {
       const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
-      await executeCampaignWorkflow("sales-email-cold-outreach", {
-        campaignId: "campaign-1",
-        orgId: "org_test",
-        brandId: "brand-abc",
-        userId: "user_test",
-        runId: "run-parent-456",
-      });
-
-      expect(mockFetch).toHaveBeenCalledOnce();
-      const [, opts] = mockFetch.mock.calls[0];
-      expect(opts.headers["x-org-id"]).toBe("org_test");
-      expect(opts.headers["x-user-id"]).toBe("user_test");
-      expect(opts.headers["x-run-id"]).toBe("run-parent-456");
+      await expect(
+        executeCampaignWorkflow("sales-email-cold-outreach", {
+          ...VALID_INPUTS,
+          userId: "",
+          featureSlug: "",
+        } as any)
+      ).rejects.toThrow("missing required fields: userId, featureSlug");
     });
 
-    it("should set tracking headers (x-campaign-id, x-brand-id, x-workflow-name) when provided", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ id: "run-123", status: "queued" }),
-      });
-
-      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
-      await executeCampaignWorkflow("sales-email-cold-outreach", {
-        campaignId: "campaign-1",
-        orgId: "org_test",
-        brandId: "brand-abc",
-      });
-
-      expect(mockFetch).toHaveBeenCalledOnce();
-      const [, opts] = mockFetch.mock.calls[0];
-      expect(opts.headers["x-campaign-id"]).toBe("campaign-1");
-      expect(opts.headers["x-brand-id"]).toBe("brand-abc");
-      expect(opts.headers["x-workflow-name"]).toBe("sales-email-cold-outreach");
-    });
-
-    it("should always set x-brand-id header (required)", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ id: "run-123", status: "queued" }),
-      });
-
-      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
-      await executeCampaignWorkflow("pr-outreach", {
-        campaignId: "campaign-2",
-        orgId: "org_test",
-        brandId: "brand-xyz",
-      });
-
-      expect(mockFetch).toHaveBeenCalledOnce();
-      const [, opts] = mockFetch.mock.calls[0];
-      expect(opts.headers["x-campaign-id"]).toBe("campaign-2");
-      expect(opts.headers["x-brand-id"]).toBe("brand-xyz");
-      expect(opts.headers["x-workflow-name"]).toBe("pr-outreach");
-    });
-
-    it("should set x-feature-slug header when featureSlug is provided", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ id: "run-123", status: "queued" }),
-      });
-
-      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
-      await executeCampaignWorkflow("sales-email-cold-outreach", {
-        campaignId: "campaign-1",
-        orgId: "org_test",
-        brandId: "brand-abc",
-        featureSlug: "sales-cold-email-v1",
-      });
-
-      expect(mockFetch).toHaveBeenCalledOnce();
-      const [, opts] = mockFetch.mock.calls[0];
-      expect(opts.headers["x-feature-slug"]).toBe("sales-cold-email-v1");
-    });
-
-    it("should not set x-feature-slug header when featureSlug is not provided", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ id: "run-123", status: "queued" }),
-      });
-
-      const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
-      await executeCampaignWorkflow("sales-email-cold-outreach", {
-        campaignId: "campaign-1",
-        orgId: "org_test",
-        brandId: "brand-abc",
-      });
-
-      expect(mockFetch).toHaveBeenCalledOnce();
-      const [, opts] = mockFetch.mock.calls[0];
-      expect(opts.headers).not.toHaveProperty("x-feature-slug");
-    });
-
-    it("should not throw when execution fails", async () => {
+    it("should not throw when execution fails (non-ok response)", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 404,
@@ -148,11 +92,7 @@ describe("Workflow module", () => {
 
       const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
       await expect(
-        executeCampaignWorkflow("sales-email-cold-outreach", {
-          campaignId: "campaign-1",
-          orgId: "org_test",
-          brandId: "brand-abc",
-        })
+        executeCampaignWorkflow("sales-email-cold-outreach", VALID_INPUTS)
       ).resolves.not.toThrow();
     });
 
@@ -162,11 +102,7 @@ describe("Workflow module", () => {
 
       const { executeCampaignWorkflow } = await import("../../src/lib/workflows.js");
       await expect(
-        executeCampaignWorkflow("any-workflow", {
-          campaignId: "campaign-1",
-          orgId: "org_test",
-          brandId: "brand-abc",
-        })
+        executeCampaignWorkflow("any-workflow", VALID_INPUTS)
       ).resolves.not.toThrow();
       expect(mockFetch).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## Summary
- Makes all 7 tracking headers mandatory when calling workflow-service (`x-org-id`, `x-user-id`, `x-run-id`, `x-brand-id`, `x-campaign-id`, `x-workflow-name`, `x-feature-slug`)
- Validates required fields **before** creating/activating campaigns — returns 400 with the exact list of missing fields
- Fixes scheduler to pass `featureSlug` and skip campaigns missing required data (`brandId`, `createdByUserId`, `featureSlug`)
- Adds `validateWorkflowInputs` helper for consistent validation across all call sites

## Test plan
- [x] All 150 tests pass
- [x] New tests for missing field validation on create/activate
- [x] Scheduler skip test for campaigns without required fields
- [x] Unit test for `validateWorkflowInputs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)