### PR TITLE
feat: transfer-brand — rename brandId, add targetBrandId

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -516,7 +516,7 @@
       "TransferBrandBody": {
         "type": "object",
         "properties": {
-          "brandId": {
+          "sourceBrandId": {
             "type": "string",
             "format": "uuid"
           },
@@ -527,10 +527,14 @@
           "targetOrgId": {
             "type": "string",
             "minLength": 1
+          },
+          "targetBrandId": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": [
-          "brandId",
+          "sourceBrandId",
           "sourceOrgId",
           "targetOrgId"
         ]

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -261,20 +261,25 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
  * POST /internal/transfer-brand
  *
  * Transfers all solo-brand campaigns from one org to another.
- * Solo-brand = brand_ids array contains exactly one element matching brandId.
+ * Solo-brand = brand_ids array contains exactly one element matching sourceBrandId.
  * Skips co-branding rows (multiple brand IDs).
+ * When targetBrandId is provided, also rewrites brand_ids to the new brand.
  * Idempotent: re-running with same params is a no-op.
  */
 router.post("/internal/transfer-brand", requireApiKey, validateBody(TransferBrandBody), async (req, res) => {
   try {
-    const { brandId, sourceOrgId, targetOrgId } = req.body;
+    const { sourceBrandId, sourceOrgId, targetOrgId, targetBrandId } = req.body;
+
+    const newBrandId = targetBrandId ?? sourceBrandId;
 
     const result = await db.execute(
       sql`WITH updated AS (
             UPDATE campaigns
-            SET org_id = ${targetOrgId}, updated_at = NOW()
+            SET org_id = ${targetOrgId},
+                brand_ids = ARRAY[${newBrandId}]::text[],
+                updated_at = NOW()
             WHERE org_id = ${sourceOrgId}
-              AND brand_ids = ARRAY[${brandId}]::text[]
+              AND brand_ids = ARRAY[${sourceBrandId}]::text[]
             RETURNING id
           )
           SELECT count(*)::int AS cnt FROM updated`
@@ -282,7 +287,7 @@ router.post("/internal/transfer-brand", requireApiKey, validateBody(TransferBran
 
     const count = Number((result as unknown as Array<{ cnt: number }>)[0]?.cnt ?? 0);
 
-    console.log(`[campaign-service] transfer-brand: updated ${count} campaigns (brandId=${brandId}, ${sourceOrgId} -> ${targetOrgId})`);
+    console.log(`[campaign-service] transfer-brand: updated ${count} campaigns (sourceBrandId=${sourceBrandId}, targetBrandId=${newBrandId}, ${sourceOrgId} -> ${targetOrgId})`);
 
     res.json({
       updatedTables: [{ tableName: "campaigns", count }],

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -170,9 +170,10 @@ export const EndRunResponse = z.object({
 // --- Internal: Brand Transfer ---
 
 export const TransferBrandBody = z.object({
-  brandId: z.string().uuid(),
+  sourceBrandId: z.string().uuid(),
   sourceOrgId: z.string().min(1),
   targetOrgId: z.string().min(1),
+  targetBrandId: z.string().uuid().optional(),
 }).openapi("TransferBrandBody");
 
 export const TransferBrandResponse = z.object({

--- a/tests/integration/transfer-brand.test.ts
+++ b/tests/integration/transfer-brand.test.ts
@@ -29,7 +29,8 @@ const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 describe("POST /internal/transfer-brand", () => {
   const sourceOrgId = "org_source_test";
   const targetOrgId = "org_target_test";
-  const brandId = crypto.randomUUID();
+  const sourceBrandId = crypto.randomUUID();
+  const targetBrandId = crypto.randomUUID();
   const otherBrandId = crypto.randomUUID();
 
   beforeEach(async () => {
@@ -41,41 +42,64 @@ describe("POST /internal/transfer-brand", () => {
     await closeDb();
   });
 
-  it("transfers solo-brand campaigns from source to target org", async () => {
-    // Insert a solo-brand campaign matching the brandId
+  it("transfers solo-brand campaigns from source to target org (no targetBrandId)", async () => {
     const campaign = await insertTestCampaign(sourceOrgId, {
       name: "Solo Brand Campaign",
-      brandIds: [brandId],
+      brandIds: [sourceBrandId],
     });
 
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set("x-api-key", API_KEY)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
       { tableName: "campaigns", count: 1 },
     ]);
 
-    // Verify the campaign now belongs to targetOrgId
+    // Verify the campaign now belongs to targetOrgId with same brand
     const updated = await db.query.campaigns.findFirst({
       where: eq(campaigns.id, campaign.id),
     });
     expect(updated!.orgId).toBe(targetOrgId);
+    expect(updated!.brandIds).toEqual([sourceBrandId]);
   });
 
-  it("skips co-branding campaigns (multiple brand IDs)", async () => {
-    // Insert a co-branding campaign with brandId + another
-    await insertTestCampaign(sourceOrgId, {
-      name: "Co-Brand Campaign",
-      brandIds: [brandId, otherBrandId],
+  it("transfers and remaps brand when targetBrandId is provided", async () => {
+    const campaign = await insertTestCampaign(sourceOrgId, {
+      name: "Remap Brand Campaign",
+      brandIds: [sourceBrandId],
     });
 
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set("x-api-key", API_KEY)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId, targetBrandId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updatedTables).toEqual([
+      { tableName: "campaigns", count: 1 },
+    ]);
+
+    // Verify org AND brand were updated
+    const updated = await db.query.campaigns.findFirst({
+      where: eq(campaigns.id, campaign.id),
+    });
+    expect(updated!.orgId).toBe(targetOrgId);
+    expect(updated!.brandIds).toEqual([targetBrandId]);
+  });
+
+  it("skips co-branding campaigns (multiple brand IDs)", async () => {
+    await insertTestCampaign(sourceOrgId, {
+      name: "Co-Brand Campaign",
+      brandIds: [sourceBrandId, otherBrandId],
+    });
+
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set("x-api-key", API_KEY)
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
@@ -86,13 +110,13 @@ describe("POST /internal/transfer-brand", () => {
   it("skips campaigns belonging to a different org", async () => {
     await insertTestCampaign("org_other", {
       name: "Other Org Campaign",
-      brandIds: [brandId],
+      brandIds: [sourceBrandId],
     });
 
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set("x-api-key", API_KEY)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
@@ -109,7 +133,7 @@ describe("POST /internal/transfer-brand", () => {
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set("x-api-key", API_KEY)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
@@ -120,14 +144,14 @@ describe("POST /internal/transfer-brand", () => {
   it("is idempotent — second run is a no-op", async () => {
     await insertTestCampaign(sourceOrgId, {
       name: "Idempotent Campaign",
-      brandIds: [brandId],
+      brandIds: [sourceBrandId],
     });
 
     // First call transfers
     const res1 = await request(app)
       .post("/internal/transfer-brand")
       .set("x-api-key", API_KEY)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res1.body.updatedTables[0].count).toBe(1);
 
@@ -135,7 +159,30 @@ describe("POST /internal/transfer-brand", () => {
     const res2 = await request(app)
       .post("/internal/transfer-brand")
       .set("x-api-key", API_KEY)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.updatedTables[0].count).toBe(0);
+  });
+
+  it("is idempotent with targetBrandId — second run is a no-op", async () => {
+    await insertTestCampaign(sourceOrgId, {
+      name: "Idempotent Remap Campaign",
+      brandIds: [sourceBrandId],
+    });
+
+    const res1 = await request(app)
+      .post("/internal/transfer-brand")
+      .set("x-api-key", API_KEY)
+      .send({ sourceBrandId, sourceOrgId, targetOrgId, targetBrandId });
+
+    expect(res1.body.updatedTables[0].count).toBe(1);
+
+    // Second call: sourceBrandId no longer exists in source org
+    const res2 = await request(app)
+      .post("/internal/transfer-brand")
+      .set("x-api-key", API_KEY)
+      .send({ sourceBrandId, sourceOrgId, targetOrgId, targetBrandId });
 
     expect(res2.status).toBe(200);
     expect(res2.body.updatedTables[0].count).toBe(0);
@@ -144,22 +191,22 @@ describe("POST /internal/transfer-brand", () => {
   it("transfers multiple matching campaigns at once", async () => {
     await insertTestCampaign(sourceOrgId, {
       name: "Campaign A",
-      brandIds: [brandId],
+      brandIds: [sourceBrandId],
     });
     await insertTestCampaign(sourceOrgId, {
       name: "Campaign B",
-      brandIds: [brandId],
+      brandIds: [sourceBrandId],
     });
     // This one should NOT be transferred (co-brand)
     await insertTestCampaign(sourceOrgId, {
       name: "Campaign C Co-Brand",
-      brandIds: [brandId, otherBrandId],
+      brandIds: [sourceBrandId, otherBrandId],
     });
 
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set("x-api-key", API_KEY)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables[0].count).toBe(2);
@@ -169,7 +216,16 @@ describe("POST /internal/transfer-brand", () => {
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set("x-api-key", API_KEY)
-      .send({ brandId: "not-a-uuid" });
+      .send({ sourceBrandId: "not-a-uuid" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid targetBrandId", async () => {
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set("x-api-key", API_KEY)
+      .send({ sourceBrandId, sourceOrgId, targetOrgId, targetBrandId: "not-a-uuid" });
 
     expect(res.status).toBe(400);
   });
@@ -177,7 +233,7 @@ describe("POST /internal/transfer-brand", () => {
   it("returns 401 without API key", async () => {
     const res = await request(app)
       .post("/internal/transfer-brand")
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(401);
   });


### PR DESCRIPTION
## Summary

- **Breaking change** to `POST /internal/transfer-brand`:
  - `brandId` → `sourceBrandId` (renamed)
  - `targetBrandId` (new, optional) — when present, rewrites `brand_ids` to the target brand ID in addition to changing `org_id`
- Fixes brand transfers where the target org has a different brand ID for the same domain (brand IDs are not cross-org unique)

## Test plan

- [x] Existing transfer tests updated and passing (11 tests)
- [x] New test: transfer with `targetBrandId` verifies both `org_id` and `brand_ids` are rewritten
- [x] New test: idempotency with `targetBrandId`
- [x] New test: invalid `targetBrandId` returns 400
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)