### PR TITLE
chore: remove verbose debug logs

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -51,7 +51,6 @@ export async function resumeDueCampaigns(): Promise<number> {
         .set({ toResumeAt: null, updatedAt: new Date() })
         .where(eq(campaigns.id, campaign.id));
 
-      console.log(`[Campaign Service] Launching workflow run from SCHEDULER RESUME — workflow=${campaign.workflowSlug}, campaignId=${campaign.id}`);
       // All three fields are validated non-null above
       const brandIdCsv = campaign.brandIds!.join(",");
       const userId = campaign.createdByUserId!;

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -39,8 +39,6 @@ export async function executeCampaignWorkflow(
   const url = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
 
-  console.log(`[Workflow] executeCampaignWorkflow called: workflowSlug=${workflowSlug}, campaignId=${inputs.campaignId}, orgId=${inputs.orgId}`);
-
   if (!url || !apiKey) {
     console.warn("[Workflow] WORKFLOW_SERVICE_URL or WORKFLOW_SERVICE_API_KEY not set, skipping workflow execution");
     return;
@@ -53,7 +51,6 @@ export async function executeCampaignWorkflow(
   }
 
   const executeUrl = `${url}/workflows/by-slug/${workflowSlug}/execute`;
-  console.log(`[Workflow] POST ${executeUrl}`);
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -84,6 +81,5 @@ export async function executeCampaignWorkflow(
     return;
   }
 
-  const data = await res.json() as { id?: string; status?: string };
-  console.log(`[Workflow] ${workflowSlug} started successfully: workflowRunId=${data.id}, status=${data.status}`);
+  await res.json();
 }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -164,9 +164,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     if (bodyWorkflowSlug) {
       resolvedWorkflowSlug = bodyWorkflowSlug;
     } else {
-      console.log(`[Campaign Service] Resolving workflowDynastySlug=${workflowDynastySlug} to latest versioned slug`);
       resolvedWorkflowSlug = await resolveLatestWorkflowSlug(workflowDynastySlug!);
-      console.log(`[Campaign Service] Resolved to workflowSlug=${resolvedWorkflowSlug}`);
     }
 
     // featureSlug comes exclusively from x-feature-slug header
@@ -231,7 +229,6 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       runId: req.runId!,
       featureSlug: campaign.featureSlug!,
     };
-    console.log(`[Campaign Service] Launching workflow run from CAMPAIGN CREATION — workflow=${campaign.workflowSlug}, campaignId=${campaign.id}`);
     executeCampaignWorkflow(campaign.workflowSlug, workflowInputs).catch((err) => {
       console.error(`[Campaign Service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
@@ -294,9 +291,7 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
     }
     // If featureDynastySlug is provided on update, resolve to latest versioned slug
     if (updates.featureDynastySlug && !updates.featureSlug) {
-      console.log(`[Campaign Service] Resolving featureDynastySlug=${updates.featureDynastySlug} on PATCH`);
       updates.featureSlug = await resolveLatestFeatureSlug(updates.featureDynastySlug);
-      console.log(`[Campaign Service] Resolved to featureSlug=${updates.featureSlug}`);
     }
 
     const [updated] = await db
@@ -315,7 +310,6 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         runId: req.runId!,
         featureSlug: req.featureSlug!,
       };
-      console.log(`[Campaign Service] Launching workflow run from CAMPAIGN ACTIVATION — workflow=${updated.workflowSlug}, campaignId=${updated.id}`);
       executeCampaignWorkflow(updated.workflowSlug, activateInputs).catch((err) => {
         console.error(`[Campaign Service] Failed to trigger workflow for campaign ${id}:`, err);
       });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -30,7 +30,6 @@ const router = Router();
 router.post("/gate-check", requireApiKey, trackingHeaders, validateBody(GateCheckBody), async (req: AuthenticatedRequest, res) => {
   try {
     const { campaignId, orgId } = req.body;
-    console.log(`[Gate Check] Received request: campaignId=${campaignId}, orgId=${orgId}`);
 
     const campaign = await db.query.campaigns.findFirst({
       where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
@@ -39,8 +38,6 @@ router.post("/gate-check", requireApiKey, trackingHeaders, validateBody(GateChec
       console.warn(`[Gate Check] Campaign not found: ${campaignId}`);
       return res.status(404).json({ error: "Campaign not found" });
     }
-
-    console.log(`[Gate Check] Running checks for campaign ${campaignId} (status=${campaign.status})...`);
     const resolvedBrandIds = (req.brandIds && req.brandIds.length > 0) ? req.brandIds : (campaign.brandIds ?? []);
     const result = await runGateChecks({
       campaignId,
@@ -65,10 +62,7 @@ router.post("/gate-check", requireApiKey, trackingHeaders, validateBody(GateChec
         await db.update(campaigns)
           .set({ toResumeAt: result.toResumeAt, updatedAt: new Date() })
           .where(eq(campaigns.id, campaignId));
-        console.log(`[Gate Check] Set toResumeAt=${result.toResumeAt.toISOString()} for campaign ${campaignId}`);
       }
-    } else {
-      console.log(`[Gate Check] PASSED for campaign ${campaignId}`);
     }
 
     res.json({
@@ -99,7 +93,6 @@ router.post("/gate-check", requireApiKey, trackingHeaders, validateBody(GateChec
 router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunBody), async (req: AuthenticatedRequest, res) => {
   try {
     const { campaignId, orgId } = req.body;
-    console.log(`[Start Run] Received request: campaignId=${campaignId}, orgId=${orgId}`);
 
     const campaign = await db.query.campaigns.findFirst({
       where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
@@ -108,7 +101,6 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
       console.warn(`[Start Run] Campaign not found: ${campaignId} (orgId=${orgId})`);
       return res.status(404).json({ error: "Campaign not found" });
     }
-    console.log(`[Start Run] Campaign found: name=${campaign.name}, workflowSlug=${campaign.workflowSlug}, status=${campaign.status}`);
     if (!campaign.brandIds || campaign.brandIds.length === 0) {
       console.warn(`[Start Run] Campaign ${campaignId} has no brandIds`);
       return res.status(400).json({ error: "Campaign has no brandIds" });
@@ -120,7 +112,6 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
     // Create run in runs-service (x-run-id from caller becomes parentRunId)
     const parentRunId = req.headers["x-run-id"] as string | undefined;
     const brandIdCsv = campaign.brandIds!.join(",");
-    console.log(`[Start Run] Creating run in runs-service for campaign ${campaignId} (parentRunId=${parentRunId || "none"}, featureSlug=${featureSlug || "none"})...`);
     const run = await createRun({
       orgId,
       serviceName: "campaign-service",
@@ -132,13 +123,9 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
       workflowSlug: campaign.workflowSlug,
       featureSlug,
     });
-    console.log(`[Start Run] Run created: runId=${run.id}`);
-
     // Build searchParams from featureInputs
     const featureInputs = campaign.featureInputs as Record<string, unknown> | null;
     const searchParams = (featureInputs && Object.keys(featureInputs).length > 0) ? featureInputs : null;
-
-    console.log(`[Start Run] SUCCESS — runId=${run.id}, searchParams=${searchParams ? "yes" : "none"}`);
 
     // Return campaign data for downstream DAG nodes
     res.json({
@@ -172,7 +159,6 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
 router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody), async (req: AuthenticatedRequest, res) => {
   try {
     const { campaignId, orgId, success, leadFound } = req.body;
-    console.log(`[End Run] Received request: campaignId=${campaignId}, orgId=${orgId}, success=${success}, leadFound=${leadFound}`);
 
     const status = success === true ? "completed" : "failed";
     const identity: IdentityHeaders = {
@@ -194,13 +180,8 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
       });
 
       const runningRuns = runs.filter((r) => r.status === "running");
-      if (runningRuns.length > 0) {
-        for (const run of runningRuns) {
-          console.log(`[End Run] Updating run ${run.id} to status=${status}`);
-          await updateRun(run.id, status, identity);
-        }
-      } else {
-        console.log(`[End Run] No running runs found for campaign ${campaignId} — skipping run update`);
+      for (const run of runningRuns) {
+        await updateRun(run.id, status, identity);
       }
     } catch (err) {
       console.error(`[End Run] Failed to update runs:`, err);
@@ -215,7 +196,7 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
         await db.update(campaigns)
           .set({ status: "stopped" })
           .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
-        console.log(`[End Run] No leads found — auto-stopped campaign ${campaignId}`);
+        console.warn(`[End Run] No leads found — auto-stopped campaign ${campaignId}`);
       } catch (err) {
         console.error(`[End Run] Failed to auto-stop campaign:`, err);
       }
@@ -228,9 +209,7 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
       const freshCampaign = await db.query.campaigns.findFirst({
         where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
       });
-      console.log(`[End Run] Campaign status for re-trigger: ${freshCampaign?.status || "NOT FOUND"}, workflowSlug=${freshCampaign?.workflowSlug || "N/A"}`);
       if (freshCampaign?.status !== "ongoing") {
-        console.log(`[End Run] Campaign ${campaignId} is not ongoing — skipping re-trigger`);
         return;
       }
 
@@ -252,7 +231,6 @@ router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody)
       }
 
       // Fire-and-forget: gate-check in the next workflow execution will validate limits
-      console.log(`[Campaign Service] Launching workflow run from END-RUN handler — workflow=${freshCampaign.workflowSlug}, campaignId=${campaignId}, previousRunSuccess=${success}`);
       executeCampaignWorkflow(freshCampaign.workflowSlug, retriggerInputs).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);
       });


### PR DESCRIPTION
## Summary
- Removed ~33 verbose `console.log` calls (request entry, step-by-step tracing, happy-path confirmations)
- Kept all `console.error` (real failures), `console.warn` (unexpected states), and important state change logs (auto-stop, scheduler)
- No behavior changes — only log output reduction

## Test plan
- [x] Build passes
- [x] Test results unchanged (same 104 pass / 84 pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)