### PR TITLE
feat: rename workflowName → workflowSlug

### DIFF
--- a/drizzle/0025_rename_workflow_name_to_slug.sql
+++ b/drizzle/0025_rename_workflow_name_to_slug.sql
@@ -1,0 +1,2 @@
+-- Rename workflow_name column to workflow_slug (values unchanged)
+ALTER TABLE "campaigns" RENAME COLUMN "workflow_name" TO "workflow_slug";--> statement-breakpoint

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1774600000000,
       "tag": "0024_backfill_feature_slug",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1774900000000,
+      "tag": "0025_rename_workflow_name_to_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -37,7 +37,7 @@
           "name": {
             "type": "string"
           },
-          "workflowName": {
+          "workflowSlug": {
             "type": "string"
           },
           "brandUrl": {
@@ -119,7 +119,7 @@
           "orgId",
           "createdByUserId",
           "name",
-          "workflowName",
+          "workflowSlug",
           "brandUrl",
           "brandId",
           "featureSlug",
@@ -158,7 +158,7 @@
             "type": "string",
             "minLength": 1
           },
-          "workflowName": {
+          "workflowSlug": {
             "type": "string",
             "minLength": 1
           },
@@ -217,7 +217,7 @@
         },
         "required": [
           "name",
-          "workflowName",
+          "workflowSlug",
           "orgId",
           "brandUrl",
           "brandId"
@@ -394,7 +394,7 @@
           "brandDomain": {
             "type": "string"
           },
-          "workflowName": {
+          "workflowSlug": {
             "type": "string"
           },
           "userId": {
@@ -427,7 +427,7 @@
           "brandId",
           "brandUrl",
           "brandDomain",
-          "workflowName",
+          "workflowSlug",
           "userId",
           "featureSlug",
           "featureInputs",
@@ -1064,11 +1064,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name (injected by workflow-service)"
+              "description": "Workflow slug (injected by workflow-service)"
             },
             "required": false,
-            "description": "Workflow name (injected by workflow-service)",
-            "name": "x-workflow-name",
+            "description": "Workflow slug (injected by workflow-service)",
+            "name": "x-workflow-slug",
             "in": "header"
           }
         ],
@@ -1143,11 +1143,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name (injected by workflow-service)"
+              "description": "Workflow slug (injected by workflow-service)"
             },
             "required": false,
-            "description": "Workflow name (injected by workflow-service)",
-            "name": "x-workflow-name",
+            "description": "Workflow slug (injected by workflow-service)",
+            "name": "x-workflow-slug",
             "in": "header"
           }
         ],
@@ -1232,11 +1232,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name (injected by workflow-service)"
+              "description": "Workflow slug (injected by workflow-service)"
             },
             "required": false,
-            "description": "Workflow name (injected by workflow-service)",
-            "name": "x-workflow-name",
+            "description": "Workflow slug (injected by workflow-service)",
+            "name": "x-workflow-slug",
             "in": "header"
           }
         ],

--- a/packages/runs-client/src/index.ts
+++ b/packages/runs-client/src/index.ts
@@ -31,7 +31,7 @@ export interface IdentityHeaders {
   runId?: string;
   campaignId?: string;
   brandId?: string;
-  workflowName?: string;
+  workflowSlug?: string;
   featureSlug?: string;
 }
 
@@ -43,7 +43,7 @@ export interface CreateRunParams {
   brandId?: string;
   campaignId?: string;
   parentRunId?: string;
-  workflowName?: string;
+  workflowSlug?: string;
   featureSlug?: string;
 }
 
@@ -78,7 +78,7 @@ export interface StatsBudgetParams {
   orgId: string;
   campaignId?: string;
   brandId?: string;
-  workflowName?: string;
+  workflowSlug?: string;
   windows: BudgetWindow[];
 }
 
@@ -95,7 +95,7 @@ function buildIdentityHeaders(identity?: IdentityHeaders): Record<string, string
   if (identity?.runId) h["x-run-id"] = identity.runId;
   if (identity?.campaignId) h["x-campaign-id"] = identity.campaignId;
   if (identity?.brandId) h["x-brand-id"] = identity.brandId;
-  if (identity?.workflowName) h["x-workflow-name"] = identity.workflowName;
+  if (identity?.workflowSlug) h["x-workflow-slug"] = identity.workflowSlug;
   if (identity?.featureSlug) h["x-feature-slug"] = identity.featureSlug;
   return h;
 }
@@ -134,11 +134,11 @@ async function runsRequest<T>(
  * parentRunId is sent as x-run-id header.
  */
 export async function createRun(params: CreateRunParams): Promise<Run> {
-  const { orgId, userId, parentRunId, brandId, campaignId, workflowName, featureSlug, ...body } = params;
+  const { orgId, userId, parentRunId, brandId, campaignId, workflowSlug, featureSlug, ...body } = params;
   return runsRequest<Run>("/v1/runs", {
     method: "POST",
     body,
-    identity: { orgId, userId, runId: parentRunId, brandId, campaignId, workflowName, featureSlug },
+    identity: { orgId, userId, runId: parentRunId, brandId, campaignId, workflowSlug, featureSlug },
   });
 }
 

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -193,7 +193,7 @@ registry.registerPath({
 const TrackingHeaders = z.object({
   "x-campaign-id": z.string().uuid().optional().openapi({ description: "Campaign ID (injected by workflow-service)" }),
   "x-brand-id": z.string().uuid().optional().openapi({ description: "Brand ID (injected by workflow-service)" }),
-  "x-workflow-name": z.string().optional().openapi({ description: "Workflow name (injected by workflow-service)" }),
+  "x-workflow-slug": z.string().optional().openapi({ description: "Workflow slug (injected by workflow-service)" }),
 }).openapi("TrackingHeaders");
 
 registry.registerPath({

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,8 +10,8 @@ export const campaigns = pgTable(
 
     name: text("name").notNull(),
 
-    // Workflow name — resolved by workflow-service, passed at campaign creation
-    workflowName: text("workflow_name").notNull(),
+    // Workflow slug — resolved by workflow-service, passed at campaign creation
+    workflowSlug: text("workflow_slug").notNull(),
 
     // Brand URL - used to identify which brand this campaign promotes
     brandUrl: text("brand_url"),

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -12,7 +12,7 @@ export interface GateCheckInput {
   userId?: string;
   runId?: string;
   brandId: string;
-  workflowName?: string;
+  workflowSlug?: string;
   status: string;
   maxBudgetDailyUsd: string | null;
   maxBudgetWeeklyUsd: string | null;
@@ -40,7 +40,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     runId: campaign.runId,
     campaignId: campaign.campaignId,
     brandId: campaign.brandId || undefined,
-    workflowName: campaign.workflowName,
+    workflowSlug: campaign.workflowSlug,
   };
 
   // Fetch all runs for this campaign (needed for stale cleanup, running check, consecutive failures)
@@ -180,7 +180,7 @@ async function fetchLeadStats(
   if (identity.runId) headers["x-run-id"] = identity.runId;
   if (identity.campaignId) headers["x-campaign-id"] = identity.campaignId;
   if (identity.brandId) headers["x-brand-id"] = identity.brandId;
-  if (identity.workflowName) headers["x-workflow-name"] = identity.workflowName;
+  if (identity.workflowSlug) headers["x-workflow-slug"] = identity.workflowSlug;
 
   const params = new URLSearchParams({ brandId, campaignId });
   const res = await fetch(`${url}/stats?${params}`, { headers });

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -18,7 +18,7 @@ export async function resumeDueCampaigns(): Promise<number> {
       id: campaigns.id,
       orgId: campaigns.orgId,
       createdByUserId: campaigns.createdByUserId,
-      workflowName: campaigns.workflowName,
+      workflowSlug: campaigns.workflowSlug,
       brandId: campaigns.brandId,
       featureSlug: campaigns.featureSlug,
     })
@@ -51,7 +51,7 @@ export async function resumeDueCampaigns(): Promise<number> {
         .set({ toResumeAt: null, updatedAt: new Date() })
         .where(eq(campaigns.id, campaign.id));
 
-      console.log(`[Campaign Service] Launching workflow run from SCHEDULER RESUME — workflow=${campaign.workflowName}, campaignId=${campaign.id}`);
+      console.log(`[Campaign Service] Launching workflow run from SCHEDULER RESUME — workflow=${campaign.workflowSlug}, campaignId=${campaign.id}`);
       // All three fields are validated non-null above
       const brandId = campaign.brandId!;
       const userId = campaign.createdByUserId!;
@@ -64,10 +64,10 @@ export async function resumeDueCampaigns(): Promise<number> {
         userId,
         campaignId: campaign.id,
         brandId,
-        workflowName: campaign.workflowName,
+        workflowSlug: campaign.workflowSlug,
         featureSlug,
       });
-      executeCampaignWorkflow(campaign.workflowName, {
+      executeCampaignWorkflow(campaign.workflowSlug, {
         campaignId: campaign.id,
         orgId: campaign.orgId,
         brandId,

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -25,21 +25,21 @@ export function validateWorkflowInputs(
  * Execute a campaign's workflow by name.
  *
  * Campaign-service no longer defines or deploys DAGs — workflow-service
- * owns workflow definitions. Campaign-service receives a workflowName
+ * owns workflow definitions. Campaign-service receives a workflowSlug
  * at campaign creation and uses it to trigger execution.
  *
  * All inputs are required — workflow-service rejects calls missing any
  * of the 7 tracking headers (x-org-id, x-user-id, x-run-id, x-brand-id,
- * x-campaign-id, x-workflow-name, x-feature-slug).
+ * x-campaign-id, x-workflow-slug, x-feature-slug).
  */
 export async function executeCampaignWorkflow(
-  workflowName: string,
+  workflowSlug: string,
   inputs: WorkflowExecutionInputs,
 ): Promise<void> {
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
 
-  console.log(`[Workflow] executeCampaignWorkflow called: workflowName=${workflowName}, campaignId=${inputs.campaignId}, orgId=${inputs.orgId}`);
+  console.log(`[Workflow] executeCampaignWorkflow called: workflowSlug=${workflowSlug}, campaignId=${inputs.campaignId}, orgId=${inputs.orgId}`);
 
   if (!url || !apiKey) {
     console.warn("[Workflow] WORKFLOW_SERVICE_URL or WORKFLOW_SERVICE_API_KEY not set, skipping workflow execution");
@@ -52,7 +52,7 @@ export async function executeCampaignWorkflow(
     throw new Error(`[Workflow] Cannot execute workflow — missing required fields: ${missing.join(", ")}`);
   }
 
-  const executeUrl = `${url}/workflows/by-name/${workflowName}/execute`;
+  const executeUrl = `${url}/workflows/by-slug/${workflowSlug}/execute`;
   console.log(`[Workflow] POST ${executeUrl}`);
 
   const headers: Record<string, string> = {
@@ -64,7 +64,7 @@ export async function executeCampaignWorkflow(
     "x-brand-id": inputs.brandId,
     "x-campaign-id": inputs.campaignId,
     "x-feature-slug": inputs.featureSlug,
-    "x-workflow-name": workflowName,
+    "x-workflow-slug": workflowSlug,
   };
 
   const res = await fetch(executeUrl, {
@@ -85,5 +85,5 @@ export async function executeCampaignWorkflow(
   }
 
   const data = await res.json() as { id?: string; status?: string };
-  console.log(`[Workflow] ${workflowName} started successfully: workflowRunId=${data.id}, status=${data.status}`);
+  console.log(`[Workflow] ${workflowSlug} started successfully: workflowRunId=${data.id}, status=${data.status}`);
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -6,7 +6,7 @@ export interface AuthenticatedRequest extends Request {
   runId?: string;
   campaignId?: string;
   brandId?: string;
-  workflowName?: string;
+  workflowSlug?: string;
   featureSlug?: string;
 }
 
@@ -53,7 +53,7 @@ export function requireOrg(
 
 /**
  * Reads optional tracking headers injected by workflow-service:
- * x-campaign-id, x-brand-id, x-workflow-name
+ * x-campaign-id, x-brand-id, x-workflow-slug
  */
 export function trackingHeaders(
   req: AuthenticatedRequest,
@@ -62,12 +62,12 @@ export function trackingHeaders(
 ) {
   const campaignId = req.headers["x-campaign-id"] as string | undefined;
   const brandId = req.headers["x-brand-id"] as string | undefined;
-  const workflowName = req.headers["x-workflow-name"] as string | undefined;
+  const workflowSlug = req.headers["x-workflow-slug"] as string | undefined;
   const featureSlug = req.headers["x-feature-slug"] as string | undefined;
 
   if (campaignId) req.campaignId = campaignId;
   if (brandId) req.brandId = brandId;
-  if (workflowName) req.workflowName = workflowName;
+  if (workflowSlug) req.workflowSlug = workflowSlug;
   if (featureSlug) req.featureSlug = featureSlug;
 
   next();

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -22,7 +22,7 @@ router.get("/campaigns/list", requireApiKey, async (_req, res) => {
         id: campaigns.id,
         orgId: campaigns.orgId,
         name: campaigns.name,
-        workflowName: campaigns.workflowName,
+        workflowSlug: campaigns.workflowSlug,
         status: campaigns.status,
         maxBudgetDailyUsd: campaigns.maxBudgetDailyUsd,
         maxBudgetWeeklyUsd: campaigns.maxBudgetWeeklyUsd,
@@ -107,7 +107,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
   try {
     const {
       name,
-      workflowName,
+      workflowSlug,
       brandUrl,
       brandId,
       featureSlug,
@@ -159,7 +159,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         orgId: req.orgId!,
         createdByUserId: req.userId ?? null,
         name,
-        workflowName,
+        workflowSlug,
         brandUrl: normalizedBrandUrl,
         brandId,
         featureSlug: resolvedFeatureSlug,
@@ -187,8 +187,8 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       runId: req.runId!,
       featureSlug: campaign.featureSlug!,
     };
-    console.log(`[Campaign Service] Launching workflow run from CAMPAIGN CREATION — workflow=${campaign.workflowName}, campaignId=${campaign.id}`);
-    executeCampaignWorkflow(campaign.workflowName, workflowInputs).catch((err) => {
+    console.log(`[Campaign Service] Launching workflow run from CAMPAIGN CREATION — workflow=${campaign.workflowSlug}, campaignId=${campaign.id}`);
+    executeCampaignWorkflow(campaign.workflowSlug, workflowInputs).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
 
@@ -265,8 +265,8 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         runId: req.runId!,
         featureSlug: req.featureSlug!,
       };
-      console.log(`[Campaign Service] Launching workflow run from CAMPAIGN ACTIVATION — workflow=${updated.workflowName}, campaignId=${updated.id}`);
-      executeCampaignWorkflow(updated.workflowName, activateInputs).catch((err) => {
+      console.log(`[Campaign Service] Launching workflow run from CAMPAIGN ACTIVATION — workflow=${updated.workflowSlug}, campaignId=${updated.id}`);
+      executeCampaignWorkflow(updated.workflowSlug, activateInputs).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });
     }

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -48,7 +48,7 @@ router.post("/gate-check", requireApiKey, trackingHeaders, validateBody(GateChec
       userId: req.headers["x-user-id"] as string | undefined,
       runId: req.headers["x-run-id"] as string | undefined,
       brandId: req.brandId || campaign.brandId || "",
-      workflowName: req.workflowName || campaign.workflowName,
+      workflowSlug: req.workflowSlug || campaign.workflowSlug,
       status: campaign.status,
       maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
       maxBudgetWeeklyUsd: campaign.maxBudgetWeeklyUsd,
@@ -108,7 +108,7 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
       console.warn(`[Start Run] Campaign not found: ${campaignId} (orgId=${orgId})`);
       return res.status(404).json({ error: "Campaign not found" });
     }
-    console.log(`[Start Run] Campaign found: name=${campaign.name}, workflowName=${campaign.workflowName}, status=${campaign.status}, brandUrl=${campaign.brandUrl}`);
+    console.log(`[Start Run] Campaign found: name=${campaign.name}, workflowSlug=${campaign.workflowSlug}, status=${campaign.status}, brandUrl=${campaign.brandUrl}`);
     if (!campaign.brandUrl) {
       console.warn(`[Start Run] Campaign ${campaignId} has no brandUrl`);
       return res.status(400).json({ error: "Campaign has no brandUrl" });
@@ -132,7 +132,7 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
       brandId: campaign.brandId,
       userId: campaign.createdByUserId || undefined,
       parentRunId: parentRunId || undefined,
-      workflowName: campaign.workflowName,
+      workflowSlug: campaign.workflowSlug,
       featureSlug,
     });
     console.log(`[Start Run] Run created: runId=${run.id}`);
@@ -153,7 +153,7 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
       brandId: campaign.brandId,
       brandUrl: campaign.brandUrl,
       brandDomain,
-      workflowName: campaign.workflowName,
+      workflowSlug: campaign.workflowSlug,
       userId: campaign.createdByUserId ?? null,
       featureSlug: campaign.featureSlug ?? null,
       featureInputs: featureInputs ?? null,
@@ -188,7 +188,7 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
       runId: req.headers["x-run-id"] as string | undefined,
       campaignId: req.campaignId,
       brandId: req.brandId,
-      workflowName: req.workflowName,
+      workflowSlug: req.workflowSlug,
       featureSlug: req.featureSlug,
     };
 
@@ -235,7 +235,7 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
       const freshCampaign = await db.query.campaigns.findFirst({
         where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
       });
-      console.log(`[End Run] Campaign status for re-trigger: ${freshCampaign?.status || "NOT FOUND"}, workflowName=${freshCampaign?.workflowName || "N/A"}`);
+      console.log(`[End Run] Campaign status for re-trigger: ${freshCampaign?.status || "NOT FOUND"}, workflowSlug=${freshCampaign?.workflowSlug || "N/A"}`);
       if (freshCampaign?.status !== "ongoing") {
         console.log(`[End Run] Campaign ${campaignId} is not ongoing — skipping re-trigger`);
         return;
@@ -259,8 +259,8 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
       }
 
       // Fire-and-forget: gate-check in the next workflow execution will validate limits
-      console.log(`[Campaign Service] Launching workflow run from END-RUN handler — workflow=${freshCampaign.workflowName}, campaignId=${campaignId}, previousRunSuccess=${success}`);
-      executeCampaignWorkflow(freshCampaign.workflowName, retriggerInputs).catch((err) => {
+      console.log(`[Campaign Service] Launching workflow run from END-RUN handler — workflow=${freshCampaign.workflowSlug}, campaignId=${campaignId}, previousRunSuccess=${success}`);
+      executeCampaignWorkflow(freshCampaign.workflowSlug, retriggerInputs).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });
     } catch (err) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -14,7 +14,7 @@ export const CampaignSchema = z.object({
   orgId: z.string(),
   createdByUserId: z.string().nullable(),
   name: z.string(),
-  workflowName: z.string(),
+  workflowSlug: z.string(),
   brandUrl: z.string().nullable(),
   brandId: z.string().uuid().nullable(),
   featureSlug: z.string().nullable(),
@@ -39,7 +39,7 @@ export const CampaignSchema = z.object({
 
 export const CreateCampaignBody = z.object({
   name: z.string().min(1, "Campaign name is required"),
-  workflowName: z.string().min(1, "workflowName is required"),
+  workflowSlug: z.string().min(1, "workflowSlug is required"),
   orgId: z.string().min(1, "orgId is required"),
   brandUrl: z.string().min(1, "brandUrl is required"),
   brandId: z.string().uuid("brandId must be a valid UUID"),
@@ -127,7 +127,7 @@ export const StartRunResponse = z.object({
   brandId: z.string().uuid(),
   brandUrl: z.string(),
   brandDomain: z.string(),
-  workflowName: z.string(),
+  workflowSlug: z.string(),
   userId: z.string().nullable(),
   featureSlug: z.string().nullable(),
   featureInputs: z.record(z.string(), z.unknown()).nullable(),

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -16,7 +16,7 @@ export async function insertTestCampaign(
   orgId: string,
   data: {
     name?: string;
-    workflowName?: string;
+    workflowSlug?: string;
     status?: string;
     brandUrl?: string;
     brandId?: string;
@@ -36,7 +36,7 @@ export async function insertTestCampaign(
     .values({
       orgId,
       name: data.name || `Test Campaign ${Date.now()}`,
-      workflowName: data.workflowName || "sales-email-cold-outreach",
+      workflowSlug: data.workflowSlug || "sales-email-cold-outreach",
       status: data.status || "ongoing",
       brandUrl: data.brandUrl || null,
       brandId: "brandId" in data ? (data.brandId || null) : crypto.randomUUID(),

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -17,7 +17,7 @@ describe("Campaign CRUD", () => {
 
   const validBody = {
     name: "Test Campaign",
-    workflowName: "sales-email-cold-outreach",
+    workflowSlug: "sales-email-cold-outreach",
     orgId: "org_test_crud",
     brandUrl: "https://example.com",
     brandId: crypto.randomUUID(),
@@ -41,12 +41,12 @@ describe("Campaign CRUD", () => {
 
       expect(res.body.campaign).toBeDefined();
       expect(res.body.campaign.name).toBe("Test Campaign");
-      expect(res.body.campaign.workflowName).toBe("sales-email-cold-outreach");
+      expect(res.body.campaign.workflowSlug).toBe("sales-email-cold-outreach");
       expect(res.body.campaign.brandId).toBe(validBody.brandId);
     });
 
-    it("should reject when workflowName is missing", async () => {
-      const { workflowName, ...body } = validBody;
+    it("should reject when workflowSlug is missing", async () => {
+      const { workflowSlug, ...body } = validBody;
 
       const res = await createCampaign(body).expect(400);
       expect(res.body.error).toBeDefined();

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -301,7 +301,7 @@ describe("Pipeline routes", () => {
       expect(res.body.brandId).toBe(brandId);
       expect(res.body.brandUrl).toBe("https://example.com");
       expect(res.body.brandDomain).toBe("example.com");
-      expect(res.body.workflowName).toBe("sales-email-cold-outreach");
+      expect(res.body.workflowSlug).toBe("sales-email-cold-outreach");
       expect(res.body).not.toHaveProperty("appId");
       expect(res.body).not.toHaveProperty("keySource");
     });
@@ -391,11 +391,11 @@ describe("Pipeline routes", () => {
       );
     });
 
-    it("should pass workflowName to createRun", async () => {
+    it("should pass workflowSlug to createRun", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
-        workflowName: "pr-email-cold-outreach",
+        workflowSlug: "pr-email-cold-outreach",
       });
 
       await request(app)
@@ -405,7 +405,7 @@ describe("Pipeline routes", () => {
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
-        expect.objectContaining({ workflowName: "pr-email-cold-outreach" }),
+        expect.objectContaining({ workflowSlug: "pr-email-cold-outreach" }),
       );
     });
 
@@ -597,12 +597,12 @@ describe("Pipeline routes", () => {
       expect(mockUpdateRun).not.toHaveBeenCalled();
     });
 
-    it("should re-trigger workflow using workflowName if campaign is still ongoing", async () => {
+    it("should re-trigger workflow using workflowSlug if campaign is still ongoing", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandUrl: "https://example.com",
         brandId,
         status: "ongoing",
-        workflowName: "sales-email-cold-outreach",
+        workflowSlug: "sales-email-cold-outreach",
         featureSlug: "sales-cold-email-v1",
       });
 
@@ -641,7 +641,7 @@ describe("Pipeline routes", () => {
         brandUrl: "https://example.com",
         brandId,
         status: "ongoing",
-        workflowName: "sales-email-cold-outreach",
+        workflowSlug: "sales-email-cold-outreach",
         featureSlug: "sales-cold-email-v1",
       });
 

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -31,7 +31,7 @@ const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 
 const validBody = {
   name: "Activation Test Campaign",
-  workflowName: "sales-email-cold-outreach",
+  workflowSlug: "sales-email-cold-outreach",
   orgId: "org_activation_test",
   brandUrl: "https://example.com",
   brandId: crypto.randomUUID(),

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -14,7 +14,7 @@ describe("runs-client createRun", () => {
     });
   });
 
-  it("should send brandId, campaignId, workflowName as headers, not in body", async () => {
+  it("should send brandId, campaignId, workflowSlug as headers, not in body", async () => {
     await createRun({
       orgId: "org-1",
       userId: "user-1",
@@ -22,7 +22,7 @@ describe("runs-client createRun", () => {
       taskName: "test-task",
       brandId: "brand-1",
       campaignId: "campaign-1",
-      workflowName: "sales-email-cold-outreach",
+      workflowSlug: "sales-email-cold-outreach",
       parentRunId: "parent-run-1",
     });
 
@@ -38,7 +38,7 @@ describe("runs-client createRun", () => {
     expect(options.headers["x-run-id"]).toBe("parent-run-1");
     expect(options.headers["x-brand-id"]).toBe("brand-1");
     expect(options.headers["x-campaign-id"]).toBe("campaign-1");
-    expect(options.headers["x-workflow-name"]).toBe("sales-email-cold-outreach");
+    expect(options.headers["x-workflow-slug"]).toBe("sales-email-cold-outreach");
 
     // Body should only contain serviceName and taskName
     const body = JSON.parse(options.body);
@@ -48,7 +48,7 @@ describe("runs-client createRun", () => {
     });
     expect(body).not.toHaveProperty("brandId");
     expect(body).not.toHaveProperty("campaignId");
-    expect(body).not.toHaveProperty("workflowName");
+    expect(body).not.toHaveProperty("workflowSlug");
   });
 
   it("should omit undefined tracking headers", async () => {
@@ -62,7 +62,7 @@ describe("runs-client createRun", () => {
 
     expect(options.headers).not.toHaveProperty("x-brand-id");
     expect(options.headers).not.toHaveProperty("x-campaign-id");
-    expect(options.headers).not.toHaveProperty("x-workflow-name");
+    expect(options.headers).not.toHaveProperty("x-workflow-slug");
     expect(options.headers).not.toHaveProperty("x-user-id");
     expect(options.headers).not.toHaveProperty("x-run-id");
   });

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -14,7 +14,7 @@ const {
   const mockDbValues: Array<{
     id: string;
     orgId: string;
-    workflowName: string;
+    workflowSlug: string;
     brandId?: string | null;
     createdByUserId?: string | null;
     featureSlug?: string | null;
@@ -54,7 +54,7 @@ vi.mock("../../src/db/schema.js", () => ({
     id: "id",
     status: "status",
     toResumeAt: "to_resume_at",
-    workflowName: "workflow_name",
+    workflowSlug: "workflow_slug",
     orgId: "org_id",
     updatedAt: "updated_at",
   },
@@ -87,7 +87,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
     mockDbValues.push({
       id: "campaign-1",
       orgId: "org-ext-1",
-      workflowName: "sales-email-cold-outreach",
+      workflowSlug: "sales-email-cold-outreach",
       brandId: "brand-123",
       createdByUserId: "user-1",
       featureSlug: "sales-cold-email-v1",
@@ -107,7 +107,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       userId: "user-1",
       campaignId: "campaign-1",
       brandId: "brand-123",
-      workflowName: "sales-email-cold-outreach",
+      workflowSlug: "sales-email-cold-outreach",
       featureSlug: "sales-cold-email-v1",
     });
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
@@ -127,7 +127,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
     mockDbValues.push({
       id: "campaign-no-brand",
       orgId: "org-ext-1",
-      workflowName: "sales-email-cold-outreach",
+      workflowSlug: "sales-email-cold-outreach",
       brandId: null,
       createdByUserId: "user-1",
       featureSlug: "sales-cold-email-v1",
@@ -144,7 +144,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
     mockDbValues.push({
       id: "campaign-no-user",
       orgId: "org-ext-1",
-      workflowName: "sales-email-cold-outreach",
+      workflowSlug: "sales-email-cold-outreach",
       brandId: "brand-1",
       createdByUserId: null,
       featureSlug: null,
@@ -162,7 +162,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       {
         id: "campaign-1",
         orgId: "org-ext-1",
-        workflowName: "sales-email-cold-outreach",
+        workflowSlug: "sales-email-cold-outreach",
         brandId: "brand-1",
         createdByUserId: "user-1",
         featureSlug: "sales-cold-email-v1",
@@ -170,7 +170,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       {
         id: "campaign-2",
         orgId: "org-ext-2",
-        workflowName: "pr-email-cold-outreach",
+        workflowSlug: "pr-email-cold-outreach",
         brandId: "brand-2",
         createdByUserId: "user-2",
         featureSlug: "pr-media-pitch-v1",
@@ -188,7 +188,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       {
         id: "campaign-1",
         orgId: "org-ext-1",
-        workflowName: "sales-email-cold-outreach",
+        workflowSlug: "sales-email-cold-outreach",
         brandId: "brand-1",
         createdByUserId: "user-1",
         featureSlug: "sales-cold-email-v1",
@@ -196,7 +196,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       {
         id: "campaign-2",
         orgId: "org-ext-2",
-        workflowName: "pr-email-cold-outreach",
+        workflowSlug: "pr-email-cold-outreach",
         brandId: "brand-2",
         createdByUserId: "user-2",
         featureSlug: "pr-media-pitch-v1",

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -9,11 +9,11 @@ function createMockReq(headers: Record<string, string> = {}): AuthenticatedReque
 }
 
 describe("trackingHeaders middleware", () => {
-  it("should read x-campaign-id, x-brand-id, x-workflow-name from headers", () => {
+  it("should read x-campaign-id, x-brand-id, x-workflow-slug from headers", () => {
     const req = createMockReq({
       "x-campaign-id": "camp-123",
       "x-brand-id": "brand-456",
-      "x-workflow-name": "sales-email-cold-outreach",
+      "x-workflow-slug": "sales-email-cold-outreach",
     });
 
     let nextCalled = false;
@@ -21,7 +21,7 @@ describe("trackingHeaders middleware", () => {
 
     expect(req.campaignId).toBe("camp-123");
     expect(req.brandId).toBe("brand-456");
-    expect(req.workflowName).toBe("sales-email-cold-outreach");
+    expect(req.workflowSlug).toBe("sales-email-cold-outreach");
     expect(nextCalled).toBe(true);
   });
 
@@ -45,7 +45,7 @@ describe("trackingHeaders middleware", () => {
 
     expect(req.campaignId).toBeUndefined();
     expect(req.brandId).toBeUndefined();
-    expect(req.workflowName).toBeUndefined();
+    expect(req.workflowSlug).toBeUndefined();
     expect(req.featureSlug).toBeUndefined();
     expect(nextCalled).toBe(true);
   });
@@ -59,6 +59,6 @@ describe("trackingHeaders middleware", () => {
 
     expect(req.campaignId).toBe("camp-789");
     expect(req.brandId).toBeUndefined();
-    expect(req.workflowName).toBeUndefined();
+    expect(req.workflowSlug).toBeUndefined();
   });
 });

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -41,7 +41,7 @@ describe("Workflow module", () => {
   });
 
   describe("executeCampaignWorkflow", () => {
-    it("should use workflowName directly in URL and send all required headers", async () => {
+    it("should use workflowSlug directly in URL and send all required headers", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ id: "run-123", status: "queued" }),
@@ -52,7 +52,7 @@ describe("Workflow module", () => {
 
       expect(mockFetch).toHaveBeenCalledOnce();
       const [url, opts] = mockFetch.mock.calls[0];
-      expect(url).toBe("https://workflow.test.local/workflows/by-name/sales-email-cold-outreach/execute");
+      expect(url).toBe("https://workflow.test.local/workflows/by-slug/sales-email-cold-outreach/execute");
       expect(opts.method).toBe("POST");
 
       // All 7 tracking headers must be present
@@ -62,7 +62,7 @@ describe("Workflow module", () => {
       expect(opts.headers["x-brand-id"]).toBe("brand-abc");
       expect(opts.headers["x-campaign-id"]).toBe("campaign-1");
       expect(opts.headers["x-feature-slug"]).toBe("sales-cold-email-v1");
-      expect(opts.headers["x-workflow-name"]).toBe("sales-email-cold-outreach");
+      expect(opts.headers["x-workflow-slug"]).toBe("sales-email-cold-outreach");
 
       const body = JSON.parse(opts.body);
       expect(body).not.toHaveProperty("appId");


### PR DESCRIPTION
## Summary
- Renames `workflow_name` DB column to `workflow_slug` (migration 0025, values unchanged)
- Renames inbound header `x-workflow-name` → `x-workflow-slug` and outbound propagation
- Updates execute route path from `/workflows/by-name/:name/execute` → `/workflows/by-slug/:slug/execute`
- Renames `workflowName` → `workflowSlug` in Zod schemas, Drizzle schema, runs-client, all routes, and all tests
- Regenerated `openapi.json`

Aligns with workflow-service naming refactor (PRs #180, #181).

## Test plan
- [x] All 62 unit tests pass
- [x] TypeScript build succeeds
- [x] OpenAPI spec regenerated
- [ ] Run migration `0025_rename_workflow_name_to_slug.sql` on prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)