### PR TITLE
feat: pipeline endpoints read campaignId/orgId from headers only

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -397,23 +397,6 @@
           "allowed"
         ]
       },
-      "GateCheckBody": {
-        "type": "object",
-        "properties": {
-          "campaignId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "orgId": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "required": [
-          "campaignId",
-          "orgId"
-        ]
-      },
       "StartRunResponse": {
         "type": "object",
         "properties": {
@@ -473,23 +456,6 @@
           "searchParams"
         ]
       },
-      "StartRunBody": {
-        "type": "object",
-        "properties": {
-          "campaignId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "orgId": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "required": [
-          "campaignId",
-          "orgId"
-        ]
-      },
       "EndRunResponse": {
         "type": "object",
         "properties": {
@@ -504,14 +470,6 @@
       "EndRunBody": {
         "type": "object",
         "properties": {
-          "campaignId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "orgId": {
-            "type": "string",
-            "minLength": 1
-          },
           "success": {
             "type": "boolean"
           },
@@ -520,8 +478,6 @@
           }
         },
         "required": [
-          "campaignId",
-          "orgId",
           "success"
         ]
       }
@@ -1135,12 +1091,42 @@
           {
             "schema": {
               "type": "string",
+              "description": "Organization UUID (required)"
+            },
+            "required": true,
+            "description": "Organization UUID (required)",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid",
-              "description": "Campaign ID (injected by workflow-service)"
+              "description": "Campaign UUID (required)"
+            },
+            "required": true,
+            "description": "Campaign UUID (required)",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "User UUID"
             },
             "required": false,
-            "description": "Campaign ID (injected by workflow-service)",
-            "name": "x-campaign-id",
+            "description": "User UUID",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Parent run UUID"
+            },
+            "required": false,
+            "description": "Parent run UUID",
+            "name": "x-run-id",
             "in": "header"
           },
           {
@@ -1163,17 +1149,18 @@
             "description": "Workflow slug (injected by workflow-service)",
             "name": "x-workflow-slug",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug"
+            },
+            "required": false,
+            "description": "Feature slug",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GateCheckBody"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Gate check result",
@@ -1185,8 +1172,18 @@
               }
             }
           },
+          "400": {
+            "description": "Missing required headers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Campaign or org not found",
+            "description": "Campaign not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1214,12 +1211,42 @@
           {
             "schema": {
               "type": "string",
+              "description": "Organization UUID (required)"
+            },
+            "required": true,
+            "description": "Organization UUID (required)",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid",
-              "description": "Campaign ID (injected by workflow-service)"
+              "description": "Campaign UUID (required)"
+            },
+            "required": true,
+            "description": "Campaign UUID (required)",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "User UUID"
             },
             "required": false,
-            "description": "Campaign ID (injected by workflow-service)",
-            "name": "x-campaign-id",
+            "description": "User UUID",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Parent run UUID"
+            },
+            "required": false,
+            "description": "Parent run UUID",
+            "name": "x-run-id",
             "in": "header"
           },
           {
@@ -1242,17 +1269,18 @@
             "description": "Workflow slug (injected by workflow-service)",
             "name": "x-workflow-slug",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug"
+            },
+            "required": false,
+            "description": "Feature slug",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StartRunBody"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Run created, campaign data returned",
@@ -1265,7 +1293,7 @@
             }
           },
           "400": {
-            "description": "Missing brandIds",
+            "description": "Missing required headers or brandIds",
             "content": {
               "application/json": {
                 "schema": {
@@ -1275,7 +1303,7 @@
             }
           },
           "404": {
-            "description": "Campaign or org not found",
+            "description": "Campaign not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1303,12 +1331,42 @@
           {
             "schema": {
               "type": "string",
+              "description": "Organization UUID (required)"
+            },
+            "required": true,
+            "description": "Organization UUID (required)",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid",
-              "description": "Campaign ID (injected by workflow-service)"
+              "description": "Campaign UUID (required)"
+            },
+            "required": true,
+            "description": "Campaign UUID (required)",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "User UUID"
             },
             "required": false,
-            "description": "Campaign ID (injected by workflow-service)",
-            "name": "x-campaign-id",
+            "description": "User UUID",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Parent run UUID"
+            },
+            "required": false,
+            "description": "Parent run UUID",
+            "name": "x-run-id",
             "in": "header"
           },
           {
@@ -1330,6 +1388,16 @@
             "required": false,
             "description": "Workflow slug (injected by workflow-service)",
             "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug"
+            },
+            "required": false,
+            "description": "Feature slug",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -13,9 +13,7 @@ import {
   GroupedStatsResponse,
   BatchBudgetUsageBody,
   ErrorResponse,
-  GateCheckBody,
   GateCheckResponse,
-  StartRunBody,
   StartRunResponse,
   EndRunBody,
   EndRunResponse,
@@ -199,11 +197,15 @@ registry.registerPath({
 
 // === PIPELINE (called by DAG via workflow-service) ===
 
-const TrackingHeaders = z.object({
-  "x-campaign-id": z.string().uuid().optional().openapi({ description: "Campaign ID (injected by workflow-service)" }),
+const PipelineHeaders = z.object({
+  "x-org-id": z.string().openapi({ description: "Organization UUID (required)" }),
+  "x-campaign-id": z.string().uuid().openapi({ description: "Campaign UUID (required)" }),
+  "x-user-id": z.string().optional().openapi({ description: "User UUID" }),
+  "x-run-id": z.string().optional().openapi({ description: "Parent run UUID" }),
   "x-brand-id": z.string().optional().openapi({ description: "Comma-separated brand UUIDs (e.g. 'uuid1,uuid2,uuid3'). Single UUID for single-brand campaigns.", example: "550e8400-e29b-41d4-a716-446655440000,6ba7b810-9dad-11d1-80b4-00c04fd430c8" }),
   "x-workflow-slug": z.string().optional().openapi({ description: "Workflow slug (injected by workflow-service)" }),
-}).openapi("TrackingHeaders");
+  "x-feature-slug": z.string().optional().openapi({ description: "Feature slug" }),
+}).openapi("PipelineHeaders");
 
 registry.registerPath({
   method: "post",
@@ -213,12 +215,12 @@ registry.registerPath({
   description: "Validates budget limits (daily/weekly/monthly/total) via runs-service stats/budget, volume limits (maxLeads), campaign status, and consecutive failures. Auto-stops the campaign if total budget or maxLeads is exceeded. Called as the first DAG node.",
   security: [{ [apiKeyAuth.name]: [] }],
   request: {
-    headers: TrackingHeaders,
-    body: { content: { "application/json": { schema: GateCheckBody } } },
+    headers: PipelineHeaders,
   },
   responses: {
     200: { description: "Gate check result", content: { "application/json": { schema: GateCheckResponse } } },
-    404: { description: "Campaign or org not found", content: { "application/json": { schema: ErrorResponse } } },
+    400: { description: "Missing required headers", content: { "application/json": { schema: ErrorResponse } } },
+    404: { description: "Campaign not found", content: { "application/json": { schema: ErrorResponse } } },
   },
 });
 
@@ -230,13 +232,12 @@ registry.registerPath({
   description: "Creates a new run in runs-service and returns all campaign data needed by downstream DAG nodes (brand-profile, fetch-lead, email-generate, etc.).",
   security: [{ [apiKeyAuth.name]: [] }],
   request: {
-    headers: TrackingHeaders,
-    body: { content: { "application/json": { schema: StartRunBody } } },
+    headers: PipelineHeaders,
   },
   responses: {
     200: { description: "Run created, campaign data returned", content: { "application/json": { schema: StartRunResponse } } },
-    400: { description: "Missing brandIds", content: { "application/json": { schema: ErrorResponse } } },
-    404: { description: "Campaign or org not found", content: { "application/json": { schema: ErrorResponse } } },
+    400: { description: "Missing required headers or brandIds", content: { "application/json": { schema: ErrorResponse } } },
+    404: { description: "Campaign not found", content: { "application/json": { schema: ErrorResponse } } },
   },
 });
 
@@ -248,7 +249,7 @@ registry.registerPath({
   description: "Finds any running runs for the campaign and marks them as completed or failed. Then re-triggers the workflow if the campaign is still ongoing. Does not require runId — finds running runs via runs-service.",
   security: [{ [apiKeyAuth.name]: [] }],
   request: {
-    headers: TrackingHeaders,
+    headers: PipelineHeaders,
     body: { content: { "application/json": { schema: EndRunBody } } },
   },
   responses: {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -58,18 +58,27 @@ export function requireOrg(
 
 /**
  * Reads optional tracking headers injected by workflow-service:
- * x-campaign-id, x-brand-id, x-workflow-slug
+ * x-org-id, x-user-id, x-run-id, x-campaign-id, x-brand-id,
+ * x-workflow-slug, x-feature-slug.
+ *
+ * Does NOT overwrite values already set by serviceAuth.
  */
 export function trackingHeaders(
   req: AuthenticatedRequest,
   _res: Response,
   next: NextFunction
 ) {
+  const orgId = req.headers["x-org-id"] as string | undefined;
+  const userId = req.headers["x-user-id"] as string | undefined;
+  const runId = req.headers["x-run-id"] as string | undefined;
   const campaignId = req.headers["x-campaign-id"] as string | undefined;
   const brandIds = parseBrandIdHeader(req.headers["x-brand-id"] as string | undefined);
   const workflowSlug = req.headers["x-workflow-slug"] as string | undefined;
   const featureSlug = req.headers["x-feature-slug"] as string | undefined;
 
+  if (orgId && !req.orgId) req.orgId = orgId;
+  if (userId && !req.userId) req.userId = userId;
+  if (runId && !req.runId) req.runId = runId;
   if (campaignId) req.campaignId = campaignId;
   if (brandIds.length > 0) req.brandIds = brandIds;
   if (workflowSlug) req.workflowSlug = workflowSlug;

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -7,7 +7,7 @@ import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun, type IdentityHeaders } from "@distribute/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
 import { executeCampaignWorkflow, validateWorkflowInputs } from "../lib/workflows.js";
-import { GateCheckBody, StartRunBody, EndRunBody } from "../schemas.js";
+import { EndRunBody } from "../schemas.js";
 
 const router = Router();
 
@@ -27,9 +27,14 @@ const router = Router();
  *   404 — campaign not found
  *   500 — internal error
  */
-router.post("/gate-check", requireApiKey, trackingHeaders, validateBody(GateCheckBody), async (req: AuthenticatedRequest, res) => {
+router.post("/gate-check", requireApiKey, trackingHeaders, async (req: AuthenticatedRequest, res) => {
   try {
-    const { campaignId, orgId } = req.body;
+    const campaignId = req.campaignId;
+    const orgId = req.orgId || (req.headers["x-org-id"] as string);
+
+    if (!campaignId || !orgId) {
+      return res.status(400).json({ error: "x-campaign-id and x-org-id headers are required" });
+    }
 
     const campaign = await db.query.campaigns.findFirst({
       where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
@@ -90,9 +95,14 @@ router.post("/gate-check", requireApiKey, trackingHeaders, validateBody(GateChec
  *   404 — campaign not found
  *   500 — internal error
  */
-router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunBody), async (req: AuthenticatedRequest, res) => {
+router.post("/start-run", requireApiKey, trackingHeaders, async (req: AuthenticatedRequest, res) => {
   try {
-    const { campaignId, orgId } = req.body;
+    const campaignId = req.campaignId;
+    const orgId = req.orgId || (req.headers["x-org-id"] as string);
+
+    if (!campaignId || !orgId) {
+      return res.status(400).json({ error: "x-campaign-id and x-org-id headers are required" });
+    }
 
     const campaign = await db.query.campaigns.findFirst({
       where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
@@ -158,14 +168,20 @@ router.post("/start-run", requireApiKey, trackingHeaders, validateBody(StartRunB
  */
 router.post("/end-run", requireApiKey, trackingHeaders, validateBody(EndRunBody), async (req: AuthenticatedRequest, res) => {
   try {
-    const { campaignId, orgId, success, leadFound } = req.body;
+    const campaignId = req.campaignId;
+    const orgId = req.orgId || (req.headers["x-org-id"] as string);
+    const { success, leadFound } = req.body;
+
+    if (!campaignId || !orgId) {
+      return res.status(400).json({ error: "x-campaign-id and x-org-id headers are required" });
+    }
 
     const status = success === true ? "completed" : "failed";
     const identity: IdentityHeaders = {
-      orgId: (req.headers["x-org-id"] as string) || orgId,
-      userId: req.headers["x-user-id"] as string | undefined,
-      runId: req.headers["x-run-id"] as string | undefined,
-      campaignId: req.campaignId,
+      orgId,
+      userId: req.userId,
+      runId: req.runId,
+      campaignId,
       brandId: req.brandIds?.join(","),
       workflowSlug: req.workflowSlug,
       featureSlug: req.featureSlug,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -135,10 +135,7 @@ export const BatchBudgetUsageBody = z.object({
 
 // --- Pipeline endpoints (called by DAG) ---
 
-export const GateCheckBody = z.object({
-  campaignId: z.string().uuid("campaignId must be a valid UUID"),
-  orgId: z.string().min(1, "orgId is required"),
-}).openapi("GateCheckBody");
+export const GateCheckBody = z.object({}).openapi("GateCheckBody");
 
 export const GateCheckResponse = z.object({
   allowed: z.boolean(),
@@ -146,10 +143,7 @@ export const GateCheckResponse = z.object({
   autoStopped: z.boolean().optional(),
 }).openapi("GateCheckResponse");
 
-export const StartRunBody = z.object({
-  campaignId: z.string().uuid("campaignId must be a valid UUID"),
-  orgId: z.string().min(1, "orgId is required"),
-}).openapi("StartRunBody");
+export const StartRunBody = z.object({}).openapi("StartRunBody");
 
 export const StartRunResponse = z.object({
   runId: z.string().uuid(),
@@ -164,8 +158,6 @@ export const StartRunResponse = z.object({
 }).openapi("StartRunResponse");
 
 export const EndRunBody = z.object({
-  campaignId: z.string().uuid("campaignId must be a valid UUID"),
-  orgId: z.string().min(1, "orgId is required"),
   success: z.boolean(),
   leadFound: z.boolean().optional(),
 }).openapi("EndRunBody");

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -66,19 +66,19 @@ describe("Pipeline routes", () => {
   // === POST /gate-check ===
 
   describe("POST /gate-check", () => {
-    it("should return 400 if campaignId is missing", async () => {
+    it("should return 400 if x-campaign-id header is missing", async () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ orgId: "some-org" })
+        .set("x-org-id", "some-org")
         .expect(400);
     });
 
-    it("should return 400 if orgId is missing", async () => {
+    it("should return 400 if x-org-id header is missing", async () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID() })
+        .set("x-campaign-id", crypto.randomUUID())
         .expect(400);
     });
 
@@ -86,7 +86,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), orgId: "nonexistent-org" })
+        .set("x-campaign-id", crypto.randomUUID())
+        .set("x-org-id", "nonexistent-org")
         .expect(404);
 
       expect(res.body.error).toBe("Campaign not found");
@@ -100,7 +101,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(res.body.allowed).toBe(true);
@@ -120,7 +122,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(res.body.allowed).toBe(false);
@@ -141,7 +144,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(res.body.allowed).toBe(false);
@@ -166,7 +170,8 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       // Verify toResumeAt was saved to the DB
@@ -191,7 +196,8 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       const updated = await db.query.campaigns.findFirst({
@@ -210,7 +216,8 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/gate-check")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(mockGateChecks).toHaveBeenCalledWith(
@@ -229,11 +236,11 @@ describe("Pipeline routes", () => {
   // === POST /start-run ===
 
   describe("POST /start-run", () => {
-    it("should return 400 if campaignId is missing", async () => {
+    it("should return 400 if x-campaign-id header is missing", async () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ orgId: "some-org" })
+        .set("x-org-id", "some-org")
         .expect(400);
     });
 
@@ -241,7 +248,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), orgId: "nonexistent-org" })
+        .set("x-campaign-id", crypto.randomUUID())
+        .set("x-org-id", "nonexistent-org")
         .expect(404);
 
       expect(res.body.error).toBe("Campaign not found");
@@ -255,7 +263,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(400);
 
       expect(res.body.error).toBe("Campaign has no brandIds");
@@ -269,7 +278,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(res.body.runId).toBe("run-123");
@@ -289,7 +299,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(res.body).not.toHaveProperty("urgency");
@@ -306,7 +317,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(res.body.searchParams).toBeNull();
@@ -321,8 +333,9 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .set("x-run-id", parentRunId)
-        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -338,7 +351,8 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -355,7 +369,8 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -371,8 +386,9 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .set("x-feature-slug", "sales-cold-email-v1")
-        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -389,8 +405,9 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .set("x-feature-slug", "header-slug")
-        .send({ campaignId: campaign.id, orgId })
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
@@ -408,7 +425,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(res.body.featureSlug).toBe("pr-media-pitch-v1");
@@ -424,7 +442,8 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(res.body.searchParams).toEqual({ mediaType: "podcast", region: "US" });
@@ -438,7 +457,8 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       expect(mockGateChecks).not.toHaveBeenCalled();
@@ -452,7 +472,8 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/start-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: campaign.id, orgId })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
         .expect(200);
 
       const callArgs = mockCreateRun.mock.calls[0][0];
@@ -463,11 +484,22 @@ describe("Pipeline routes", () => {
   // === POST /end-run ===
 
   describe("POST /end-run", () => {
-    it("should return 400 if required fields are missing", async () => {
+    it("should return 400 if success field is missing from body", async () => {
       await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
-        .send({ campaignId: crypto.randomUUID(), orgId: "org-1" })
+        .set("x-campaign-id", crypto.randomUUID())
+        .set("x-org-id", "org-1")
+        .send({})
+        .expect(400);
+    });
+
+    it("should return 400 if x-campaign-id header is missing", async () => {
+      await request(app)
+        .post("/end-run")
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org-1")
+        .send({ success: true })
         .expect(400);
     });
 
@@ -485,11 +517,9 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
-        .send({
-          campaignId: campaign.id,
-          orgId,
-          success: true,
-        })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
+        .send({ success: true })
         .expect(200);
 
       expect(res.body.status).toBe("completed");
@@ -510,11 +540,9 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
-        .send({
-          campaignId: campaign.id,
-          orgId,
-          success: false,
-        })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
+        .send({ success: false })
         .expect(200);
 
       expect(res.body.status).toBe("failed");
@@ -531,11 +559,9 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
-        .send({
-          campaignId: campaign.id,
-          orgId,
-          success: false,
-        })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
+        .send({ success: false })
         .expect(200);
 
       expect(res.body.status).toBe("failed");
@@ -560,11 +586,7 @@ describe("Pipeline routes", () => {
         .set("x-brand-id", brandIds[0])
         .set("x-campaign-id", campaign.id)
         .set("x-feature-slug", "sales-cold-email-v1")
-        .send({
-          campaignId: campaign.id,
-          orgId,
-          success: true,
-        })
+        .send({ success: true })
         .expect(200);
 
       // Wait for async re-trigger
@@ -598,11 +620,7 @@ describe("Pipeline routes", () => {
         .set("x-brand-id", brandIds[0])
         .set("x-campaign-id", campaign.id)
         .set("x-feature-slug", "sales-cold-email-v1")
-        .send({
-          campaignId: campaign.id,
-          orgId,
-          success: false,
-        })
+        .send({ success: false })
         .expect(200);
 
       // Wait for async re-trigger
@@ -623,11 +641,9 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
-        .send({
-          campaignId: campaign.id,
-          orgId,
-          success: true,
-        })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
+        .send({ success: true })
         .expect(200);
 
       await new Promise((r) => setTimeout(r, 100));
@@ -650,12 +666,9 @@ describe("Pipeline routes", () => {
       const res = await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
-        .send({
-          campaignId: campaign.id,
-          orgId,
-          success: true,
-          leadFound: false,
-        })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
+        .send({ success: true, leadFound: false })
         .expect(200);
 
       expect(res.body.status).toBe("completed");
@@ -690,12 +703,7 @@ describe("Pipeline routes", () => {
         .set("x-brand-id", brandIds[0])
         .set("x-campaign-id", campaign.id)
         .set("x-feature-slug", "sales-cold-email-v1")
-        .send({
-          campaignId: campaign.id,
-          orgId,
-          success: true,
-          leadFound: true,
-        })
+        .send({ success: true, leadFound: true })
         .expect(200);
 
       // Wait for async re-trigger
@@ -720,11 +728,9 @@ describe("Pipeline routes", () => {
       await request(app)
         .post("/end-run")
         .set("x-api-key", API_KEY)
-        .send({
-          campaignId: campaign.id,
-          orgId,
-          success: true,
-        })
+        .set("x-campaign-id", campaign.id)
+        .set("x-org-id", orgId)
+        .send({ success: true })
         .expect(200);
 
       const callArgs = mockListRuns.mock.calls[0][0];


### PR DESCRIPTION
## Summary
- Removed `campaignId` and `orgId` from the request body of `/gate-check`, `/start-run`, and `/end-run`
- These values now come exclusively from `x-campaign-id` and `x-org-id` headers (already injected by workflow-service)
- Updated OpenAPI spec with required `PipelineHeaders` schema including all tracking headers

## Breaking change
Callers must send `x-campaign-id` and `x-org-id` as headers instead of JSON body fields. The `/end-run` body is now just `{ success, leadFound? }`.

## Test plan
- [x] All 84 unit tests pass
- [x] Header validation tests (400 on missing headers) pass
- [x] Integration test failures are pre-existing (test DB missing `brand_ids` column)
- [x] Build + OpenAPI generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)