### PR TITLE
fix: use resolved workflow slug from header in /start-run

### DIFF
--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -123,7 +123,7 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       brandId: brandIdCsv,
       userId: campaign.createdByUserId || undefined,
       parentRunId: parentRunId || undefined,
-      workflowSlug: campaign.workflowSlug,
+      workflowSlug: req.workflowSlug || campaign.workflowSlug,
       featureSlug,
     });
     // Build searchParams from featureInputs

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -353,10 +353,10 @@ describe("Pipeline routes", () => {
       );
     });
 
-    it("should pass workflowSlug to createRun", async () => {
+    it("should fall back to campaign.workflowSlug when header matches DB", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
-        workflowSlug: "pr-email-cold-outreach",
+        workflowSlug: "sales-email-cold-outreach",
       });
 
       await request(app)
@@ -365,7 +365,27 @@ describe("Pipeline routes", () => {
         .expect(200);
 
       expect(mockCreateRun).toHaveBeenCalledWith(
-        expect.objectContaining({ workflowSlug: "pr-email-cold-outreach" }),
+        expect.objectContaining({ workflowSlug: "sales-email-cold-outreach" }),
+      );
+    });
+
+    it("should prefer x-workflow-slug header over campaign.workflowSlug for createRun", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        workflowSlug: "pr-cold-email-outreach-sophia-mistral",
+      });
+
+      await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({
+          "x-org-id": orgId,
+          "x-campaign-id": campaign.id,
+          "x-workflow-slug": "pr-cold-email-outreach-sophia-mistral-v3",
+        }))
+        .expect(200);
+
+      expect(mockCreateRun).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowSlug: "pr-cold-email-outreach-sophia-mistral-v3" }),
       );
     });
 


### PR DESCRIPTION
## Summary
- `/start-run` was using `campaign.workflowSlug` (stale DB value) when creating child runs via runs-service
- When workflow-service upgrades a deprecated slug (e.g. `v1` → `v3`), the parent run has the resolved slug, causing a 409 parent-child conflict
- Now prefers `x-workflow-slug` header (set by workflow-service after slug resolution) over the DB value, matching the existing pattern in `/gate-check`

## Test plan
- [x] Added regression test: header slug differs from DB slug → header wins
- [x] Updated existing test to reflect new precedence behavior
- [x] All 41 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)