### PR TITLE
fix: replace fire-and-forget re-trigger with toResumeAt

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -1,6 +1,6 @@
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
-import { eq, and, lte, isNotNull } from "drizzle-orm";
+import { eq, and, lte, isNotNull, isNull } from "drizzle-orm";
 import { executeCampaignWorkflow } from "./workflows.js";
 
 const SCHEDULER_INTERVAL_MS = 60_000; // 1 minute
@@ -79,6 +79,31 @@ export async function resumeDueCampaigns(): Promise<number> {
   return dueCampaigns.length;
 }
 
+/**
+ * Heartbeat: detect ongoing campaigns with no toResumeAt (stuck campaigns).
+ * Sets toResumeAt = now so the next tick picks them up via resumeDueCampaigns.
+ */
+export async function claimStuckCampaigns(): Promise<number> {
+  const now = new Date();
+
+  const stuck = await db
+    .update(campaigns)
+    .set({ toResumeAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(campaigns.status, "ongoing"),
+        isNull(campaigns.toResumeAt),
+      ),
+    )
+    .returning({ id: campaigns.id });
+
+  if (stuck.length > 0) {
+    console.warn(`[campaign-service] Heartbeat: claimed ${stuck.length} stuck campaign(s): ${stuck.map((c) => c.id).join(", ")}`);
+  }
+
+  return stuck.length;
+}
+
 /** Tracks whether a scheduler tick is currently running. */
 let isRunning = false;
 
@@ -97,7 +122,8 @@ export function startScheduler(): () => void {
       return;
     }
     isRunning = true;
-    resumeDueCampaigns()
+    claimStuckCampaigns()
+      .then(() => resumeDueCampaigns())
       .catch((err) => {
         console.error("[campaign-service] Unhandled error:", err);
       })

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -6,7 +6,6 @@ import { requireApiKey, requirePipelineHeaders, trackingHeaders, type Authentica
 import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun, type IdentityHeaders } from "@distribute/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
-import { executeCampaignWorkflow } from "../lib/workflows.js";
 import { EndRunBody, TransferBrandBody } from "../schemas.js";
 import { traceEvent } from "../lib/trace-event.js";
 
@@ -260,9 +259,9 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       return;
     }
 
-    // Re-trigger if campaign is still ongoing
+    // Schedule re-trigger via toResumeAt — the scheduler picks it up on the next tick.
+    // This prevents exponential cascades when downstream services are down.
     try {
-      // Re-fetch campaign for fresh status and stored data
       const freshCampaign = await db.query.campaigns.findFirst({
         where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
       });
@@ -270,43 +269,26 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
         return;
       }
 
-      // Resolve all fields from the campaign DB record — no dependence on forwarded headers
-      const brandIdCsv = (freshCampaign.brandIds ?? []).join(",");
-      const userId = freshCampaign.createdByUserId;
-      const featureSlug = freshCampaign.featureSlug;
-
-      if (!brandIdCsv || !userId || !featureSlug) {
-        console.warn(`[campaign-service] Cannot re-trigger campaign ${campaignId} — missing campaign data: brandIds=${!!brandIdCsv}, userId=${!!userId}, featureSlug=${!!featureSlug}`);
-        return;
-      }
-
-      // Do NOT create a run here — /start-run in the new workflow will create it.
-      // Creating one here causes a race: gate-check in the new workflow sees it as
-      // "running" and blocks with "A run is already in progress".
-      const runId = freshCampaign.parentRunId || crypto.randomUUID();
+      // Failed runs get a 60s backoff; completed runs resume immediately
+      const delayMs = status === "failed" ? 60_000 : 0;
+      const toResumeAt = new Date(Date.now() + delayMs);
 
       if (req.runId) {
         traceEvent(req.runId, {
           service: "campaign-service",
-          event: "re-trigger",
-          detail: `Re-triggering workflow "${freshCampaign.workflowSlug}" for campaign ${campaignId} — brandIds=[${brandIdCsv}], userId=${userId}, featureSlug=${featureSlug}`,
-          data: { campaignId, workflowSlug: freshCampaign.workflowSlug, brandIdCsv, userId, featureSlug },
+          event: "re-trigger-scheduled",
+          detail: `Scheduled re-trigger for campaign ${campaignId} via toResumeAt=${toResumeAt.toISOString()} (delay=${delayMs}ms)`,
+          data: { campaignId, toResumeAt: toResumeAt.toISOString(), delayMs },
         }, req.headers).catch(() => {});
       }
 
-      // Fire-and-forget: gate-check in the next workflow execution will validate limits
-      executeCampaignWorkflow(freshCampaign.workflowSlug, {
-        campaignId,
-        orgId,
-        brandId: brandIdCsv,
-        userId,
-        runId,
-        featureSlug,
-      }).catch((err) => {
-        console.error(`[campaign-service] Re-trigger failed for campaign ${campaignId}:`, err);
-      });
+      await db.update(campaigns)
+        .set({ toResumeAt, updatedAt: new Date() })
+        .where(eq(campaigns.id, campaignId));
+
+      console.log(`[campaign-service] Set toResumeAt=${toResumeAt.toISOString()} for campaign ${campaignId} (status=${status})`);
     } catch (err) {
-      console.error(`[campaign-service] Re-trigger check failed:`, err);
+      console.error(`[campaign-service] Failed to schedule re-trigger for campaign ${campaignId}:`, err);
     }
   } catch (error) {
     console.error("[campaign-service] Unhandled error:", error);

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -574,7 +574,7 @@ describe("Pipeline routes", () => {
       expect(mockUpdateRun).not.toHaveBeenCalled();
     });
 
-    it("should re-trigger workflow when stopCampaign is false and campaign is ongoing", async () => {
+    it("should set toResumeAt=now when success=true stopCampaign=false and campaign is ongoing", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "ongoing",
@@ -583,53 +583,60 @@ describe("Pipeline routes", () => {
         createdByUserId: "user_test",
       });
 
+      const before = Date.now();
+
       await request(app)
         .post("/end-run")
         .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
         .send({ success: true, stopCampaign: false })
         .expect(200);
 
-      // Wait for async re-trigger
+      // Wait for async toResumeAt update
       await new Promise((r) => setTimeout(r, 100));
 
-      // end-run must NOT create a run — /start-run in the new workflow handles that.
-      // Creating one here would cause gate-check to block with "A run is already in progress".
-      expect(mockCreateRun).not.toHaveBeenCalled();
-      expect(mockExecute).toHaveBeenCalledWith(
-        "sales-email-cold-outreach",
-        expect.objectContaining({
-          campaignId: campaign.id,
-          orgId,
-        }),
-      );
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.toResumeAt).not.toBeNull();
+      const resumeTime = new Date(updated!.toResumeAt!).getTime();
+      // Should be ~now (within 5s tolerance)
+      expect(resumeTime).toBeGreaterThanOrEqual(before);
+      expect(resumeTime).toBeLessThan(before + 5_000);
+      // Must NOT fire-and-forget
+      expect(mockExecute).not.toHaveBeenCalled();
     });
 
-    it("should use parentRunId from campaign as runId for re-trigger", async () => {
-      const parentRunId = crypto.randomUUID();
+    it("should set toResumeAt=now+60s when success=false stopCampaign=false and campaign is ongoing", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "ongoing",
         workflowSlug: "sales-email-cold-outreach",
         featureSlug: "sales-cold-email-v1",
         createdByUserId: "user_test",
-        parentRunId,
       });
+
+      const before = Date.now();
 
       await request(app)
         .post("/end-run")
         .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
-        .send({ success: true, stopCampaign: false })
+        .send({ success: false, stopCampaign: false })
         .expect(200);
 
       await new Promise((r) => setTimeout(r, 100));
 
-      expect(mockExecute).toHaveBeenCalledWith(
-        "sales-email-cold-outreach",
-        expect.objectContaining({ runId: parentRunId }),
-      );
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.toResumeAt).not.toBeNull();
+      const resumeTime = new Date(updated!.toResumeAt!).getTime();
+      // Should be ~now + 60s (within 5s tolerance)
+      expect(resumeTime).toBeGreaterThanOrEqual(before + 55_000);
+      expect(resumeTime).toBeLessThan(before + 65_000);
+      expect(mockExecute).not.toHaveBeenCalled();
     });
 
-    it("should NOT re-trigger if campaign is stopped", async () => {
+    it("should NOT set toResumeAt if campaign is stopped", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "stopped",
@@ -643,6 +650,10 @@ describe("Pipeline routes", () => {
 
       await new Promise((r) => setTimeout(r, 100));
 
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.toResumeAt).toBeNull();
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
@@ -673,14 +684,15 @@ describe("Pipeline routes", () => {
       // Should NOT re-trigger
       expect(mockExecute).not.toHaveBeenCalled();
 
-      // Should auto-stop in DB
+      // Should auto-stop in DB and NOT set toResumeAt
       const updated = await db.query.campaigns.findFirst({
         where: eq(campaigns.id, campaign.id),
       });
       expect(updated!.status).toBe("stopped");
+      expect(updated!.toResumeAt).toBeNull();
     });
 
-    it("should re-trigger normally when stopCampaign is false", async () => {
+    it("should set toResumeAt and NOT fire-and-forget when stopCampaign is false", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "ongoing",
@@ -700,16 +712,13 @@ describe("Pipeline routes", () => {
         .send({ success: true, stopCampaign: false })
         .expect(200);
 
-      // Wait for async re-trigger
       await new Promise((r) => setTimeout(r, 100));
 
-      expect(mockExecute).toHaveBeenCalledWith(
-        "sales-email-cold-outreach",
-        expect.objectContaining({
-          campaignId: campaign.id,
-          orgId,
-        }),
-      );
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.toResumeAt).not.toBeNull();
+      expect(mockExecute).not.toHaveBeenCalled();
     });
 
     it("should not pass appId to listRuns", async () => {

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -46,9 +46,10 @@ vi.mock("drizzle-orm", () => ({
   and: vi.fn(),
   lte: vi.fn(),
   isNotNull: vi.fn(),
+  isNull: vi.fn(),
 }));
 
-import { resumeDueCampaigns } from "../../src/lib/scheduler.js";
+import { resumeDueCampaigns, claimStuckCampaigns } from "../../src/lib/scheduler.js";
 
 describe("Scheduler - resumeDueCampaigns", () => {
   beforeEach(() => {
@@ -249,5 +250,27 @@ describe("Scheduler - resumeDueCampaigns", () => {
 
     expect(count).toBe(2);
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("Scheduler - claimStuckCampaigns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbReturning.mockResolvedValue([]);
+  });
+
+  it("should return 0 when no stuck campaigns exist", async () => {
+    const count = await claimStuckCampaigns();
+    expect(count).toBe(0);
+  });
+
+  it("should claim stuck campaigns and return the count", async () => {
+    mockDbReturning.mockResolvedValue([
+      { id: "stuck-campaign-1" },
+      { id: "stuck-campaign-2" },
+    ]);
+
+    const count = await claimStuckCampaigns();
+    expect(count).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- **Removes fire-and-forget `executeCampaignWorkflow()`** from `/end-run` — this caused exponential cascades (60+ workflows in 20s) when downstream services went down
- **`/end-run` with `success=true`** → sets `toResumeAt = now` (scheduler picks up next tick)
- **`/end-run` with `success=false`** → sets `toResumeAt = now + 60s` (backoff before retry)
- **Scheduler heartbeat** in `claimStuckCampaigns()` → detects ongoing campaigns with `toResumeAt IS NULL` and sets `toResumeAt = now` to recover stuck campaigns
- `stopCampaign=true` path unchanged (auto-stops, no re-trigger)

## Test plan

- [x] Unit tests pass (`pnpm test:unit` — 76 tests)
- [ ] Integration tests (require DB, CI will run)
- [ ] Deploy to production via `release.sh hotfix`
- [ ] Verify stuck campaigns auto-recover within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)