### PR TITLE
hotfix: Remove consecutive failures gate that falsely auto-stops campaigns

### DIFF
--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -4,7 +4,6 @@ import { campaigns } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 
 const STALE_THRESHOLD_MS = 3 * 60 * 60 * 1000; // 3 hours
-const MAX_CONSECUTIVE_FAILURES = 10;
 
 export interface GateCheckInput {
   campaignId: string;
@@ -136,20 +135,6 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
       await autoStopCampaign(campaign.campaignId);
       return { allowed: false, reason: "Max leads reached", autoStopped: true };
     }
-  }
-
-  // 5. Consecutive failures check
-  const sortedRuns = [...runs].sort((a, b) =>
-    new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
-  );
-  let consecutiveFailures = 0;
-  for (const run of sortedRuns) {
-    if (run.status === "failed") consecutiveFailures++;
-    else break;
-  }
-  if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-    await autoStopCampaign(campaign.campaignId);
-    return { allowed: false, reason: `${MAX_CONSECUTIVE_FAILURES} consecutive failures`, autoStopped: true };
   }
 
   return { allowed: true };

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -305,42 +305,6 @@ describe("Gate Check", () => {
     });
   });
 
-  describe("Consecutive failures check", () => {
-    it("should auto-stop after 10 consecutive failures", async () => {
-      const runs = Array.from({ length: 10 }, (_, i) =>
-        makeRun({ id: `r${i + 1}`, status: "failed", startedAt: new Date(Date.now() - (i + 1) * 1000).toISOString() })
-      );
-      mockListRuns.mockResolvedValue({ runs });
-
-      const result = await runGateChecks(makeCampaign());
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toBe("10 consecutive failures");
-      expect(result.autoStopped).toBe(true);
-    });
-
-    it("should allow when failures are not consecutive", async () => {
-      const runs = [
-        makeRun({ id: "r1", status: "failed", startedAt: new Date(Date.now() - 1000).toISOString() }),
-        makeRun({ id: "r2", status: "completed", startedAt: new Date(Date.now() - 2000).toISOString() }),
-        makeRun({ id: "r3", status: "failed", startedAt: new Date(Date.now() - 3000).toISOString() }),
-      ];
-      mockListRuns.mockResolvedValue({ runs });
-
-      const result = await runGateChecks(makeCampaign());
-      expect(result.allowed).toBe(true);
-    });
-
-    it("should allow when fewer than 10 consecutive failures", async () => {
-      const runs = Array.from({ length: 9 }, (_, i) =>
-        makeRun({ id: `r${i + 1}`, status: "failed", startedAt: new Date(Date.now() - (i + 1) * 1000).toISOString() })
-      );
-      mockListRuns.mockResolvedValue({ runs });
-
-      const result = await runGateChecks(makeCampaign());
-      expect(result.allowed).toBe(true);
-    });
-  });
-
   describe("toResumeAt on temporal budget exceeded", () => {
     it("should return toResumeAt when daily budget is exceeded", async () => {
       mockGetStatsBudget.mockResolvedValue(


### PR DESCRIPTION
Automated by release.sh