### PR TITLE
hotfix: Scheduler inflight guard checks any live run for campaign (stop lead-service 409 storm)

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -20,7 +20,49 @@ export const IDLE_MAX_MS = 60 * 60_000; // 1 hour
 
 // A run is considered "fresh" (campaign actively executing) if it started within this window.
 // Older running rows are treated as orphans (workflow died without /end-run).
-const STUCK_RUN_FRESHNESS_THRESHOLD_MS = 10 * 60_000; // 10 minutes
+//
+// MUST be strictly greater than the longest legitimate flow duration. lead-service's
+// buffer/next fill can run up to ~10min (PULL_NEXT_TIMEOUT_MS=600s), and the wrapping
+// `lead-service/lead-serve` run has been observed at 755s in prod — so the old 10min
+// (= 600s) value left a legit long fill sitting right at the orphan boundary, where
+// claimStuckCampaigns could misclassify it as stuck and re-fire mid-fill (→ lead-service
+// 409 "Concurrent buffer/next" storms). 15min gives margin above the observed max.
+const STUCK_RUN_FRESHNESS_THRESHOLD_MS = 15 * 60_000; // 15 minutes
+
+/**
+ * Is a flow genuinely alive for this campaign right now?
+ *
+ * True when runs-service has ANY `running` run tagged with this campaignId that
+ * started within the freshness window — regardless of which service/taskName
+ * created it.
+ *
+ * Why campaignId-scoped and NOT (serviceName="campaign-service", taskName=campaignId):
+ * the campaign-service parent run is an ephemeral ~2s marker (start-run → end-run
+ * within seconds), NOT an enclosing span. The real work — lead-service buffer/next —
+ * runs up to ~12min in a separate `lead-service/lead-serve` run that is NOT linked
+ * under the marker (no parent_run_id chain). Scoping the inflight check to the marker
+ * saw a corpse and re-fired mid-fill, colliding with the still-running buffer/next
+ * → lead-service rejects the duplicate with 409 → windmill job hard-fails. Scoping to
+ * campaignId + running + freshness sees the genuinely-live descendant instead.
+ *
+ * The freshness bound preserves orphan recovery: a run still marked `running` past the
+ * threshold (workflow died without /end-run) no longer counts as alive, so the campaign
+ * is re-claimed/re-fired.
+ */
+async function hasLiveRunForCampaign(
+  orgId: string,
+  campaignId: string,
+  freshnessCutoff: Date,
+): Promise<boolean> {
+  const { runs } = await listRuns({
+    orgId,
+    campaignId,
+    status: "running",
+    startedAfter: freshnessCutoff.toISOString(),
+    limit: 1,
+  });
+  return runs.length > 0;
+}
 
 /**
  * Find all ongoing campaigns whose nextRunAt has passed,
@@ -67,22 +109,19 @@ export async function reRunDueCampaigns(): Promise<number> {
         continue;
       }
 
-      // Sequential-runs invariant: never fire a new parent run while a prior one is still alive.
-      // Without this guard, /end-run mis-fires (or claimStuckCampaigns false-positives) can lead to
-      // two parent flows running in parallel — caught downstream by lead-service as 409, but noisy.
-      const { runs: inflight } = await listRuns({
-        orgId: campaign.orgId,
-        serviceName: "campaign-service",
-        taskName: campaign.id,
-        status: "running",
-      });
-      if (inflight.length > 0) {
+      // Sequential-runs invariant: never fire a new flow while a prior one is still alive.
+      // Checks ANY running run for the campaign (not the ephemeral campaign-service marker),
+      // so the genuinely-long lead-service buffer/next fill is seen. Without this, /end-run's
+      // immediate re-trigger fires a second flow mid-fill → lead-service 409 storm.
+      const freshnessCutoff = new Date(now.getTime() - STUCK_RUN_FRESHNESS_THRESHOLD_MS);
+      const alive = await hasLiveRunForCampaign(campaign.orgId, campaign.id, freshnessCutoff);
+      if (alive) {
         const rescheduledAt = new Date(now.getTime() + 60_000);
         await db
           .update(campaigns)
           .set({ nextRunAt: rescheduledAt, updatedAt: new Date() })
           .where(eq(campaigns.id, campaign.id));
-        console.warn(`[campaign-service] Skipped re-fire for campaign ${campaign.id} — ${inflight.length} run(s) still in-flight. Rescheduled nextRunAt=${rescheduledAt.toISOString()}`);
+        console.warn(`[campaign-service] Skipped re-fire for campaign ${campaign.id} — a run is still in-flight. Rescheduled nextRunAt=${rescheduledAt.toISOString()}`);
         continue;
       }
 
@@ -141,15 +180,11 @@ export async function claimStuckCampaigns(): Promise<number> {
   let claimedCount = 0;
 
   for (const candidate of candidates) {
-    const { runs } = await listRuns({
-      orgId: candidate.orgId,
-      serviceName: "campaign-service",
-      taskName: candidate.id,
-      status: "running",
-      startedAfter: freshnessCutoff.toISOString(),
-    });
+    // Same definition of "alive" as reRunDueCampaigns: ANY running run for the
+    // campaign within the freshness window, regardless of which service owns it.
+    const alive = await hasLiveRunForCampaign(candidate.orgId, candidate.id, freshnessCutoff);
 
-    if (runs.length > 0) {
+    if (alive) {
       // Fresh run in flight → campaign is alive, not stuck.
       continue;
     }

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -262,15 +262,73 @@ describe("Scheduler - reRunDueCampaigns", () => {
     const count = await reRunDueCampaigns();
 
     expect(count).toBe(1);
-    expect(mockListRuns).toHaveBeenCalledWith(
+    // Guard is scoped to the campaign (any service), NOT the ephemeral
+    // (campaign-service, campaignId) marker run — so a live lead-service
+    // buffer/next run is seen.
+    const guardCall = mockListRuns.mock.calls[0][0];
+    expect(guardCall).toEqual(
       expect.objectContaining({
         orgId: "org-ext-1",
-        serviceName: "campaign-service",
-        taskName: "campaign-1",
+        campaignId: "campaign-1",
         status: "running",
+        startedAfter: expect.any(String),
       }),
     );
+    expect(guardCall.serviceName).toBeUndefined();
+    expect(guardCall.taskName).toBeUndefined();
     expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("should detect a live run owned by another service (e.g. lead-service)", async () => {
+    mockDbReturning.mockResolvedValue([
+      {
+        id: "campaign-1",
+        orgId: "org-ext-1",
+        workflowSlug: "sales-email-cold-outreach",
+        brandIds: ["brand-123"],
+        createdByUserId: "user-1",
+        parentRunId: null,
+        featureSlug: "sales-cold-email-v1",
+      },
+    ]);
+    // The campaign-service marker is long dead; the genuinely-alive run is a
+    // lead-service buffer/next fill. campaignId-scoped query returns it.
+    mockListRuns.mockResolvedValue({
+      runs: [{ id: "lead-serve-run", status: "running", startedAt: new Date().toISOString() }],
+      limit: 50,
+      offset: 0,
+    });
+
+    await reRunDueCampaigns();
+
+    expect(mockExecuteCampaignWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("should re-fire when the only running run has aged past the freshness threshold", async () => {
+    mockDbReturning.mockResolvedValue([
+      {
+        id: "campaign-1",
+        orgId: "org-ext-1",
+        workflowSlug: "sales-email-cold-outreach",
+        brandIds: ["brand-123"],
+        createdByUserId: "user-1",
+        parentRunId: null,
+        featureSlug: "sales-cold-email-v1",
+      },
+    ]);
+    // runs-service filters by startedAfter=freshnessCutoff; an orphan older than
+    // 15min is excluded → empty result → re-fire (orphan recovery).
+    mockListRuns.mockResolvedValue({ runs: [], limit: 50, offset: 0 });
+
+    const before = Date.now();
+    await reRunDueCampaigns();
+
+    // Freshness cutoff sent to runs-service is ~15min in the past.
+    const cutoffIso = mockListRuns.mock.calls[0][0].startedAfter as string;
+    const cutoffAgeMs = before - new Date(cutoffIso).getTime();
+    expect(cutoffAgeMs).toBeGreaterThanOrEqual(15 * 60_000 - 5_000);
+    expect(cutoffAgeMs).toBeLessThanOrEqual(15 * 60_000 + 5_000);
+    expect(mockExecuteCampaignWorkflow).toHaveBeenCalledTimes(1);
   });
 
   it("should reschedule nextRunAt to ~now+60s when skipping due to in-flight run", async () => {
@@ -373,15 +431,39 @@ describe("Scheduler - claimStuckCampaigns", () => {
     const count = await claimStuckCampaigns();
 
     expect(count).toBe(0);
-    expect(mockListRuns).toHaveBeenCalledWith(
+    // Same campaignId-scoped definition of "alive" as reRunDueCampaigns.
+    const guardCall = mockListRuns.mock.calls[0][0];
+    expect(guardCall).toEqual(
       expect.objectContaining({
         orgId: "org-1",
-        serviceName: "campaign-service",
-        taskName: "c-running",
+        campaignId: "c-running",
         status: "running",
         startedAfter: expect.any(String),
       }),
     );
+    expect(guardCall.serviceName).toBeUndefined();
+    expect(guardCall.taskName).toBeUndefined();
+    expect(mockDbReturning).not.toHaveBeenCalled();
+  });
+
+  it("should NOT reclaim a campaign whose run is 10-min-but-alive (within 15-min window)", async () => {
+    mockDbFindMany.mockResolvedValue([{ id: "c-long-fill", orgId: "org-1" }]);
+    // A 10-min-old buffer/next run is still within the 15-min freshness window,
+    // so runs-service (startedAfter filter) returns it → alive → not stuck.
+    const tenMinOld = new Date(Date.now() - 10 * 60_000).toISOString();
+    mockListRuns.mockResolvedValue({
+      runs: [{ id: "lead-serve-run", status: "running", startedAt: tenMinOld }],
+      limit: 50,
+      offset: 0,
+    });
+
+    const count = await claimStuckCampaigns();
+
+    expect(count).toBe(0);
+    const cutoffIso = mockListRuns.mock.calls[0][0].startedAfter as string;
+    const cutoffAgeMs = Date.now() - new Date(cutoffIso).getTime();
+    expect(cutoffAgeMs).toBeGreaterThanOrEqual(15 * 60_000 - 5_000);
+    expect(cutoffAgeMs).toBeLessThanOrEqual(15 * 60_000 + 5_000);
     expect(mockDbReturning).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Automated by release.sh