### PR TITLE
fix: gate-check race condition in /end-run re-trigger

### DIFF
--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -232,18 +232,10 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
         return;
       }
 
-      // Create a new run for the re-trigger, linked to the campaign's parentRunId
-      const newRun = await createRun({
-        orgId,
-        serviceName: "campaign-service",
-        taskName: campaignId,
-        campaignId,
-        brandId: brandIdCsv,
-        userId,
-        parentRunId: freshCampaign.parentRunId || undefined,
-        workflowSlug: freshCampaign.workflowSlug,
-        featureSlug,
-      });
+      // Do NOT create a run here — /start-run in the new workflow will create it.
+      // Creating one here causes a race: gate-check in the new workflow sees it as
+      // "running" and blocks with "A run is already in progress".
+      const runId = freshCampaign.parentRunId || crypto.randomUUID();
 
       // Fire-and-forget: gate-check in the next workflow execution will validate limits
       executeCampaignWorkflow(freshCampaign.workflowSlug, {
@@ -251,7 +243,7 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
         orgId,
         brandId: brandIdCsv,
         userId,
-        runId: newRun.id,
+        runId,
         featureSlug,
       }).catch((err) => {
         console.error(`[End Run] Re-trigger failed for campaign ${campaignId}:`, err);

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -572,7 +572,9 @@ describe("Pipeline routes", () => {
       // Wait for async re-trigger
       await new Promise((r) => setTimeout(r, 100));
 
-      expect(mockCreateRun).toHaveBeenCalled();
+      // end-run must NOT create a run — /start-run in the new workflow handles that.
+      // Creating one here would cause gate-check to block with "A run is already in progress".
+      expect(mockCreateRun).not.toHaveBeenCalled();
       expect(mockExecute).toHaveBeenCalledWith(
         "sales-email-cold-outreach",
         expect.objectContaining({
@@ -582,7 +584,7 @@ describe("Pipeline routes", () => {
       );
     });
 
-    it("should create a new run for re-trigger with parentRunId from campaign", async () => {
+    it("should use parentRunId from campaign as runId for re-trigger", async () => {
       const parentRunId = crypto.randomUUID();
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
@@ -601,8 +603,9 @@ describe("Pipeline routes", () => {
 
       await new Promise((r) => setTimeout(r, 100));
 
-      expect(mockCreateRun).toHaveBeenCalledWith(
-        expect.objectContaining({ parentRunId }),
+      expect(mockExecute).toHaveBeenCalledWith(
+        "sales-email-cold-outreach",
+        expect.objectContaining({ runId: parentRunId }),
       );
     });
 


### PR DESCRIPTION
## Summary

- `/end-run` was creating a new run (status=running) via `createRun()` before re-triggering the workflow
- The new workflow's `/gate-check` found this run and blocked with "A run is already in progress"
- Fix: removed `createRun()` from `/end-run` — the new workflow's `/start-run` node handles run creation instead

This was the root cause of campaigns stopping after the first successful email send.

## Test plan
- [x] 194 tests pass
- [x] Test updated: end-run must NOT call createRun
- [x] Test added: end-run passes parentRunId as runId to re-triggered workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)