### PR TITLE
fix(scheduler): enforce sequential parent runs per campaign

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -55,6 +55,25 @@ export async function reRunDueCampaigns(): Promise<number> {
         continue;
       }
 
+      // Sequential-runs invariant: never fire a new parent run while a prior one is still alive.
+      // Without this guard, /end-run mis-fires (or claimStuckCampaigns false-positives) can lead to
+      // two parent flows running in parallel — caught downstream by lead-service as 409, but noisy.
+      const { runs: inflight } = await listRuns({
+        orgId: campaign.orgId,
+        serviceName: "campaign-service",
+        taskName: campaign.id,
+        status: "running",
+      });
+      if (inflight.length > 0) {
+        const rescheduledAt = new Date(now.getTime() + 60_000);
+        await db
+          .update(campaigns)
+          .set({ nextRunAt: rescheduledAt, updatedAt: new Date() })
+          .where(eq(campaigns.id, campaign.id));
+        console.warn(`[campaign-service] Skipped re-fire for campaign ${campaign.id} — ${inflight.length} run(s) still in-flight. Rescheduled nextRunAt=${rescheduledAt.toISOString()}`);
+        continue;
+      }
+
       const brandIdCsv = campaign.brandIds!.join(",");
       const userId = campaign.createdByUserId!;
       const featureSlug = campaign.featureSlug!;

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -225,20 +225,28 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       }, req.headers).catch(() => {});
     }
 
-    // Find and update running runs for this campaign
-    try {
-      const { runs } = await listRuns({
-        orgId,
-        serviceName: "campaign-service",
-        taskName: campaignId,
-      });
-
-      const runningRuns = runs.filter((r) => r.status === "running");
-      for (const run of runningRuns) {
-        await updateRun(run.id, status, identity);
+    // Finalize ONLY this caller's own run row, matched by parentRunId === req.runId.
+    // Sibling parent runs (concurrent campaign runs from a stale schedule) are NOT touched —
+    // each is responsible for ending its own row when its DAG terminates. The previous
+    // "mark all running runs failed" behavior swept siblings and was the root cause of
+    // the serial-invariant violation seen at lead-service.
+    if (!req.runId) {
+      console.warn(`[campaign-service] /end-run called without x-run-id for campaign ${campaignId} — cannot finalize a run row`);
+    } else {
+      try {
+        const { runs } = await listRuns({
+          orgId,
+          serviceName: "campaign-service",
+          taskName: campaignId,
+          parentRunId: req.runId,
+          status: "running",
+        });
+        for (const run of runs) {
+          await updateRun(run.id, status, identity);
+        }
+      } catch (err) {
+        console.error(`[campaign-service] Failed to update run for campaign ${campaignId}:`, err);
       }
-    } catch (err) {
-      console.error(`[campaign-service] Failed to update runs:`, err);
     }
 
     // Respond immediately, then handle re-trigger asynchronously

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -574,6 +574,33 @@ describe("Pipeline routes", () => {
       expect(mockUpdateRun).not.toHaveBeenCalled();
     });
 
+    it("should call listRuns with parentRunId filter matching caller's x-run-id", async () => {
+      const campaign = await insertTestCampaign(orgId, { brandIds });
+      const callerRunId = crypto.randomUUID();
+
+      mockListRuns.mockResolvedValue({
+        runs: [{ id: "run-own", status: "running", startedAt: new Date().toISOString() }],
+      });
+
+      await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id, "x-run-id": callerRunId }))
+        .send({ success: false, stopCampaign: false })
+        .expect(200);
+
+      expect(mockListRuns).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgId,
+          serviceName: "campaign-service",
+          taskName: campaign.id,
+          parentRunId: callerRunId,
+          status: "running",
+        }),
+      );
+      expect(mockUpdateRun).toHaveBeenCalledTimes(1);
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-own", "failed", expect.objectContaining({ orgId }));
+    });
+
     it("should set nextRunAt=now when success=true stopCampaign=false and campaign is ongoing", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -69,6 +69,7 @@ describe("Scheduler - reRunDueCampaigns", () => {
     vi.clearAllMocks();
     mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
     mockDbReturning.mockResolvedValue([]);
+    mockListRuns.mockResolvedValue({ runs: [], limit: 50, offset: 0 });
   });
 
   it("should return 0 when no campaigns are due", async () => {
@@ -230,6 +231,73 @@ describe("Scheduler - reRunDueCampaigns", () => {
 
     expect(count).toBe(2);
     expect(mockExecuteCampaignWorkflow).toHaveBeenCalledTimes(2);
+  });
+
+  it("should NOT fire when a running run already exists for the campaign", async () => {
+    mockDbReturning.mockResolvedValue([
+      {
+        id: "campaign-1",
+        orgId: "org-ext-1",
+        workflowSlug: "sales-email-cold-outreach",
+        brandIds: ["brand-123"],
+        createdByUserId: "user-1",
+        parentRunId: null,
+        featureSlug: "sales-cold-email-v1",
+      },
+    ]);
+    mockListRuns.mockResolvedValue({
+      runs: [{ id: "run-inflight", status: "running", startedAt: new Date().toISOString() }],
+      limit: 50,
+      offset: 0,
+    });
+
+    const count = await reRunDueCampaigns();
+
+    expect(count).toBe(1);
+    expect(mockListRuns).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: "org-ext-1",
+        serviceName: "campaign-service",
+        taskName: "campaign-1",
+        status: "running",
+      }),
+    );
+    expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("should reschedule nextRunAt to ~now+60s when skipping due to in-flight run", async () => {
+    mockDbReturning.mockResolvedValue([
+      {
+        id: "campaign-skip",
+        orgId: "org-ext-1",
+        workflowSlug: "sales-email-cold-outreach",
+        brandIds: ["brand-123"],
+        createdByUserId: "user-1",
+        parentRunId: null,
+        featureSlug: "sales-cold-email-v1",
+      },
+    ]);
+    mockListRuns.mockResolvedValue({
+      runs: [{ id: "run-inflight", status: "running", startedAt: new Date().toISOString() }],
+      limit: 50,
+      offset: 0,
+    });
+
+    const { db } = await import("../../src/db/index.js");
+    const setMock = (db.update as unknown as ReturnType<typeof vi.fn>)().set as unknown as ReturnType<typeof vi.fn>;
+    setMock.mockClear();
+
+    const before = Date.now();
+    await reRunDueCampaigns();
+
+    // The atomic claim call uses .set({ nextRunAt: null, ... }) → returning(...).
+    // The reschedule call uses .set({ nextRunAt: <Date>, ... }) with no .returning() chain.
+    // Find the call whose payload has a Date nextRunAt.
+    const rescheduleCall = setMock.mock.calls.find((args) => args[0]?.nextRunAt instanceof Date);
+    expect(rescheduleCall).toBeDefined();
+    const rescheduledAt = rescheduleCall![0].nextRunAt as Date;
+    expect(rescheduledAt.getTime()).toBeGreaterThanOrEqual(before + 55_000);
+    expect(rescheduledAt.getTime()).toBeLessThan(before + 65_000);
   });
 
   it("should continue processing other campaigns if one throws", async () => {


### PR DESCRIPTION
## Summary

- Scheduler now refuses to fire a new parent run while a prior run is still `running` in runs-service, and reschedules `nextRunAt = now+60s` instead. Re-evaluates next tick.
- `/end-run` finalizes only the caller's own run row (filtered by `parentRunId === req.runId`). It no longer sweeps sibling parent runs.

Together this enforces the invariant: **at most one parent run per campaign in-flight at any time.**

## Why

Production log evidence (campaign `2abb47b1-9594-43fe-8c49-9ea4d1c01c04`):

```
[campaign-service] Run failed — rescheduled campaign 2abb47b1 in 60000ms
[lead-service] Concurrent buffer/next call for orgId=… campaignId=2abb47b1…
   In-flight: parentRunId=d3779c23 startedAt=2026-05-12T04:03:35.835Z elapsedMs=516533
   Rejected: parentRunId=69e77efa
```

lead-service caught the violation with a 409 (`Concurrent buffer/next call for same campaign`). campaign-service was launching parent run #2 while parent run #1 was still alive. Two root causes:

1. `/end-run` marked *all* running rows for the campaign as failed (not just the caller's). When one parent's `onError` fired, the sibling parent's runs-service row was clobbered too — releasing the conceptual lock and letting the scheduler fire again.
2. `reRunDueCampaigns` had no in-flight check before firing.

## How

| File | Change |
|---|---|
| `src/lib/scheduler.ts` | `reRunDueCampaigns` calls `listRuns({ status: "running" })` between claim and fire; if any → reschedule + skip. |
| `src/routes/internal.ts` | `/end-run` filters `listRuns({ parentRunId: req.runId, status: "running" })` — touches at most one row. |
| `tests/unit/scheduler.test.ts` | +2 tests: skip-fire-when-running, reschedule ~now+60s. |
| `tests/integration/internal-routes.test.ts` | +1 test: listRuns called with parentRunId filter, only caller's row updated. |

No DB migration. No new state. No new endpoint.

## Liveness audit

| Event | Who sets `nextRunAt` |
|---|---|
| Only one run alive, finishes | That run's `/end-run` (sees 0 siblings → sets normally) |
| Two runs alive (this bug), B finishes first | A's `/end-run` later (sees 0 running → sets) |
| Worker dies without calling `/end-run` | `claimStuckCampaigns` (unchanged) after time window |
| Scheduler skips fire due to in-flight | The skip path itself reschedules +60s |

No path orphans the campaign.

## Known non-goals

- **Multi-instance scheduler race.** Two campaign-service replicas could both see no running row before either fires. lead-service still catches via 409 (status quo). Full fix requires `current_run_id` CAS column — out of scope.
- **Orphan running rows in runs-service.** When a Windmill worker dies mid-flight, sub-run rows (lead-service, ai-visibility-score) stay `running` forever. Separate problem — needs Windmill cancellation API or per-service heartbeat. Not addressed here.
- **`ai-visibility-scoring-lighthouse-2` DAG 400 storms.** Separate bug (campaign `7078a445…` bound to deprecated workflow_slug). Handled in another workspace.

## Test plan

- [x] `pnpm test:unit` — 91 tests pass locally, including new scheduler tests
- [ ] `pnpm test:integration` — runs in CI (local lacks Postgres)
- [ ] After deploy to staging: grep lead-service logs for `Concurrent buffer/next call` over 24h; expect zero campaign-service-attributed entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)