### PR TITLE
refactor: rename toResumeAt → nextRunAt (BREAKING API + DB column)

### DIFF
--- a/drizzle/0031_rename_to_resume_at.sql
+++ b/drizzle/0031_rename_to_resume_at.sql
@@ -1,0 +1,2 @@
+-- Rename to_resume_at column to next_run_at (values unchanged)
+ALTER TABLE "campaigns" RENAME COLUMN "to_resume_at" TO "next_run_at";

--- a/openapi.json
+++ b/openapi.json
@@ -94,7 +94,7 @@
           "status": {
             "type": "string"
           },
-          "toResumeAt": {
+          "nextRunAt": {
             "type": "string",
             "nullable": true
           },
@@ -135,7 +135,7 @@
           "startDate",
           "endDate",
           "status",
-          "toResumeAt",
+          "nextRunAt",
           "notifyFrequency",
           "notifyChannel",
           "notifyDestination",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -41,7 +41,7 @@ export const campaigns = pgTable(
 
     // Status: 'ongoing' or 'stopped'
     status: text("status").notNull().default("ongoing"),
-    toResumeAt: timestamp("to_resume_at", { withTimezone: true }),
+    nextRunAt: timestamp("next_run_at", { withTimezone: true }),
 
     // Notifications (legacy - to be replaced by reportingFrequency)
     notifyFrequency: text("notify_frequency"),  // 'daily', 'weekly', 'per_reply'

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -24,7 +24,7 @@ export interface GateCheckResult {
   allowed: boolean;
   reason?: string;
   autoStopped?: boolean;
-  toResumeAt?: Date;
+  nextRunAt?: Date;
 }
 
 export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheckResult> {
@@ -75,20 +75,20 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   }
 
   // Build windows for configured budgets only
-  const budgetLimits: Array<{ limit: string; label: string; autoStop: boolean; resumeAt?: Date }> = [];
+  const budgetLimits: Array<{ limit: string; label: string; autoStop: boolean; nextRunAt?: Date }> = [];
   const windows: BudgetWindow[] = [];
 
   if (campaign.maxBudgetDailyUsd) {
     windows.push({ label: "daily", since: startOfToday().toISOString() });
-    budgetLimits.push({ limit: campaign.maxBudgetDailyUsd, label: "daily", autoStop: false, resumeAt: nextDayStart() });
+    budgetLimits.push({ limit: campaign.maxBudgetDailyUsd, label: "daily", autoStop: false, nextRunAt: nextDayStart() });
   }
   if (campaign.maxBudgetWeeklyUsd) {
     windows.push({ label: "weekly", since: daysAgo(7).toISOString() });
-    budgetLimits.push({ limit: campaign.maxBudgetWeeklyUsd, label: "weekly", autoStop: false, resumeAt: nextWeekStart() });
+    budgetLimits.push({ limit: campaign.maxBudgetWeeklyUsd, label: "weekly", autoStop: false, nextRunAt: nextWeekStart() });
   }
   if (campaign.maxBudgetMonthlyUsd) {
     windows.push({ label: "monthly", since: startOfMonth().toISOString() });
-    budgetLimits.push({ limit: campaign.maxBudgetMonthlyUsd, label: "monthly", autoStop: false, resumeAt: nextMonthStart() });
+    budgetLimits.push({ limit: campaign.maxBudgetMonthlyUsd, label: "monthly", autoStop: false, nextRunAt: nextMonthStart() });
   }
   if (campaign.maxBudgetTotalUsd) {
     windows.push({ label: "total" });
@@ -112,7 +112,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
         await autoStopCampaign(campaign.campaignId);
         return { allowed: false, reason: "Total budget exceeded", autoStopped: true };
       }
-      return { allowed: false, reason: `${budgetLimit.label} budget exceeded`, toResumeAt: budgetLimit.resumeAt };
+      return { allowed: false, reason: `${budgetLimit.label} budget exceeded`, nextRunAt: budgetLimit.nextRunAt };
     }
   }
 

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -6,25 +6,25 @@ import { executeCampaignWorkflow } from "./workflows.js";
 const SCHEDULER_INTERVAL_MS = 60_000; // 1 minute
 
 /**
- * Find all ongoing campaigns whose toResumeAt has passed,
- * atomically claim them (clear toResumeAt), and re-trigger their workflow.
+ * Find all ongoing campaigns whose nextRunAt has passed,
+ * atomically claim them (clear nextRunAt), and re-trigger their workflow.
  *
  * Uses UPDATE ... RETURNING to atomically claim campaigns, preventing
  * duplicate triggers from overlapping ticks or multiple service instances.
  */
-export async function resumeDueCampaigns(): Promise<number> {
+export async function reRunDueCampaigns(): Promise<number> {
   const now = new Date();
 
   // Atomic claim: UPDATE + RETURNING ensures only one instance/tick processes each campaign.
   // PostgreSQL row-level locks prevent two concurrent UPDATEs from claiming the same row.
   const dueCampaigns = await db
     .update(campaigns)
-    .set({ toResumeAt: null, updatedAt: now })
+    .set({ nextRunAt: null, updatedAt: now })
     .where(
       and(
         eq(campaigns.status, "ongoing"),
-        isNotNull(campaigns.toResumeAt),
-        lte(campaigns.toResumeAt, now),
+        isNotNull(campaigns.nextRunAt),
+        lte(campaigns.nextRunAt, now),
       ),
     )
     .returning({
@@ -39,7 +39,7 @@ export async function resumeDueCampaigns(): Promise<number> {
 
   if (dueCampaigns.length === 0) return 0;
 
-  console.log(`[campaign-service] Claimed ${dueCampaigns.length} campaign(s) for resume`);
+  console.log(`[campaign-service] Claimed ${dueCampaigns.length} campaign(s) for re-run`);
 
   for (const campaign of dueCampaigns) {
     try {
@@ -48,7 +48,7 @@ export async function resumeDueCampaigns(): Promise<number> {
       if (!campaign.createdByUserId) missingFields.push("createdByUserId");
       if (!campaign.featureSlug) missingFields.push("featureSlug");
       if (missingFields.length > 0) {
-        console.warn(`[campaign-service] Campaign ${campaign.id} missing required fields for workflow execution: ${missingFields.join(", ")} — skipping resume`);
+        console.warn(`[campaign-service] Campaign ${campaign.id} missing required fields for workflow execution: ${missingFields.join(", ")} — skipping re-run`);
         continue;
       }
 
@@ -80,19 +80,19 @@ export async function resumeDueCampaigns(): Promise<number> {
 }
 
 /**
- * Heartbeat: detect ongoing campaigns with no toResumeAt (stuck campaigns).
- * Sets toResumeAt = now so the next tick picks them up via resumeDueCampaigns.
+ * Heartbeat: detect ongoing campaigns with no nextRunAt (stuck campaigns).
+ * Sets nextRunAt = now so the next tick picks them up via reRunDueCampaigns.
  */
 export async function claimStuckCampaigns(): Promise<number> {
   const now = new Date();
 
   const stuck = await db
     .update(campaigns)
-    .set({ toResumeAt: now, updatedAt: now })
+    .set({ nextRunAt: now, updatedAt: now })
     .where(
       and(
         eq(campaigns.status, "ongoing"),
-        isNull(campaigns.toResumeAt),
+        isNull(campaigns.nextRunAt),
       ),
     )
     .returning({ id: campaigns.id });
@@ -123,7 +123,7 @@ export function startScheduler(): () => void {
     }
     isRunning = true;
     claimStuckCampaigns()
-      .then(() => resumeDueCampaigns())
+      .then(() => reRunDueCampaigns())
       .catch((err) => {
         console.error("[campaign-service] Unhandled error:", err);
       })

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -77,10 +77,10 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
     }
 
     if (!result.allowed) {
-      // Save toResumeAt so the scheduler can re-trigger when the budget window resets
-      if (result.toResumeAt) {
+      // Save nextRunAt so the scheduler can re-trigger when the budget window resets
+      if (result.nextRunAt) {
         await db.update(campaigns)
-          .set({ toResumeAt: result.toResumeAt, updatedAt: new Date() })
+          .set({ nextRunAt: result.nextRunAt, updatedAt: new Date() })
           .where(eq(campaigns.id, campaignId));
       }
     }
@@ -257,7 +257,7 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       return;
     }
 
-    // Schedule re-trigger via toResumeAt — the scheduler picks it up on the next tick.
+    // Schedule re-trigger via nextRunAt — the scheduler picks it up on the next tick.
     // This prevents exponential cascades when downstream services are down.
     try {
       const freshCampaign = await db.query.campaigns.findFirst({
@@ -267,24 +267,24 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
         return;
       }
 
-      // Failed runs get a 60s backoff; completed runs resume immediately
+      // Failed runs get a 60s backoff; completed runs re-run immediately
       const delayMs = status === "failed" ? 60_000 : 0;
-      const toResumeAt = new Date(Date.now() + delayMs);
+      const nextRunAt = new Date(Date.now() + delayMs);
 
       if (req.runId) {
         traceEvent(req.runId, {
           service: "campaign-service",
           event: "re-trigger-scheduled",
-          detail: `Scheduled re-trigger for campaign ${campaignId} via toResumeAt=${toResumeAt.toISOString()} (delay=${delayMs}ms)`,
-          data: { campaignId, toResumeAt: toResumeAt.toISOString(), delayMs },
+          detail: `Scheduled re-trigger for campaign ${campaignId} via nextRunAt=${nextRunAt.toISOString()} (delay=${delayMs}ms)`,
+          data: { campaignId, nextRunAt: nextRunAt.toISOString(), delayMs },
         }, req.headers).catch(() => {});
       }
 
       await db.update(campaigns)
-        .set({ toResumeAt, updatedAt: new Date() })
+        .set({ nextRunAt, updatedAt: new Date() })
         .where(eq(campaigns.id, campaignId));
 
-      console.log(`[campaign-service] Set toResumeAt=${toResumeAt.toISOString()} for campaign ${campaignId} (status=${status})`);
+      console.log(`[campaign-service] Set nextRunAt=${nextRunAt.toISOString()} for campaign ${campaignId} (status=${status})`);
     } catch (err) {
       console.error(`[campaign-service] Failed to schedule re-trigger for campaign ${campaignId}:`, err);
     }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -27,7 +27,7 @@ export const CampaignSchema = z.object({
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
   status: z.string(),
-  toResumeAt: z.string().nullable(),
+  nextRunAt: z.string().nullable(),
   notifyFrequency: z.string().nullable(),
   notifyChannel: z.string().nullable(),
   notifyDestination: z.string().nullable(),

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -26,7 +26,7 @@ export async function insertTestCampaign(
     maxLeads?: number;
     featureSlug?: string;
     featureInputs?: Record<string, unknown>;
-    toResumeAt?: Date | null;
+    nextRunAt?: Date | null;
     createdByUserId?: string;
     parentRunId?: string;
   } = {}
@@ -46,7 +46,7 @@ export async function insertTestCampaign(
       maxBudgetMonthlyUsd: data.maxBudgetMonthlyUsd || null,
       maxBudgetTotalUsd: data.maxBudgetTotalUsd || null,
       maxLeads: data.maxLeads || null,
-      toResumeAt: data.toResumeAt ?? null,
+      nextRunAt: data.nextRunAt ?? null,
       createdByUserId: data.createdByUserId || null,
       parentRunId: data.parentRunId || null,
     })

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -180,7 +180,7 @@ describe("Pipeline routes", () => {
       expect(res.body.autoStopped).toBe(true);
     });
 
-    it("should save toResumeAt to DB when gate-check returns it", async () => {
+    it("should save nextRunAt to DB when gate-check returns it", async () => {
       const campaign = await insertTestCampaign(orgId, { brandIds });
 
       const tomorrow = new Date();
@@ -190,7 +190,7 @@ describe("Pipeline routes", () => {
       mockGateChecks.mockResolvedValue({
         allowed: false,
         reason: "daily budget exceeded",
-        toResumeAt: tomorrow,
+        nextRunAt: tomorrow,
       });
 
       await request(app)
@@ -201,11 +201,11 @@ describe("Pipeline routes", () => {
       const updated = await db.query.campaigns.findFirst({
         where: eq(campaigns.id, campaign.id),
       });
-      expect(updated!.toResumeAt).not.toBeNull();
-      expect(new Date(updated!.toResumeAt!).getTime()).toBe(tomorrow.getTime());
+      expect(updated!.nextRunAt).not.toBeNull();
+      expect(new Date(updated!.nextRunAt!).getTime()).toBe(tomorrow.getTime());
     });
 
-    it("should NOT save toResumeAt when gate-check does not return it", async () => {
+    it("should NOT save nextRunAt when gate-check does not return it", async () => {
       const campaign = await insertTestCampaign(orgId, { brandIds });
 
       mockGateChecks.mockResolvedValue({
@@ -222,7 +222,7 @@ describe("Pipeline routes", () => {
       const updated = await db.query.campaigns.findFirst({
         where: eq(campaigns.id, campaign.id),
       });
-      expect(updated!.toResumeAt).toBeNull();
+      expect(updated!.nextRunAt).toBeNull();
     });
 
     it("should pass campaign data to runGateChecks", async () => {
@@ -574,7 +574,7 @@ describe("Pipeline routes", () => {
       expect(mockUpdateRun).not.toHaveBeenCalled();
     });
 
-    it("should set toResumeAt=now when success=true stopCampaign=false and campaign is ongoing", async () => {
+    it("should set nextRunAt=now when success=true stopCampaign=false and campaign is ongoing", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "ongoing",
@@ -591,22 +591,22 @@ describe("Pipeline routes", () => {
         .send({ success: true, stopCampaign: false })
         .expect(200);
 
-      // Wait for async toResumeAt update
+      // Wait for async nextRunAt update
       await new Promise((r) => setTimeout(r, 100));
 
       const updated = await db.query.campaigns.findFirst({
         where: eq(campaigns.id, campaign.id),
       });
-      expect(updated!.toResumeAt).not.toBeNull();
-      const resumeTime = new Date(updated!.toResumeAt!).getTime();
+      expect(updated!.nextRunAt).not.toBeNull();
+      const nextRunTime = new Date(updated!.nextRunAt!).getTime();
       // Should be ~now (within 5s tolerance)
-      expect(resumeTime).toBeGreaterThanOrEqual(before);
-      expect(resumeTime).toBeLessThan(before + 5_000);
+      expect(nextRunTime).toBeGreaterThanOrEqual(before);
+      expect(nextRunTime).toBeLessThan(before + 5_000);
       // Must NOT fire-and-forget
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
-    it("should set toResumeAt=now+60s when success=false stopCampaign=false and campaign is ongoing", async () => {
+    it("should set nextRunAt=now+60s when success=false stopCampaign=false and campaign is ongoing", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "ongoing",
@@ -628,15 +628,15 @@ describe("Pipeline routes", () => {
       const updated = await db.query.campaigns.findFirst({
         where: eq(campaigns.id, campaign.id),
       });
-      expect(updated!.toResumeAt).not.toBeNull();
-      const resumeTime = new Date(updated!.toResumeAt!).getTime();
+      expect(updated!.nextRunAt).not.toBeNull();
+      const nextRunTime = new Date(updated!.nextRunAt!).getTime();
       // Should be ~now + 60s (within 5s tolerance)
-      expect(resumeTime).toBeGreaterThanOrEqual(before + 55_000);
-      expect(resumeTime).toBeLessThan(before + 65_000);
+      expect(nextRunTime).toBeGreaterThanOrEqual(before + 55_000);
+      expect(nextRunTime).toBeLessThan(before + 65_000);
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
-    it("should NOT set toResumeAt if campaign is stopped", async () => {
+    it("should NOT set nextRunAt if campaign is stopped", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "stopped",
@@ -653,7 +653,7 @@ describe("Pipeline routes", () => {
       const updated = await db.query.campaigns.findFirst({
         where: eq(campaigns.id, campaign.id),
       });
-      expect(updated!.toResumeAt).toBeNull();
+      expect(updated!.nextRunAt).toBeNull();
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
@@ -684,15 +684,15 @@ describe("Pipeline routes", () => {
       // Should NOT re-trigger
       expect(mockExecute).not.toHaveBeenCalled();
 
-      // Should auto-stop in DB and NOT set toResumeAt
+      // Should auto-stop in DB and NOT set nextRunAt
       const updated = await db.query.campaigns.findFirst({
         where: eq(campaigns.id, campaign.id),
       });
       expect(updated!.status).toBe("stopped");
-      expect(updated!.toResumeAt).toBeNull();
+      expect(updated!.nextRunAt).toBeNull();
     });
 
-    it("should set toResumeAt and NOT fire-and-forget when stopCampaign is false", async () => {
+    it("should set nextRunAt and NOT fire-and-forget when stopCampaign is false", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "ongoing",
@@ -717,7 +717,7 @@ describe("Pipeline routes", () => {
       const updated = await db.query.campaigns.findFirst({
         where: eq(campaigns.id, campaign.id),
       });
-      expect(updated!.toResumeAt).not.toBeNull();
+      expect(updated!.nextRunAt).not.toBeNull();
       expect(mockExecute).not.toHaveBeenCalled();
     });
 

--- a/tests/integration/scheduler-rerun.test.ts
+++ b/tests/integration/scheduler-rerun.test.ts
@@ -24,11 +24,11 @@ import { db } from "../../src/db/index.js";
 import { campaigns } from "../../src/db/schema.js";
 import { eq } from "drizzle-orm";
 import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
-import { resumeDueCampaigns } from "../../src/lib/scheduler.js";
+import { reRunDueCampaigns } from "../../src/lib/scheduler.js";
 
 const orgId = "scheduler-test-org";
 
-describe("Scheduler - resumeDueCampaigns (integration)", () => {
+describe("Scheduler - reRunDueCampaigns (integration)", () => {
   beforeEach(async () => {
     await cleanTestData();
     vi.clearAllMocks();
@@ -46,28 +46,28 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
       status: "ongoing",
     });
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
     expect(count).toBe(0);
     expect(mockExecute).not.toHaveBeenCalled();
   });
 
-  it("should resume campaign whose toResumeAt is in the past", async () => {
+  it("should re-run campaign whose nextRunAt is in the past", async () => {
     const pastDate = new Date(Date.now() - 60_000); // 1 minute ago
     const campaign = await insertTestCampaign(orgId, {
       status: "ongoing",
-      toResumeAt: pastDate,
+      nextRunAt: pastDate,
       featureSlug: "sales-cold-email-v1",
       createdByUserId: "user_scheduler_test",
     });
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
     expect(count).toBe(1);
 
-    // Should have cleared toResumeAt
+    // Should have cleared nextRunAt
     const updated = await db.query.campaigns.findFirst({
       where: eq(campaigns.id, campaign.id),
     });
-    expect(updated!.toResumeAt).toBeNull();
+    expect(updated!.nextRunAt).toBeNull();
 
     // Should have triggered workflow (run is created by /start-run in the DAG, not here)
     expect(mockExecute).toHaveBeenCalledWith(
@@ -79,49 +79,49 @@ describe("Scheduler - resumeDueCampaigns (integration)", () => {
     );
   });
 
-  it("should NOT resume campaign whose toResumeAt is in the future", async () => {
+  it("should NOT resume campaign whose nextRunAt is in the future", async () => {
     const futureDate = new Date(Date.now() + 3_600_000); // 1 hour from now
     await insertTestCampaign(orgId, {
       status: "ongoing",
-      toResumeAt: futureDate,
+      nextRunAt: futureDate,
     });
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
     expect(count).toBe(0);
     expect(mockExecute).not.toHaveBeenCalled();
   });
 
-  it("should NOT resume stopped campaigns even with past toResumeAt", async () => {
+  it("should NOT resume stopped campaigns even with past nextRunAt", async () => {
     const pastDate = new Date(Date.now() - 60_000);
     await insertTestCampaign(orgId, {
       status: "stopped",
-      toResumeAt: pastDate,
+      nextRunAt: pastDate,
     });
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
     expect(count).toBe(0);
     expect(mockExecute).not.toHaveBeenCalled();
   });
 
-  it("should resume multiple due campaigns", async () => {
+  it("should re-run multiple due campaigns", async () => {
     const pastDate = new Date(Date.now() - 60_000);
 
     await insertTestCampaign(orgId, {
       name: "Campaign A",
       status: "ongoing",
-      toResumeAt: pastDate,
+      nextRunAt: pastDate,
       featureSlug: "sales-cold-email-v1",
       createdByUserId: "user_scheduler_test",
     });
     await insertTestCampaign(orgId, {
       name: "Campaign B",
       status: "ongoing",
-      toResumeAt: pastDate,
+      nextRunAt: pastDate,
       featureSlug: "sales-cold-email-v1",
       createdByUserId: "user_scheduler_test",
     });
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
     expect(count).toBe(2);
     expect(mockExecute).toHaveBeenCalledTimes(2);
   });

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -305,8 +305,8 @@ describe("Gate Check", () => {
     });
   });
 
-  describe("toResumeAt on temporal budget exceeded", () => {
-    it("should return toResumeAt when daily budget is exceeded", async () => {
+  describe("nextRunAt on temporal budget exceeded", () => {
+    it("should return nextRunAt when daily budget is exceeded", async () => {
       mockGetStatsBudget.mockResolvedValue(
         makeBudgetResponse([{ label: "daily", totalCostInUsdCents: "1500" }])
       );
@@ -314,13 +314,13 @@ describe("Gate Check", () => {
       const result = await runGateChecks(makeCampaign({ maxBudgetDailyUsd: "10.00" }));
       expect(result.allowed).toBe(false);
       expect(result.reason).toBe("daily budget exceeded");
-      expect(result.toResumeAt).toBeInstanceOf(Date);
+      expect(result.nextRunAt).toBeInstanceOf(Date);
       // Should be tomorrow at midnight
       const expected = nextDayStart();
-      expect(result.toResumeAt!.getTime()).toBe(expected.getTime());
+      expect(result.nextRunAt!.getTime()).toBe(expected.getTime());
     });
 
-    it("should return toResumeAt when weekly budget is exceeded", async () => {
+    it("should return nextRunAt when weekly budget is exceeded", async () => {
       mockGetStatsBudget.mockResolvedValue(
         makeBudgetResponse([{ label: "weekly", totalCostInUsdCents: "6000" }])
       );
@@ -331,12 +331,12 @@ describe("Gate Check", () => {
       }));
       expect(result.allowed).toBe(false);
       expect(result.reason).toBe("weekly budget exceeded");
-      expect(result.toResumeAt).toBeInstanceOf(Date);
+      expect(result.nextRunAt).toBeInstanceOf(Date);
       const expected = nextWeekStart();
-      expect(result.toResumeAt!.getTime()).toBe(expected.getTime());
+      expect(result.nextRunAt!.getTime()).toBe(expected.getTime());
     });
 
-    it("should return toResumeAt when monthly budget is exceeded", async () => {
+    it("should return nextRunAt when monthly budget is exceeded", async () => {
       mockGetStatsBudget.mockResolvedValue(
         makeBudgetResponse([{ label: "monthly", totalCostInUsdCents: "11000" }])
       );
@@ -347,12 +347,12 @@ describe("Gate Check", () => {
       }));
       expect(result.allowed).toBe(false);
       expect(result.reason).toBe("monthly budget exceeded");
-      expect(result.toResumeAt).toBeInstanceOf(Date);
+      expect(result.nextRunAt).toBeInstanceOf(Date);
       const expected = nextMonthStart();
-      expect(result.toResumeAt!.getTime()).toBe(expected.getTime());
+      expect(result.nextRunAt!.getTime()).toBe(expected.getTime());
     });
 
-    it("should NOT return toResumeAt when total budget is exceeded (auto-stop instead)", async () => {
+    it("should NOT return nextRunAt when total budget is exceeded (auto-stop instead)", async () => {
       mockGetStatsBudget.mockResolvedValue(
         makeBudgetResponse([{ label: "total", totalCostInUsdCents: "5500" }])
       );
@@ -363,10 +363,10 @@ describe("Gate Check", () => {
       }));
       expect(result.allowed).toBe(false);
       expect(result.autoStopped).toBe(true);
-      expect(result.toResumeAt).toBeUndefined();
+      expect(result.nextRunAt).toBeUndefined();
     });
 
-    it("should return earliest toResumeAt when daily exceeds before weekly", async () => {
+    it("should return earliest nextRunAt when daily exceeds before weekly", async () => {
       mockGetStatsBudget.mockResolvedValue(
         makeBudgetResponse([
           { label: "daily", totalCostInUsdCents: "1500" },
@@ -380,9 +380,9 @@ describe("Gate Check", () => {
       }));
       expect(result.allowed).toBe(false);
       expect(result.reason).toBe("daily budget exceeded");
-      // Daily is checked first, so toResumeAt should be next day
+      // Daily is checked first, so nextRunAt should be next day
       const expected = nextDayStart();
-      expect(result.toResumeAt!.getTime()).toBe(expected.getTime());
+      expect(result.nextRunAt!.getTime()).toBe(expected.getTime());
     });
   });
 

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -30,7 +30,7 @@ vi.mock("../../src/db/schema.js", () => ({
   campaigns: {
     id: "id",
     status: "status",
-    toResumeAt: "to_resume_at",
+    nextRunAt: "next_run_at",
     workflowSlug: "workflow_slug",
     orgId: "org_id",
     updatedAt: "updated_at",
@@ -49,9 +49,9 @@ vi.mock("drizzle-orm", () => ({
   isNull: vi.fn(),
 }));
 
-import { resumeDueCampaigns, claimStuckCampaigns } from "../../src/lib/scheduler.js";
+import { reRunDueCampaigns, claimStuckCampaigns } from "../../src/lib/scheduler.js";
 
-describe("Scheduler - resumeDueCampaigns", () => {
+describe("Scheduler - reRunDueCampaigns", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
@@ -59,7 +59,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
   });
 
   it("should return 0 when no campaigns are due", async () => {
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
     expect(count).toBe(0);
     expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
   });
@@ -77,7 +77,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       },
     ]);
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
 
     expect(count).toBe(1);
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
@@ -105,7 +105,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       },
     ]);
 
-    await resumeDueCampaigns();
+    await reRunDueCampaigns();
 
     // No createRun import or call — scheduler delegates run creation to the DAG
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledTimes(1);
@@ -124,7 +124,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       },
     ]);
 
-    await resumeDueCampaigns();
+    await reRunDueCampaigns();
 
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledWith(
       "sales-email-cold-outreach",
@@ -145,7 +145,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       },
     ]);
 
-    await resumeDueCampaigns();
+    await reRunDueCampaigns();
 
     const call = mockExecuteCampaignWorkflow.mock.calls[0];
     expect(call[1].runId).toMatch(
@@ -166,7 +166,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       },
     ]);
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
 
     expect(count).toBe(1);
     expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
@@ -185,7 +185,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       },
     ]);
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
 
     expect(count).toBe(1);
     expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
@@ -213,7 +213,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       },
     ]);
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
 
     expect(count).toBe(2);
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledTimes(2);
@@ -246,7 +246,7 @@ describe("Scheduler - resumeDueCampaigns", () => {
       .mockImplementationOnce(() => { throw new Error("Workflow error"); })
       .mockResolvedValueOnce(undefined);
 
-    const count = await resumeDueCampaigns();
+    const count = await reRunDueCampaigns();
 
     expect(count).toBe(2);
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

Drop \"resume\" vocabulary across campaign-service. Campaigns have only two statuses (\`ongoing\` / \`stopped\`). The \`toResumeAt\` / \`resumeDueCampaigns\` naming suggested a paused state that does not exist — gate-blocked campaigns stay \`ongoing\` and are simply re-run by the scheduler when the budget window resets.

## Renames

| Layer | Before | After |
|---|---|---|
| DB column | \`to_resume_at\` | \`next_run_at\` |
| Drizzle field | \`campaigns.toResumeAt\` | \`campaigns.nextRunAt\` |
| **OpenAPI \`Campaign\` field** | \`toResumeAt\` | \`nextRunAt\` |
| Scheduler fn | \`resumeDueCampaigns()\` | \`reRunDueCampaigns()\` |
| \`GateCheckResult\` | \`toResumeAt\` | \`nextRunAt\` |
| Test file | \`scheduler-resume.test.ts\` | \`scheduler-rerun.test.ts\` |

\`claimStuckCampaigns\`, \`nextDayStart\`, \`nextWeekStart\`, \`nextMonthStart\` left alone — names already correct.

## ⚠️ Deployment ordering

This PR breaks the OpenAPI contract: \`Campaign.toResumeAt\` field renamed to \`Campaign.nextRunAt\`. Direct downstream consumers (api-service, distribute.you frontend) need their corresponding PRs merged first.

**Do NOT merge to prod** until:
- [ ] api-service updated to read \`nextRunAt\` (separate PR, pending)
- [ ] distribute.you updated to read \`nextRunAt\` (separate PR, pending)
- [ ] All three deploy together to staging → smoke check → promote together to prod

Staging merge OK because Railway will deploy this service first; downstream services will see \`nextRunAt\` and adapt in their own PRs.

## Migration

\`drizzle/0031_rename_to_resume_at.sql\` — single \`ALTER TABLE ... RENAME COLUMN\`. Atomic, no data loss, no downtime if app deploy + migration coordinated.

## Test plan

- [x] \`pnpm run build\` passes
- [x] \`pnpm test:unit\` — 76/76 passing
- [ ] \`pnpm test:integration\` — runs in CI (no local DB)
- [ ] Apply migration on staging DB → confirm column \`next_run_at\` exists
- [ ] Smoke: campaign hits daily-budget gate → \`next_run_at\` set in DB → scheduler re-runs at window reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)