### PR TITLE
fix: read featureSlug from x-feature-slug header

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -23,18 +23,16 @@ export function serviceAuth(
   const orgId = req.headers["x-org-id"] as string;
   const userId = req.headers["x-user-id"] as string | undefined;
   const runId = req.headers["x-run-id"] as string | undefined;
+  const featureSlug = req.headers["x-feature-slug"] as string | undefined;
 
   if (!orgId) {
     return res.status(400).json({ error: "x-org-id header required" });
   }
 
   req.orgId = orgId;
-  if (userId) {
-    req.userId = userId;
-  }
-  if (runId) {
-    req.runId = runId;
-  }
+  if (userId) req.userId = userId;
+  if (runId) req.runId = runId;
+  if (featureSlug) req.featureSlug = featureSlug;
 
   next();
 }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -127,6 +127,9 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     const normalizedBrandUrl = normalizeUrl(brandUrl);
     console.log(`[Campaign Service] Creating campaign with brandUrl: ${normalizedBrandUrl}`);
 
+    // Resolve featureSlug: prefer header, fallback to body
+    const resolvedFeatureSlug = req.featureSlug || featureSlug || "";
+
     // Validate all required workflow fields BEFORE creating the campaign
     const preCheckInputs = {
       campaignId: "pending",  // will be assigned after insert
@@ -134,19 +137,19 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       brandId: brandId || "",
       userId: req.userId || "",
       runId: req.runId || "",
-      featureSlug: featureSlug || "",
+      featureSlug: resolvedFeatureSlug,
     };
     const missing = validateWorkflowInputs(preCheckInputs);
     // campaignId is always "pending" here — exclude it from the check
     const actualMissing = missing.filter((f) => f !== "campaignId");
     if (actualMissing.length > 0) {
       const headerMap: Record<string, string> = {
-        userId: "x-user-id", runId: "x-run-id", brandId: "brandId (body)",
-        featureSlug: "featureSlug (body)", orgId: "x-org-id",
+        userId: "x-user-id", runId: "x-run-id", brandId: "x-brand-id",
+        featureSlug: "x-feature-slug", orgId: "x-org-id",
       };
       const missingHeaders = actualMissing.map((f) => headerMap[f] || f);
       return res.status(400).json({
-        error: `Cannot create campaign — missing required fields for workflow execution: ${missingHeaders.join(", ")}`,
+        error: `Cannot create campaign — missing required headers for workflow execution: ${missingHeaders.join(", ")}`,
       });
     }
 
@@ -159,7 +162,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         workflowName,
         brandUrl: normalizedBrandUrl,
         brandId,
-        featureSlug,
+        featureSlug: resolvedFeatureSlug || featureSlug,
         featureInputs,
         maxBudgetDailyUsd,
         maxBudgetWeeklyUsd,
@@ -225,17 +228,17 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         brandId: existing.brandId || "",
         userId: req.userId || "",
         runId: req.runId || "",
-        featureSlug: existing.featureSlug || "",
+        featureSlug: req.featureSlug || existing.featureSlug || "",
       };
       const missingActivate = validateWorkflowInputs(preActivateInputs);
       if (missingActivate.length > 0) {
         const headerMap: Record<string, string> = {
-          userId: "x-user-id", runId: "x-run-id", brandId: "brandId",
-          featureSlug: "featureSlug", orgId: "x-org-id", campaignId: "campaignId",
+          userId: "x-user-id", runId: "x-run-id", brandId: "x-brand-id",
+          featureSlug: "x-feature-slug", orgId: "x-org-id", campaignId: "campaignId",
         };
         const missingHeaders = missingActivate.map((f) => headerMap[f] || f);
         return res.status(400).json({
-          error: `Cannot activate campaign — missing required fields for workflow execution: ${missingHeaders.join(", ")}`,
+          error: `Cannot activate campaign — missing required headers for workflow execution: ${missingHeaders.join(", ")}`,
         });
       }
     }
@@ -260,7 +263,7 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         brandId: updated.brandId!,
         userId: req.userId!,
         runId: req.runId!,
-        featureSlug: updated.featureSlug!,
+        featureSlug: req.featureSlug || updated.featureSlug!,
       };
       console.log(`[Campaign Service] Launching workflow run from CAMPAIGN ACTIVATION — workflow=${updated.workflowName}, campaignId=${updated.id}`);
       executeCampaignWorkflow(updated.workflowName, activateInputs).catch((err) => {

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -21,7 +21,6 @@ describe("Campaign CRUD", () => {
     orgId: "org_test_crud",
     brandUrl: "https://example.com",
     brandId: crypto.randomUUID(),
-    featureSlug: "sales-cold-email-v1",
   };
 
   /** Helper: create a campaign with all required headers */
@@ -32,6 +31,7 @@ describe("Campaign CRUD", () => {
       .set("x-org-id", orgId)
       .set("x-user-id", "user_test_crud")
       .set("x-run-id", crypto.randomUUID())
+      .set("x-feature-slug", "sales-cold-email-v1")
       .send(body);
   }
 
@@ -86,11 +86,18 @@ describe("Campaign CRUD", () => {
       });
     });
 
-    it("should reject campaign creation without featureSlug (required for workflow)", async () => {
-      const { featureSlug, ...bodyWithoutSlug } = validBody;
+    it("should reject campaign creation without x-feature-slug header", async () => {
+      const res = await request(app)
+        .post("/campaigns")
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .set("x-user-id", "user_test_crud")
+        .set("x-run-id", crypto.randomUUID())
+        // no x-feature-slug header
+        .send(validBody)
+        .expect(400);
 
-      const res = await createCampaign(bodyWithoutSlug).expect(400);
-      expect(res.body.error).toContain("featureSlug");
+      expect(res.body.error).toContain("x-feature-slug");
     });
 
     it("should reject campaign creation without x-user-id header", async () => {
@@ -173,6 +180,7 @@ describe("Campaign CRUD", () => {
         .set("x-org-id", "org_test_crud")
         .set("x-user-id", "user_test_crud")
         .set("x-run-id", crypto.randomUUID())
+        .set("x-feature-slug", "sales-cold-email-v1")
         .send({ status: "activate" })
         .expect(200);
 

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -35,7 +35,6 @@ const validBody = {
   orgId: "org_activation_test",
   brandUrl: "https://example.com",
   brandId: crypto.randomUUID(),
-  featureSlug: "sales-cold-email-v1",
 };
 
 /** Helper: create a campaign with all required headers */
@@ -46,6 +45,7 @@ function createCampaign(body: Record<string, unknown> = validBody) {
     .set("x-org-id", "org_activation_test")
     .set("x-user-id", "user_activation_test")
     .set("x-run-id", crypto.randomUUID())
+    .set("x-feature-slug", "sales-cold-email-v1")
     .send(body);
 }
 
@@ -117,6 +117,7 @@ describe("Workflow trigger", () => {
         .set("x-org-id", "org_activation_test")
         .set("x-user-id", "user_activation_test")
         .set("x-run-id", crypto.randomUUID())
+        .set("x-feature-slug", "sales-cold-email-v1")
         .send({ status: "activate" })
         .expect(200);
 
@@ -197,6 +198,7 @@ describe("Workflow trigger", () => {
         .set("x-org-id", "org_activation_test")
         .set("x-user-id", "user_activation_test")
         .set("x-run-id", crypto.randomUUID())
+        .set("x-feature-slug", "sales-cold-email-v1")
         .send({ status: "activate" })
         .expect(200);
 


### PR DESCRIPTION
## Summary
- `serviceAuth` middleware now reads `x-feature-slug` from the header (like `x-user-id` and `x-run-id`)
- Campaign creation/activation use the header value with fallback to the body field
- Error messages reference `x-feature-slug` consistently with all other headers

## Test plan
- [x] All 150 tests pass
- [x] Test for missing `x-feature-slug` header returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)