### PR TITLE
fix(scheduler): grace delay on completed re-trigger — kill ~60s per-lead idle tax

### DIFF
--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -17,6 +17,22 @@ const router = Router();
 // re-claimed + re-fired on the very next scheduler tick.
 const GATE_BLOCK_BACKOFF_MS = 15 * 60_000; // 15 min
 
+// Grace delay before a COMPLETED run becomes due for re-trigger.
+//
+// Why not 0: the campaign-service `/end-run` is fired by the ephemeral
+// `campaign-service / <campaignId>` marker, which ends ~6s BEFORE the wrapping
+// `workflow / execute-workflow` run (that run is tagged with the same campaignId).
+// Setting nextRunAt=now + wakeScheduler() fired the next tick instantly, but the
+// in-flight guard (scheduler.ts hasLiveRunForCampaign) still saw the tearing-down
+// wrapper run as "alive" → skipped + rescheduled +60s. So an intended-instant
+// re-run actually paid a flat ~60s idle tax EVERY lead (~110s/lead observed).
+//
+// A small grace lets the wrapper run finish before the re-run tick, so the guard
+// sees no live run and re-fires cleanly (~40s/lead). If teardown ever exceeds the
+// grace, the guard's +60s skip still applies — never worse than the old behavior.
+// Does NOT touch the long-fill (cold-buffer up to ~755s) in-flight protection.
+const RERUN_GRACE_MS = 10_000; // 10s
+
 /**
  * POST /gate-check
  *
@@ -294,8 +310,10 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
         return;
       }
 
-      // Failed runs get a 60s backoff; completed runs re-run immediately
-      const delayMs = status === "failed" ? 60_000 : 0;
+      // Failed runs get a 60s backoff; completed runs re-run after a short grace
+      // (RERUN_GRACE_MS) so the wrapping workflow run finishes teardown before the
+      // re-run tick — otherwise the in-flight guard sees it alive and forces +60s.
+      const delayMs = status === "failed" ? 60_000 : RERUN_GRACE_MS;
       const nextRunAt = new Date(Date.now() + delayMs);
 
       if (req.runId) {

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -625,7 +625,7 @@ describe("Pipeline routes", () => {
       expect(mockUpdateRun).toHaveBeenCalledWith("run-own", "failed", expect.objectContaining({ orgId }));
     });
 
-    it("should set nextRunAt=now when success=true stopCampaign=false and campaign is ongoing", async () => {
+    it("should set nextRunAt=now+10s grace when success=true stopCampaign=false and campaign is ongoing", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "ongoing",
@@ -650,9 +650,10 @@ describe("Pipeline routes", () => {
       });
       expect(updated!.nextRunAt).not.toBeNull();
       const nextRunTime = new Date(updated!.nextRunAt!).getTime();
-      // Should be ~now (within 5s tolerance)
-      expect(nextRunTime).toBeGreaterThanOrEqual(before);
-      expect(nextRunTime).toBeLessThan(before + 5_000);
+      // Should be ~now + 10s grace (lets the wrapping workflow run finish teardown
+      // before the re-run tick, so the in-flight guard doesn't slam a +60s skip).
+      expect(nextRunTime).toBeGreaterThanOrEqual(before + 9_000);
+      expect(nextRunTime).toBeLessThan(before + 15_000);
       // Must NOT fire-and-forget
       expect(mockExecute).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Problem
A live cold-email campaign processes ~1 lead per ~110s (~30 leads/hr). Only ~30s is real work; ~60-80s is forced idle.

## Root cause
On a **completed** run, `/end-run` set `nextRunAt = now` + `wakeScheduler()` (`src/routes/internal.ts:298`) to re-run instantly. But `/end-run` fires from the ephemeral `campaign-service / <campaignId>` marker, which ends **~6s before** the wrapping `workflow / execute-workflow` run (tagged with the same `campaignId`). The instant tick → `reRunDueCampaigns` → `hasLiveRunForCampaign` sees the still-tearing-down wrapper run as alive → in-flight guard reschedules `+60_000` (`src/lib/scheduler.ts:119`). Every lead pays a flat ~60s tax.

Evidence (runs-service prod, this campaign): `workflow / execute-workflow` runs last ~30s but start ~105s apart (gaps 83-143s).

## Fix
Add `RERUN_GRACE_MS = 10_000`: a completed run becomes due after a 10s grace instead of `0`. The wrapper finishes teardown before the re-run tick, so the guard sees no live run and re-fires cleanly. Cadence ~110s → ~40s/lead (~2.7×).

- If teardown ever exceeds the grace → falls back to the +60s skip (**never worse**).
- Failed-run 60s backoff: untouched.
- Long-fill (cold-buffer up to ~755s) in-flight protection (`scheduler.ts:118-128`): untouched — no extra polling.

## Tests
- Unit 108/108.
- Integration: `end-run` re-trigger asserts `nextRunAt ≈ now+10s` for completed, `now+60s` for failed. 50/50 green.

## Verify post-deploy
Re-run the workflow-run gap query on the campaign → gaps should drop to ~40s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)