### PR TITLE
fix: transfer-brand two-step update

### DIFF
--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -263,20 +263,22 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
  * Transfers all solo-brand campaigns from one org to another.
  * Solo-brand = brand_ids array contains exactly one element matching sourceBrandId.
  * Skips co-branding rows (multiple brand IDs).
- * When targetBrandId is provided, also rewrites brand_ids to the new brand.
+ *
+ * Two-step process:
+ *   Step 1: UPDATE org_id WHERE brand_ids = [sourceBrandId] AND org_id = sourceOrgId
+ *   Step 2 (when targetBrandId present): UPDATE brand_ids WHERE brand_ids = [sourceBrandId] (no org filter)
+ *
  * Idempotent: re-running with same params is a no-op.
  */
 router.post("/internal/transfer-brand", requireApiKey, validateBody(TransferBrandBody), async (req, res) => {
   try {
     const { sourceBrandId, sourceOrgId, targetOrgId, targetBrandId } = req.body;
 
-    const newBrandId = targetBrandId ?? sourceBrandId;
-
-    const result = await db.execute(
+    // Step 1: Move matching rows to target org
+    const step1 = await db.execute(
       sql`WITH updated AS (
             UPDATE campaigns
             SET org_id = ${targetOrgId},
-                brand_ids = ARRAY[${newBrandId}]::text[],
                 updated_at = NOW()
             WHERE org_id = ${sourceOrgId}
               AND brand_ids = ARRAY[${sourceBrandId}]::text[]
@@ -285,12 +287,30 @@ router.post("/internal/transfer-brand", requireApiKey, validateBody(TransferBran
           SELECT count(*)::int AS cnt FROM updated`
     );
 
-    const count = Number((result as unknown as Array<{ cnt: number }>)[0]?.cnt ?? 0);
+    const movedCount = Number((step1 as unknown as Array<{ cnt: number }>)[0]?.cnt ?? 0);
 
-    console.log(`[campaign-service] transfer-brand: updated ${count} campaigns (sourceBrandId=${sourceBrandId}, targetBrandId=${newBrandId}, ${sourceOrgId} -> ${targetOrgId})`);
+    // Step 2: Rewrite brand_ids (no org filter — catches all rows with sourceBrandId)
+    let remappedCount = 0;
+    if (targetBrandId) {
+      const step2 = await db.execute(
+        sql`WITH updated AS (
+              UPDATE campaigns
+              SET brand_ids = ARRAY[${targetBrandId}]::text[],
+                  updated_at = NOW()
+              WHERE brand_ids = ARRAY[${sourceBrandId}]::text[]
+              RETURNING id
+            )
+            SELECT count(*)::int AS cnt FROM updated`
+      );
+      remappedCount = Number((step2 as unknown as Array<{ cnt: number }>)[0]?.cnt ?? 0);
+    }
+
+    const totalCount = Math.max(movedCount, remappedCount);
+
+    console.log(`[campaign-service] transfer-brand: moved ${movedCount}, remapped ${remappedCount} campaigns (sourceBrandId=${sourceBrandId}, targetBrandId=${targetBrandId ?? "none"}, ${sourceOrgId} -> ${targetOrgId})`);
 
     res.json({
-      updatedTables: [{ tableName: "campaigns", count }],
+      updatedTables: [{ tableName: "campaigns", count: totalCount }],
     });
   } catch (error) {
     console.error("[campaign-service] transfer-brand error:", error);

--- a/tests/integration/transfer-brand.test.ts
+++ b/tests/integration/transfer-brand.test.ts
@@ -212,6 +212,44 @@ describe("POST /internal/transfer-brand", () => {
     expect(res.body.updatedTables[0].count).toBe(2);
   });
 
+  it("step 2 remaps brand_ids across all orgs (no org filter)", async () => {
+    // Campaign in source org — step 1 moves it, step 2 remaps it
+    const campaignSource = await insertTestCampaign(sourceOrgId, {
+      name: "Source Org Campaign",
+      brandIds: [sourceBrandId],
+    });
+
+    // Campaign in a third org with same sourceBrandId — step 1 skips it, step 2 remaps it
+    const thirdOrgId = "org_third_test";
+    const campaignThird = await insertTestCampaign(thirdOrgId, {
+      name: "Third Org Campaign",
+      brandIds: [sourceBrandId],
+    });
+
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set("x-api-key", API_KEY)
+      .send({ sourceBrandId, sourceOrgId, targetOrgId, targetBrandId });
+
+    expect(res.status).toBe(200);
+    // count reflects max(step1=1, step2=2) = 2
+    expect(res.body.updatedTables[0].count).toBe(2);
+
+    // Source campaign: moved to targetOrg AND brand remapped
+    const updatedSource = await db.query.campaigns.findFirst({
+      where: eq(campaigns.id, campaignSource.id),
+    });
+    expect(updatedSource!.orgId).toBe(targetOrgId);
+    expect(updatedSource!.brandIds).toEqual([targetBrandId]);
+
+    // Third org campaign: stayed in thirdOrg but brand was remapped
+    const updatedThird = await db.query.campaigns.findFirst({
+      where: eq(campaigns.id, campaignThird.id),
+    });
+    expect(updatedThird!.orgId).toBe(thirdOrgId);
+    expect(updatedThird!.brandIds).toEqual([targetBrandId]);
+  });
+
   it("returns 400 for invalid body", async () => {
     const res = await request(app)
       .post("/internal/transfer-brand")


### PR DESCRIPTION
## Summary

- Split transfer-brand into two separate UPDATE steps:
  - **Step 1:** `UPDATE org_id` WHERE `brand_ids = [sourceBrandId] AND org_id = sourceOrgId`
  - **Step 2:** `UPDATE brand_ids` WHERE `brand_ids = [sourceBrandId]` — no org filter
- New test: verifies step 2 remaps brand_ids across all orgs

## Test plan

- [x] 12/12 transfer-brand tests pass
- [x] New test: "step 2 remaps brand_ids across all orgs (no org filter)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)