### PR TITLE
fix(gate-check): auto-stop no-budget campaigns + backoff blocked results (stop Windmill re-fire loop)

### DIFF
--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -68,10 +68,14 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   }
 
   // 3. Budget check (fail-closed: no budget defined = blocked)
+  // A campaign with no budget can never run → terminal auto-stop (mirrors the
+  // "Total budget exceeded" / "Max leads reached" blocks). Leaving it ongoing with
+  // no nextRunAt makes the scheduler re-claim + re-fire the Windmill flow every tick.
   const hasAnyBudget = campaign.maxBudgetDailyUsd || campaign.maxBudgetWeeklyUsd ||
                        campaign.maxBudgetMonthlyUsd || campaign.maxBudgetTotalUsd;
   if (!hasAnyBudget) {
-    return { allowed: false, reason: "No budget defined (fail-closed)" };
+    await autoStopCampaign(campaign.campaignId);
+    return { allowed: false, reason: "No budget defined (fail-closed)", autoStopped: true };
   }
 
   // Build windows for configured budgets only

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -12,6 +12,11 @@ import { traceEvent } from "../lib/trace-event.js";
 
 const router = Router();
 
+// Backoff applied to a BLOCKED gate result that carries no scheduler decision
+// (neither autoStopped nor a window nextRunAt). Guarantees the campaign is not
+// re-claimed + re-fired on the very next scheduler tick.
+const GATE_BLOCK_BACKOFF_MS = 15 * 60_000; // 15 min
+
 /**
  * POST /gate-check
  *
@@ -78,10 +83,18 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
     }
 
     if (!result.allowed) {
-      // Save nextRunAt so the scheduler can re-trigger when the budget window resets
-      if (result.nextRunAt) {
+      // Invariant: every BLOCKED result must persist a scheduler decision — either
+      // terminal (autoStopped) OR a future nextRunAt. A null here would let
+      // claimStuckCampaigns re-claim the (ongoing, nextRunAt=null) campaign every tick
+      // and re-fire the Windmill flow indefinitely. Window blocks carry their own
+      // nextRunAt (reset boundary); any other no-decision block backs off explicitly.
+      let nextRunAt = result.nextRunAt ?? null;
+      if (!nextRunAt && !result.autoStopped) {
+        nextRunAt = new Date(Date.now() + GATE_BLOCK_BACKOFF_MS);
+      }
+      if (nextRunAt) {
         await db.update(campaigns)
-          .set({ nextRunAt: result.nextRunAt, updatedAt: new Date() })
+          .set({ nextRunAt, updatedAt: new Date() })
           .where(eq(campaigns.id, campaignId));
       }
     }

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -225,6 +225,30 @@ describe("Pipeline routes", () => {
       expect(updated!.nextRunAt).toBeNull();
     });
 
+    it("should persist a future nextRunAt when a blocked result has neither autoStopped nor nextRunAt", async () => {
+      const campaign = await insertTestCampaign(orgId, { brandIds });
+
+      // A no-decision block (e.g. "A run is already in progress" / "Lead stats unavailable")
+      // must NOT leave nextRunAt null — otherwise claimStuckCampaigns re-claims the
+      // (ongoing, nextRunAt=null) campaign every tick and re-fires the Windmill flow.
+      mockGateChecks.mockResolvedValue({
+        allowed: false,
+        reason: "A run is already in progress",
+      });
+
+      const before = Date.now();
+      await request(app)
+        .post("/gate-check")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.nextRunAt).not.toBeNull();
+      expect(new Date(updated!.nextRunAt!).getTime()).toBeGreaterThan(before);
+    });
+
     it("should pass campaign data to runGateChecks", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -151,7 +151,7 @@ describe("Gate Check", () => {
   });
 
   describe("Budget check", () => {
-    it("should block if no budget is defined (fail-closed)", async () => {
+    it("should auto-stop if no budget is defined (fail-closed, terminal)", async () => {
       const result = await runGateChecks(makeCampaign({
         maxBudgetDailyUsd: null,
         maxBudgetWeeklyUsd: null,
@@ -160,6 +160,10 @@ describe("Gate Check", () => {
       }));
       expect(result.allowed).toBe(false);
       expect(result.reason).toBe("No budget defined (fail-closed)");
+      // A zero-budget campaign can never run → terminal auto-stop, not retryable,
+      // so it is never re-claimed by the scheduler (no Windmill re-fire loop).
+      expect(result.autoStopped).toBe(true);
+      expect(mockDbUpdate).toHaveBeenCalled();
     });
 
     it("should block when daily budget is exceeded", async () => {


### PR DESCRIPTION
## Problem
A campaign that fails the gate with **no budget defined** was left `ongoing` with `nextRunAt=null`. The scheduler's `claimStuckCampaigns` then re-claimed it every tick and re-dispatched the Windmill `execute-workflow` flow, whose first node re-hits `/gate-check` → re-blocks → **infinite loop**. Measured in prod: ~31k `execute-workflow` runs per abandoned campaign over 6 days, ~93k wasted dispatches total. The gate blocks *before* `/start-run`, so no `campaign-service` run is ever created → `claimStuckCampaigns` always re-claims.

Root cause (confirmed via runs-service `run_events`): the no-budget branch in `runGateChecks` returned `{ allowed:false, reason }` with **neither `autoStopped` nor `nextRunAt`**, and the `/gate-check` handler persists `nextRunAt` only when the result carries one → `nextRunAt` stays null.

## Fix
- **`src/lib/gate-check.ts`** — the `"No budget defined (fail-closed)"` block now `autoStopCampaign(...)` + returns `autoStopped:true`, mirroring the existing terminal blocks `"Total budget exceeded"` / `"Max leads reached"`. A zero-budget campaign can never run → terminal, not retryable.
- **`src/routes/internal.ts`** `/gate-check` handler — defensive invariant: any blocked result with **no `autoStopped` and no `nextRunAt`** now persists a future `nextRunAt` (`GATE_BLOCK_BACKOFF_MS = 15 min`). Catches the remaining no-decision blocks (`"A run is already in progress"`, `"Lead stats unavailable"`). **A blocked gate result never leaves `nextRunAt` null.**

Both are explicit decisions (auto-stop / backoff), not error-swallowing — fail-loud convention intact.

## Not in scope (No-gos)
- ❌ No consecutive-failure / re-fire counter — commit `5d5d1fb` removed exactly that for false-positives. Persist-a-decision is the correct layer.
- Happy path (gate PASSED) + budget-window reschedule path unchanged.

## Tests (207/207 green; tsc clean)
- **Unit** `gate-check.test.ts`: no-budget input → `{allowed:false, autoStopped:true}` + `db.update` called.
- **Integration** `internal-routes.test.ts` (new): blocked result with neither `autoStopped` nor `nextRunAt` → handler persists a **future** `nextRunAt`. Existing budget-window save / autoStopped-no-write / PASS-no-write tests stay green.

## Triage
HOTFIX → `main`. Recurrence-prevention (4 looping campaigns already manually DB-stopped). Full happy-path + budget-window test coverage gates the merge.

Related: DIS-169 (strategic windowed-maxRuns rework) — this is the minimal interim, aligned, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)