### PR TITLE
perf(scheduler): adaptive tick lets Neon compute scale to zero when idle

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -4,7 +4,19 @@ import { eq, and, lte, isNotNull, isNull } from "drizzle-orm";
 import { executeCampaignWorkflow } from "./workflows.js";
 import { listRuns } from "@distribute/runs-client";
 
-const SCHEDULER_INTERVAL_MS = 60_000; // 1 minute
+// Cadence while a campaign is actively running (a run is in-flight). At this
+// rate the scheduler catches /end-run reschedules and stuck-run detection.
+export const ACTIVE_INTERVAL_MS = 60_000; // 1 minute
+
+// Hard ceiling on how long the scheduler sleeps between ticks. Two reasons:
+//   1. setTimeout delays above ~2^31 ms (~24.8 days) overflow int32 and fire
+//      immediately — a far-future nextRunAt must be bounded.
+//   2. Safety backstop: if a future code path marks a campaign "ongoing"
+//      without calling wakeScheduler(), the hourly re-check still picks it up
+//      instead of stranding it forever.
+// Cost of one wake/hour while fully idle is negligible (~0.30 $/month) and lets
+// Neon's compute suspend (5-min idle timeout) for ~55 of every 60 minutes.
+export const IDLE_MAX_MS = 60 * 60_000; // 1 hour
 
 // A run is considered "fresh" (campaign actively executing) if it started within this window.
 // Older running rows are treated as orphans (workflow died without /end-run).
@@ -163,33 +175,112 @@ export async function claimStuckCampaigns(): Promise<number> {
   return claimedCount;
 }
 
-/** Tracks whether a scheduler tick is currently running. */
+/**
+ * Pure decision: how long until the next scheduler tick should run, given the
+ * current snapshot of ongoing campaigns.
+ *
+ *   - No ongoing campaigns        → IDLE_MAX_MS. Nothing to poll; the Neon
+ *     compute can suspend. A new campaign wakes the scheduler via wakeScheduler().
+ *   - Any in-flight (nextRunAt=NULL) → ACTIVE_INTERVAL_MS. A run is executing
+ *     (or possibly stuck); poll at the active cadence to catch /end-run + stuck.
+ *   - All waiting (future nextRunAt) → sleep until the soonest due time, floored
+ *     to avoid a busy-spin and capped at IDLE_MAX_MS.
+ *
+ * Pure (no DB / no clock side-effect) so the cadence logic is trivially testable.
+ */
+export function computeNextDelayMs(
+  ongoing: Array<{ nextRunAt: Date | null }>,
+  now: number = Date.now(),
+): number {
+  if (ongoing.length === 0) return IDLE_MAX_MS;
+  if (ongoing.some((c) => c.nextRunAt === null)) return ACTIVE_INTERVAL_MS;
+  const soonest = Math.min(...ongoing.map((c) => c.nextRunAt!.getTime()));
+  const delay = soonest - now;
+  return Math.min(Math.max(delay, 1_000), IDLE_MAX_MS);
+}
+
+/** Load the ongoing-campaign snapshot used to pick the next tick delay. */
+async function loadOngoingSnapshot(): Promise<Array<{ nextRunAt: Date | null }>> {
+  return db.query.campaigns.findMany({
+    where: eq(campaigns.status, "ongoing"),
+    columns: { nextRunAt: true },
+  });
+}
+
+let timer: ReturnType<typeof setTimeout> | null = null;
 let isRunning = false;
+let started = false;
+
+function scheduleNext(delayMs: number): void {
+  if (!started) return;
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => {
+    void tick();
+  }, delayMs);
+}
 
 /**
- * Start the scheduler interval. Returns a cleanup function.
+ * One scheduler tick: detect stuck campaigns, re-fire due ones, then pick and
+ * schedule the next tick delay from the resulting ongoing-campaign state.
  *
- * Uses a concurrency guard so overlapping ticks (when processing takes > 60s)
- * are skipped rather than causing duplicate triggers.
+ * The concurrency guard makes overlapping ticks (when processing takes longer
+ * than the scheduled delay) a no-op — the in-flight tick reschedules on its way
+ * out, so exactly one live timer survives.
+ */
+async function tick(): Promise<void> {
+  if (!started || isRunning) return;
+  isRunning = true;
+  try {
+    try {
+      await claimStuckCampaigns();
+      await reRunDueCampaigns();
+    } catch (err) {
+      console.error("[campaign-service] Scheduler tick error:", err);
+    }
+
+    let delayMs = ACTIVE_INTERVAL_MS;
+    try {
+      delayMs = computeNextDelayMs(await loadOngoingSnapshot());
+    } catch (err) {
+      console.error("[campaign-service] Scheduler delay computation error:", err);
+    }
+    scheduleNext(delayMs);
+  } finally {
+    isRunning = false;
+  }
+}
+
+/**
+ * Wake the scheduler to run a tick promptly. Call after any write that makes a
+ * campaign schedulable (create, activate, /end-run reschedule) so re-runs fire
+ * without waiting out the current sleep — and so the scheduler resumes from a
+ * deep idle sleep the moment work appears.
+ *
+ * No-op when the scheduler isn't running (e.g. unit tests, NODE_ENV=test) so it
+ * never strands a dangling timer.
+ */
+export function wakeScheduler(): void {
+  if (!started) return;
+  scheduleNext(0);
+}
+
+/**
+ * Start the scheduler. Returns a cleanup function that stops it.
+ *
+ * Self-rescheduling setTimeout (not a fixed setInterval): each tick picks its
+ * own next delay so an idle service stops querying Postgres and lets the Neon
+ * compute suspend, while an active one keeps the 60s cadence.
  */
 export function startScheduler(): () => void {
-  console.log(`[campaign-service] Starting (interval=${SCHEDULER_INTERVAL_MS}ms)`);
+  started = true;
+  console.log(`[campaign-service] Scheduler starting (active=${ACTIVE_INTERVAL_MS}ms, idleMax=${IDLE_MAX_MS}ms)`);
+  scheduleNext(0);
 
-  const handle = setInterval(() => {
-    if (isRunning) {
-      console.warn("[campaign-service] Previous tick still running, skipping");
-      return;
+  return () => {
+    started = false;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
     }
-    isRunning = true;
-    claimStuckCampaigns()
-      .then(() => reRunDueCampaigns())
-      .catch((err) => {
-        console.error("[campaign-service] Unhandled error:", err);
-      })
-      .finally(() => {
-        isRunning = false;
-      });
-  }, SCHEDULER_INTERVAL_MS);
-
-  return () => clearInterval(handle);
+  };
 }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -7,6 +7,7 @@ import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/
 import { validateBody, validateQuery } from "../middleware/validate.js";
 import { CreateCampaignBody, UpdateCampaignBody, CampaignsFilterQuery } from "../schemas.js";
 import { executeCampaignWorkflow, validateWorkflowInputs } from "../lib/workflows.js";
+import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 
 const router = Router();
@@ -211,6 +212,9 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       console.error(`[campaign-service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
 
+    // New ongoing campaign → wake the scheduler so it resumes monitoring from idle.
+    wakeScheduler();
+
     res.status(201).json({ campaign });
   } catch (error: any) {
     if (error?.code === "23505" && (error?.constraint === "uniq_campaigns_org_name" || error?.constraint_name === "uniq_campaigns_org_name")) {
@@ -296,6 +300,8 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
       executeCampaignWorkflow(updated.workflowSlug, activateInputs).catch((err) => {
         console.error(`[campaign-service] Failed to trigger workflow for campaign ${id}:`, err);
       });
+      // Campaign just activated (status → ongoing) → wake the scheduler from idle.
+      wakeScheduler();
     }
 
     res.json({ campaign: updated });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -7,6 +7,7 @@ import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun, type IdentityHeaders } from "@distribute/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
 import { EndRunBody, TransferBrandBody } from "../schemas.js";
+import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 
 const router = Router();
@@ -291,6 +292,10 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       await db.update(campaigns)
         .set({ nextRunAt, updatedAt: new Date() })
         .where(eq(campaigns.id, campaignId));
+
+      // Re-run scheduled → wake the scheduler so it fires at (or near) nextRunAt
+      // instead of waiting out the current idle sleep.
+      wakeScheduler();
 
       if (status === "failed") {
         console.warn(`[campaign-service] Run failed — rescheduled campaign ${campaignId} in ${delayMs}ms (nextRunAt=${nextRunAt.toISOString()})`);

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -62,7 +62,15 @@ vi.mock("drizzle-orm", () => ({
   isNull: vi.fn(),
 }));
 
-import { reRunDueCampaigns, claimStuckCampaigns } from "../../src/lib/scheduler.js";
+import {
+  reRunDueCampaigns,
+  claimStuckCampaigns,
+  computeNextDelayMs,
+  startScheduler,
+  wakeScheduler,
+  ACTIVE_INTERVAL_MS,
+  IDLE_MAX_MS,
+} from "../../src/lib/scheduler.js";
 
 describe("Scheduler - reRunDueCampaigns", () => {
   beforeEach(() => {
@@ -488,5 +496,105 @@ describe("Scheduler - logging hygiene", () => {
 
     expect(warnSpy).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("Scheduler - computeNextDelayMs (cadence)", () => {
+  const NOW = 1_000_000_000_000;
+
+  it("returns IDLE_MAX_MS when no campaigns are ongoing (Neon can suspend)", () => {
+    expect(computeNextDelayMs([], NOW)).toBe(IDLE_MAX_MS);
+  });
+
+  it("returns ACTIVE_INTERVAL_MS when any campaign is in-flight (nextRunAt null)", () => {
+    const delay = computeNextDelayMs(
+      [{ nextRunAt: null }, { nextRunAt: new Date(NOW + 5 * 60_000) }],
+      NOW,
+    );
+    expect(delay).toBe(ACTIVE_INTERVAL_MS);
+  });
+
+  it("sleeps until the soonest future nextRunAt when all are waiting", () => {
+    const delay = computeNextDelayMs(
+      [
+        { nextRunAt: new Date(NOW + 5 * 60_000) },
+        { nextRunAt: new Date(NOW + 30 * 60_000) },
+      ],
+      NOW,
+    );
+    expect(delay).toBe(5 * 60_000);
+  });
+
+  it("caps the delay at IDLE_MAX_MS for a far-future nextRunAt (setTimeout-overflow safe)", () => {
+    const delay = computeNextDelayMs(
+      [{ nextRunAt: new Date(NOW + 6 * 60 * 60_000) }], // 6h away
+      NOW,
+    );
+    expect(delay).toBe(IDLE_MAX_MS);
+  });
+
+  it("floors the delay at 1s for a due/past nextRunAt (no busy-spin)", () => {
+    expect(computeNextDelayMs([{ nextRunAt: new Date(NOW - 10_000) }], NOW)).toBe(1_000);
+    expect(computeNextDelayMs([{ nextRunAt: new Date(NOW + 500) }], NOW)).toBe(1_000);
+  });
+});
+
+describe("Scheduler - lifecycle (timers)", () => {
+  let stop: (() => void) | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
+    mockDbReturning.mockResolvedValue([]);
+    mockDbFindMany.mockResolvedValue([]);
+    mockListRuns.mockResolvedValue({ runs: [], limit: 50, offset: 0 });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    if (stop) {
+      stop();
+      stop = null;
+    }
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("runs an immediate tick on start (queries ongoing campaigns)", async () => {
+    stop = startScheduler();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockDbFindMany).toHaveBeenCalled();
+  });
+
+  it("wakeScheduler() triggers a prompt tick", async () => {
+    stop = startScheduler();
+    await vi.advanceTimersByTimeAsync(0); // boot tick (0 ongoing → next tick in IDLE_MAX_MS)
+    mockDbFindMany.mockClear();
+
+    wakeScheduler();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockDbFindMany).toHaveBeenCalled();
+  });
+
+  it("with 0 ongoing campaigns, does NOT re-poll at the 60s active cadence", async () => {
+    stop = startScheduler();
+    await vi.advanceTimersByTimeAsync(0); // boot tick: 0 ongoing → schedules IDLE_MAX_MS
+    mockDbFindMany.mockClear();
+
+    // No tick should fire at the old 60s interval — Neon stays asleep.
+    await vi.advanceTimersByTimeAsync(ACTIVE_INTERVAL_MS + 5_000);
+    expect(mockDbFindMany).not.toHaveBeenCalled();
+
+    // The idle backstop tick fires only once IDLE_MAX_MS has elapsed.
+    await vi.advanceTimersByTimeAsync(IDLE_MAX_MS);
+    expect(mockDbFindMany).toHaveBeenCalled();
+  });
+
+  it("wakeScheduler() is a no-op when the scheduler is not started", async () => {
+    // Note: no startScheduler() call here.
+    wakeScheduler();
+    await vi.advanceTimersByTimeAsync(IDLE_MAX_MS + ACTIVE_INTERVAL_MS);
+    expect(mockDbFindMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Root cause (measured, not assumed)

campaign-service's Neon compute never suspended → billed 24/7 at the 0.25 CU floor. The cost brief guessed a DB-touching health endpoint. **Wrong for this service** — `/health` returns static JSON (no DB). The real driver:

`src/lib/scheduler.ts` ran a fixed **60s `setInterval`** that issued **2 Postgres queries every minute unconditionally** (`claimStuckCampaigns` → `findMany`, `reRunDueCampaigns` → `UPDATE … RETURNING`), even with **zero ongoing campaigns**. 60s < Neon's 5-min idle timeout → the idle timer reset every minute → compute never suspended.

Evidence (Neon API): `cpu_used_sec / active_time = 0.25` (the CU floor) with `active_time ≈ 100%` of the window = pinned awake doing light work. Production state at diagnosis: **568 stopped, 5 ongoing** (only 1 with a future `next_run_at`) → idle or near-idle most of the time, yet polling 1440×/day.

## Fix (1 file core + 3 one-line call sites)

Replace the fixed interval with a **self-rescheduling `setTimeout`** whose delay is chosen from actual state (`computeNextDelayMs`, pure + unit-tested):

| State after a tick | Next delay |
|---|---|
| A campaign **in-flight** (`nextRunAt = null`) | `60s` — unchanged active cadence (catch `/end-run` + stuck detection) |
| All ongoing **waiting** (future `nextRunAt`) | sleep until the **soonest** due time |
| **Zero** ongoing | sleep up to **1h** idle backstop |

`wakeScheduler()` (no-op until `startScheduler()` runs → inert under `NODE_ENV=test`) is called on the write paths that create schedulable state — **campaign create**, **activate** (`campaigns.ts`), and **`/end-run` re-trigger** (`internal.ts`) — so re-runs fire immediately instead of waiting out the sleep, and the scheduler resumes instantly from deep idle.

**Why 1h cap, not literally ∞:** (1) `setTimeout` delays > ~24.8 days overflow int32 and fire immediately — a far-future `nextRunAt` must be bounded; (2) safety backstop if a future code path marks a campaign `ongoing` without calling `wakeScheduler()`. Cost of one wake/hour while fully idle ≈ \$0.30/mo; lets Neon suspend ~55 of every 60 idle minutes.

## What does NOT change
- Active campaigns keep the exact 60s behavior.
- `/health` untouched (Railway healthcheck → still 200, still no DB). Readiness semantics intact.
- Scale-to-zero stays enabled (it already was; nothing disabled).
- No schema change, no new endpoint, no `openapi.json` drift, **no new env vars**.

## Tests
- `computeNextDelayMs`: 0-ongoing → `IDLE_MAX_MS`; in-flight → `ACTIVE_INTERVAL_MS`; waiting → soonest; far-future → capped; due/past → floored 1s.
- Lifecycle (fake timers): boot runs an immediate tick; `wakeScheduler()` triggers a prompt tick; **0 ongoing does NOT re-poll at 60s**; `wakeScheduler()` is a no-op when not started.
- Full unit suite green (100/100). (Integration suite needs a live DB — runs in CI, not in this fresh workspace.)

## Verification after deploy
- `curl /health` → 200, no DB query in logs.
- Neon console: campaign-service `active_time` stops growing during a window with no active/due campaigns (compute shows Idle/suspended).

## Replication note (fleet) — NOT a shared pattern
campaign-service's cause is **service-specific** (a polling scheduler), not the brief's health-endpoint pattern. The real fleet-wide anti-pattern is broader:

> **Any always-on Railway container issuing an unconditional DB query more often than every 5 min** — health probe, cron/interval, pool keepalive, OR a polling scheduler.

Neon ranking (compute = \$, same window): the truly never-sleeping services are **runs-service** (~100%, but avg CU 0.54 → likely real traffic, verify before touching), **campaign-service** (this PR), **postmark-service** (~99% @ floor), **instantly-service** (~84% @ floor). The ~28-30h band (key/workflow/stripe/pressbeat-sales/polaritycourse/features/journalists/brand) already sleeps ~half the time. Each service needs its **own** diagnosis — some are health-DB, some are schedulers/cron. Tracked + rollout list in the DIS issue.

Triage: **staging** (cost/perf, not prod-down).