### PR TITLE
docs(claude): pin scheduler in-flight guard invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,7 @@ Unit tests (`pnpm test:unit`) need neither — they fully mock db/runs-client.
 - `drizzle/` — Database migration files
 - `tests/` — Test files (`*.test.ts`)
 - `openapi.json` — Auto-generated, do NOT edit manually
+
+## Scheduler in-flight guard — check ANY live run for the campaign, never the campaign-service marker
+
+The `campaign-service / <campaignId>` parent run (created by the workflow DAG's start-run) is an **ephemeral ~2s marker** — `start-run → end-run` within seconds — NOT an enclosing span. The genuinely-long work (lead-service `buffer/next`, observed up to **755s**) runs in a separate `lead-service / lead-serve` run that is **not linked** under the marker via `parent_run_id`. So `src/lib/scheduler.ts`'s "is a flow still alive?" check MUST query `listRuns` scoped to **`campaignId` + `status=running` + `startedAfter=freshnessCutoff`** (any service) via `hasLiveRunForCampaign()` — **never** `(serviceName="campaign-service", taskName=campaignId)`, which only sees the 2s corpse and re-fires mid-fill → `lead-service` `409 Concurrent buffer/next` storm. `STUCK_RUN_FRESHNESS_THRESHOLD_MS` must stay **strictly greater than** lead-service's max fill (`PULL_NEXT_TIMEOUT` 600s; observed 755s) — currently 15min. `reRunDueCampaigns` and `claimStuckCampaigns` MUST share the same helper. (Set 2026-06-13, v0.25.1 / DIS-277.)


### PR DESCRIPTION
Doc-only. Pins the v0.25.1 / DIS-277 root cause: the scheduler in-flight guard must check ANY live run for the campaign (campaignId-scoped), never the ephemeral 2s `(campaign-service, campaignId)` marker. Prevents re-scoping the guard back to the corpse in a future edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)