### PR TITLE
debug: log x-org-id on campaign 404

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -124,6 +124,7 @@ router.get("/campaigns/:id", requireApiKey, serviceAuth, async (req: Authenticat
     });
 
     if (!campaign) {
+      console.warn(`[campaign-service] GET /campaigns/:id 404 — id=${id}, x-org-id=${req.orgId}`);
       return res.status(404).json({ error: "Campaign not found" });
     }
 


### PR DESCRIPTION
## Summary
- Adds a `console.warn` on GET /campaigns/:id 404 to log the received `x-org-id` — needed to trace an org mismatch causing spurious 404s.
- Temporary debug log, will remove once root cause is identified.

## Test plan
- [ ] Deploy to staging, reproduce the 404, check Railway logs for the logged org ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)