### PR TITLE
fix: featureSlug from x-feature-slug header only, no fallback

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -127,8 +127,8 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     const normalizedBrandUrl = normalizeUrl(brandUrl);
     console.log(`[Campaign Service] Creating campaign with brandUrl: ${normalizedBrandUrl}`);
 
-    // Resolve featureSlug: prefer header, fallback to body
-    const resolvedFeatureSlug = req.featureSlug || featureSlug || "";
+    // featureSlug comes exclusively from x-feature-slug header
+    const resolvedFeatureSlug = req.featureSlug || "";
 
     // Validate all required workflow fields BEFORE creating the campaign
     const preCheckInputs = {
@@ -162,7 +162,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         workflowName,
         brandUrl: normalizedBrandUrl,
         brandId,
-        featureSlug: resolvedFeatureSlug || featureSlug,
+        featureSlug: resolvedFeatureSlug,
         featureInputs,
         maxBudgetDailyUsd,
         maxBudgetWeeklyUsd,
@@ -228,7 +228,7 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         brandId: existing.brandId || "",
         userId: req.userId || "",
         runId: req.runId || "",
-        featureSlug: req.featureSlug || existing.featureSlug || "",
+        featureSlug: req.featureSlug || "",
       };
       const missingActivate = validateWorkflowInputs(preActivateInputs);
       if (missingActivate.length > 0) {
@@ -263,7 +263,7 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         brandId: updated.brandId!,
         userId: req.userId!,
         runId: req.runId!,
-        featureSlug: req.featureSlug || updated.featureSlug!,
+        featureSlug: req.featureSlug!,
       };
       console.log(`[Campaign Service] Launching workflow run from CAMPAIGN ACTIVATION — workflow=${updated.workflowName}, campaignId=${updated.id}`);
       executeCampaignWorkflow(updated.workflowName, activateInputs).catch((err) => {

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -118,8 +118,8 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
       return res.status(400).json({ error: "Campaign has no brandId" });
     }
 
-    // Resolve featureSlug from header (workflow context) or campaign record
-    const featureSlug = req.featureSlug || campaign.featureSlug || undefined;
+    // featureSlug comes exclusively from x-feature-slug header
+    const featureSlug = req.featureSlug || undefined;
 
     // Create run in runs-service (x-run-id from caller becomes parentRunId)
     const parentRunId = req.headers["x-run-id"] as string | undefined;
@@ -242,7 +242,7 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
       }
 
       const resolvedBrandId = req.brandId || freshCampaign.brandId || "";
-      const resolvedFeatureSlug = identity.featureSlug || freshCampaign.featureSlug || "";
+      const resolvedFeatureSlug = identity.featureSlug || "";
 
       const retriggerInputs = {
         campaignId,

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -413,12 +413,12 @@ describe("Pipeline routes", () => {
       const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
-        featureSlug: "sales-cold-email-v1",
       });
 
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
+        .set("x-feature-slug", "sales-cold-email-v1")
         .send({ campaignId: campaign.id, orgId })
         .expect(200);
 


### PR DESCRIPTION
## Summary
- Removes all fallbacks to request body or campaign DB record for featureSlug
- `x-feature-slug` header is the sole source, consistent with all other tracking headers

## Test plan
- [x] All 150 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)