### PR TITLE
feat(gate-check): credit-affordability pre-flight to stop broke-org retry storm

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ BRAND_SERVICE_URL='https://brand.distribute.you'
 BRAND_SERVICE_API_KEY='your-brand-api-key'
 LEAD_SERVICE_URL='http://localhost:3008'
 LEAD_SERVICE_API_KEY='your-lead-api-key'
+BILLING_SERVICE_URL='https://billing.distribute.you'
+BILLING_SERVICE_API_KEY='your-billing-api-key'
 EMAIL_GATEWAY_SERVICE_URL='https://email-gateway.distribute.you'
 EMAIL_GATEWAY_SERVICE_API_KEY='your-gateway-api-key'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ When the user shares logs, errors, or bug reports: **ONLY diagnose and explain**
 
 Campaign CRUD and orchestration service for MCP Factory. Manages campaign lifecycle, budget tracking, and run coordination.
 
+## Log level: expected business states are NOT warnings
+
+A gate block caused by a **normal, expected** business state — out of credits, budget window exceeded, max leads reached — must trace/log at `info`, never `warn`/`error`. Running out of credit happens; it is not an anomaly and it is not campaign-service's job to flag it loudly (billing's dunning engine owns the "out of credit" story). Reserve `warn`/`error` for genuine fail-OPEN/fail-closed anomalies (misconfig, non-2xx from a sibling, unexpected throw). When adding a new gate-check block, decide its trace level by "is this an expected outcome or a fault?" — expected → info. (Set 2026-06-14, credit-affordability gate PR #171: the gate-check-result trace hard-coded `warn` for every BLOCKED result; out-of-credit blocks were surfacing as warnings.)
+
 ## Commands
 
 - `pnpm test` — run all tests (Vitest)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ Required variables:
 - `DATABASE_URL` - PostgreSQL connection string
 - `RUNS_SERVICE_URL` - URL of runs-service
 - `RUNS_SERVICE_API_KEY` - API key for runs-service
+- `BILLING_SERVICE_URL` - URL of billing-service (credit-affordability pre-flight in the gate)
+- `BILLING_SERVICE_API_KEY` - API key for billing-service
 - `SENTRY_DSN` - Sentry DSN for error tracking (optional)
+
+If `BILLING_SERVICE_URL` / `BILLING_SERVICE_API_KEY` are unset, the gate's credit-affordability
+check fails open (the run is allowed) so a missing config never freezes campaigns.
 
 ## Development
 

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -120,6 +120,18 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     }
   }
 
+  // 3b. Credit affordability check (fail-OPEN — deliberately differs from the budget
+  // checks' fail-closed stance). A broke org's run is pre-filtered here so it stops
+  // storming the per-minute Windmill flow + wasting Apollo enrichment before the LLM
+  // step 402s. This is NOT a terminal stop: the campaign stays ongoing and backs off
+  // via nextRunAt, so a recharge auto-resumes it on the next check (no manual restart,
+  // no webhook). A billing blip must not freeze ALL campaigns, and chat-service's own
+  // authorize remains the hard gate downstream — so any billing-call failure allows.
+  const affordable = await checkAffordability(campaign.campaignId, identity);
+  if (!affordable) {
+    return { allowed: false, reason: "Insufficient credits", nextRunAt: nextHalfHour() };
+  }
+
   // 4. Volume check
   if (campaign.maxLeads != null) {
     const completedRuns = runs.filter((r: Run) => r.status === "completed");
@@ -184,6 +196,47 @@ async function fetchLeadStats(
   return { totalServed: (data.totalServed as number) || (data.served as number) || 0 };
 }
 
+/**
+ * Pre-flight credit affordability check against billing-service.
+ * Returns true (allow the run) unless billing explicitly reports affordable=false.
+ *
+ * Fail-OPEN by design: missing config, network error, or non-2xx all return true.
+ * Credit affordability is a PRE-FILTER, not the final gate — chat-service's own
+ * authorize is the hard gate. A billing outage must never freeze every campaign.
+ */
+async function checkAffordability(campaignId: string, identity: IdentityHeaders): Promise<boolean> {
+  const url = process.env.BILLING_SERVICE_URL;
+  const apiKey = process.env.BILLING_SERVICE_API_KEY;
+  if (!url || !apiKey) {
+    console.warn("[campaign-service] Billing service not configured — skipping affordability check (fail-open)");
+    return true;
+  }
+
+  const headers: Record<string, string> = {
+    "x-api-key": apiKey,
+    "x-org-id": identity.orgId,
+  };
+  if (identity.userId) headers["x-user-id"] = identity.userId;
+  if (identity.runId) headers["x-run-id"] = identity.runId;
+  if (identity.campaignId) headers["x-campaign-id"] = identity.campaignId;
+  if (identity.brandId) headers["x-brand-id"] = identity.brandId;
+  if (identity.workflowSlug) headers["x-workflow-slug"] = identity.workflowSlug;
+
+  try {
+    const res = await fetch(`${url}/internal/campaigns/${campaignId}/affordability`, { headers });
+    if (!res.ok) {
+      console.warn(`[campaign-service] Affordability check failed (${res.status}) — allowing run (fail-open)`);
+      return true;
+    }
+    const data = await res.json() as { affordable?: boolean };
+    // Only an explicit affordable=false blocks. Anything else (true, missing) allows.
+    return data.affordable !== false;
+  } catch (err) {
+    console.warn("[campaign-service] Affordability check threw — allowing run (fail-open):", err);
+    return true;
+  }
+}
+
 function startOfToday(): Date {
   const d = new Date();
   d.setHours(0, 0, 0, 0);
@@ -199,6 +252,12 @@ function startOfMonth(): Date {
   d.setDate(1);
   d.setHours(0, 0, 0, 0);
   return d;
+}
+
+// Backoff for the credit-affordability block. Short enough to resume promptly after a
+// recharge, long enough not to defeat the scheduler's adaptive-tick Neon scale-to-zero.
+export function nextHalfHour(): Date {
+  return new Date(Date.now() + 30 * 60 * 1000);
 }
 
 export function nextDayStart(): Date {

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -73,11 +73,16 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
     });
 
     if (req.runId) {
+      // An out-of-credit org is a NORMAL, expected state (people run out of credit) —
+      // not an anomaly to warn on. The campaign simply backs off and auto-resumes on
+      // recharge. Trace it at info level, like a passing check, so it never surfaces as
+      // a warning/error in logs. Genuine fail-closed blocks keep warn level.
+      const benignBlock = result.reason === "Insufficient credits";
       traceEvent(req.runId, {
         service: "campaign-service",
         event: "gate-check-result",
         detail: `Gate check ${result.allowed ? "PASSED" : "BLOCKED"} for campaign ${campaignId}${result.reason ? ` — reason: ${result.reason}` : ""}${result.autoStopped ? " (auto-stopped)" : ""}`,
-        level: result.allowed ? "info" : "warn",
+        level: result.allowed || benignBlock ? "info" : "warn",
         data: { campaignId, allowed: result.allowed, reason: result.reason, autoStopped: result.autoStopped },
       }, req.headers).catch(() => {});
     }

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 const {
   mockListRuns,
@@ -306,6 +306,86 @@ describe("Gate Check", () => {
       const result = await runGateChecks(makeCampaign({ maxLeads: 10 }));
       expect(result.allowed).toBe(false);
       expect(result.reason).toBe("Lead stats unavailable (fail-closed)");
+    });
+  });
+
+  describe("Credit affordability check", () => {
+    const ORIG_URL = process.env.BILLING_SERVICE_URL;
+    const ORIG_KEY = process.env.BILLING_SERVICE_API_KEY;
+
+    beforeEach(() => {
+      process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+      process.env.BILLING_SERVICE_API_KEY = "test-billing-key";
+    });
+
+    afterEach(() => {
+      if (ORIG_URL === undefined) delete process.env.BILLING_SERVICE_URL;
+      else process.env.BILLING_SERVICE_URL = ORIG_URL;
+      if (ORIG_KEY === undefined) delete process.env.BILLING_SERVICE_API_KEY;
+      else process.env.BILLING_SERVICE_API_KEY = ORIG_KEY;
+    });
+
+    it("should block with 30min backoff (NOT auto-stopped) when org cannot afford the run", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ affordable: false, balanceCents: "0", lastRequiredCents: "150", hasHistory: true }),
+      });
+
+      const before = Date.now();
+      const result = await runGateChecks(makeCampaign());
+      const after = Date.now();
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Insufficient credits");
+      // Backed off ~30min, campaign stays ongoing → recharge auto-resumes (no manual restart).
+      expect(result.nextRunAt).toBeInstanceOf(Date);
+      expect(result.nextRunAt!.getTime()).toBeGreaterThanOrEqual(before + 30 * 60 * 1000);
+      expect(result.nextRunAt!.getTime()).toBeLessThanOrEqual(after + 30 * 60 * 1000 + 1000);
+      // Must NOT auto-stop — that would need a manual restart instead of self-healing.
+      expect(result.autoStopped).toBeUndefined();
+      expect(mockDbUpdate).not.toHaveBeenCalled();
+    });
+
+    it("should proceed when org can afford the run (affordable=true)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ affordable: true, balanceCents: "5000", lastRequiredCents: "150", hasHistory: true }),
+      });
+
+      const result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should fail-open (allow + warn) when the billing call throws", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockFetch.mockRejectedValueOnce(new Error("ECONNRESET"));
+
+      const result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("should fail-open (allow) on a non-2xx billing response", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      const result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should call the locked affordability contract with x-api-key + identity headers", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ affordable: true, balanceCents: "5000", lastRequiredCents: null, hasHistory: false }),
+      });
+
+      await runGateChecks(makeCampaign({ userId: "user-1", runId: "run-1" }));
+
+      const [calledUrl, opts] = mockFetch.mock.calls[0];
+      expect(calledUrl).toBe("https://billing.test.local/internal/campaigns/campaign-1/affordability");
+      expect(opts.headers["x-api-key"]).toBe("test-billing-key");
+      expect(opts.headers["x-org-id"]).toBe("org-1");
+      expect(opts.headers["x-campaign-id"]).toBe("campaign-1");
     });
   });
 


### PR DESCRIPTION
## What
Adds a credit-affordability check to the campaign gate so a broke org's campaign **stops re-firing** its per-minute Windmill run and **auto-resumes on recharge** — no manual restart, no webhook.

## Why
When an org runs out of credits, campaign-service keeps re-triggering the campaign's workflow every minute. Each run does paid Apollo enrichment, then 402s at the LLM step (chat-service `/complete` → insufficient credits). Result: red error logs, Windmill retries, wasted spend — looping forever until someone notices.

## How
In `src/lib/gate-check.ts` `runGateChecks`, after the budget checks, a new check calls billing-service's read-only per-campaign affordability endpoint:

```
GET {BILLING_SERVICE_URL}/internal/campaigns/:campaignId/affordability
  auth: x-api-key = BILLING_SERVICE_API_KEY
  200 → { affordable, balanceCents, lastRequiredCents, hasHistory }
```

- `affordable=false` → `{ allowed:false, reason:"Insufficient credits", nextRunAt: now+30min }`. **Backoff, NOT auto-stop** — campaign stays ongoing and re-checks at `nextRunAt`, so a recharge auto-resumes it (same machinery as the windowed budget blocks).
- `affordable=true` → gate proceeds exactly as today.
- **Fail-OPEN** on any billing-call problem (missing config / non-2xx / throw): run allowed + warning logged. A billing blip must not freeze every campaign, and chat-service's own authorize stays the hard gate downstream. Deliberately differs from the budget checks' fail-closed stance — this is a pre-filter.

Out-of-credit is a **normal** state, so its BLOCKED gate trace is emitted at `info` (not `warn`) — running out of credit is not an anomaly.

## Tests
`tests/unit/gate-check.test.ts` — 5 new cases: insufficient → blocked w/ 30min backoff and NOT auto-stopped; affordable → allowed; billing throws → fail-open; non-2xx → fail-open; locked-contract URL + x-api-key + identity headers. Full unit suite: **108 passed**. Build + openapi regen green.

## ⚠️ Merge gates
1. **Railway env**: `BILLING_SERVICE_URL` + `BILLING_SERVICE_API_KEY` must be set on campaign-service before merge (shared vars, already present on other services). Until set, the check fails open (allows) — safe but inert.
2. **billing-service dependency**: `GET /internal/campaigns/:campaignId/affordability` must be deployed to **staging first** (sibling work on billing's `KevinLourd/credit-gate-rfc` branch). Not yet on billing main/staging — do not merge until live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)