### PR TITLE
feat(brand-pause): hold a brand's ongoing campaigns at the scheduler

### DIFF
--- a/drizzle/0033_brand_pause.sql
+++ b/drizzle/0033_brand_pause.sql
@@ -1,0 +1,10 @@
+-- Brand pause flag: ONE mutable row per brand. paused=true holds every ongoing campaign
+-- targeting the brand at the scheduler (campaign stays 'ongoing', is not claimed/fired).
+-- Idempotent (IF NOT EXISTS) so a partial-apply replay is safe.
+CREATE TABLE IF NOT EXISTS "brand_pause" (
+	"brand_id" text PRIMARY KEY NOT NULL,
+	"org_id" text NOT NULL,
+	"paused" boolean DEFAULT false NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "idx_brand_pause_org" ON "brand_pause" USING btree ("org_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1775700000000,
       "tag": "0032_fix_idx_campaigns_org",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1775800000000,
+      "tag": "0033_brand_pause",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -287,6 +287,41 @@
           }
         }
       },
+      "BrandPauseResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string"
+          },
+          "orgId": {
+            "type": "string"
+          },
+          "paused": {
+            "type": "boolean"
+          },
+          "updatedAt": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "brandId",
+          "orgId",
+          "paused",
+          "updatedAt"
+        ]
+      },
+      "UpdateBrandPauseBody": {
+        "type": "object",
+        "properties": {
+          "paused": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "paused"
+        ]
+      },
       "StatsResponse": {
         "type": "object",
         "properties": {
@@ -862,6 +897,125 @@
           },
           "404": {
             "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/brands/{brandId}/pause": {
+      "get": {
+        "tags": [
+          "Brands"
+        ],
+        "summary": "Get a brand's pause state",
+        "description": "Returns whether the brand is paused. When paused, the scheduler holds every ongoing campaign targeting this brand. No row → paused=false, updatedAt=null. Org-scoped via x-org-id.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Brand pause state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandPauseResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing x-org-id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Brands"
+        ],
+        "summary": "Set a brand's pause state (upsert)",
+        "description": "Pauses or un-pauses all of the brand's ongoing campaigns at the scheduler. Upserts one mutable row per brand. Un-pausing resumes held campaigns on the next scheduler tick with zero re-launch. Org-scoped via x-org-id.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBrandPauseBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated brand pause state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandPauseResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -19,6 +19,8 @@ import {
   EndRunResponse,
   TransferBrandBody,
   TransferBrandResponse,
+  UpdateBrandPauseBody,
+  BrandPauseResponse,
 } from "../src/schemas.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -129,6 +131,41 @@ registry.registerPath({
   responses: {
     200: { description: "Campaign deleted", content: { "application/json": { schema: z.object({ message: z.string() }) } } },
     404: { description: "Not found", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+// === BRAND PAUSE ===
+
+registry.registerPath({
+  method: "get",
+  path: "/brands/{brandId}/pause",
+  tags: ["Brands"],
+  summary: "Get a brand's pause state",
+  description: "Returns whether the brand is paused. When paused, the scheduler holds every ongoing campaign targeting this brand. No row → paused=false, updatedAt=null. Org-scoped via x-org-id.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: { params: z.object({ brandId: z.string() }) },
+  responses: {
+    200: { description: "Brand pause state", content: { "application/json": { schema: BrandPauseResponse } } },
+    400: { description: "Missing x-org-id", content: { "application/json": { schema: ErrorResponse } } },
+    401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/brands/{brandId}/pause",
+  tags: ["Brands"],
+  summary: "Set a brand's pause state (upsert)",
+  description: "Pauses or un-pauses all of the brand's ongoing campaigns at the scheduler. Upserts one mutable row per brand. Un-pausing resumes held campaigns on the next scheduler tick with zero re-launch. Org-scoped via x-org-id.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: {
+    params: z.object({ brandId: z.string() }),
+    body: { content: { "application/json": { schema: UpdateBrandPauseBody } } },
+  },
+  responses: {
+    200: { description: "Updated brand pause state", content: { "application/json": { schema: BrandPauseResponse } } },
+    400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
+    401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
   },
 });
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, index, uniqueIndex, date, decimal, integer, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, index, uniqueIndex, date, decimal, integer, jsonb, boolean } from "drizzle-orm/pg-core";
 
 // Campaigns table
 export const campaigns = pgTable(
@@ -59,3 +59,27 @@ export const campaigns = pgTable(
 
 export type Campaign = typeof campaigns.$inferSelect;
 export type NewCampaign = typeof campaigns.$inferInsert;
+
+// Brand pause flag — ONE mutable row per brand (upsert in place).
+//
+// When paused=true, the campaign-service scheduler holds EVERY ongoing campaign whose
+// brandIds includes this brand (same org): the campaign stays 'ongoing' but is not claimed
+// or re-fired. Un-pausing (paused=false) lets the next scheduler tick pick those campaigns
+// up again with zero re-launch. Read/written via GET/PATCH /brands/:brandId/pause and
+// joined locally by the scheduler + gate-check (no per-tick HTTP). Mirrors the single-scalar
+// per-brand store pattern (billing-service brand_daily_budgets).
+export const brandPause = pgTable(
+  "brand_pause",
+  {
+    brandId: text("brand_id").primaryKey(),
+    orgId: text("org_id").notNull(),
+    paused: boolean("paused").notNull().default(false),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_brand_pause_org").on(table.orgId),
+  ]
+);
+
+export type BrandPause = typeof brandPause.$inferSelect;
+export type NewBrandPause = typeof brandPause.$inferInsert;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const __dirname = dirname(__filename);
 const openapiPath = join(__dirname, "..", "openapi.json");
 import healthRoutes from "./routes/health.js";
 import campaignsRoutes from "./routes/campaigns.js";
+import brandsRoutes from "./routes/brands.js";
 import statsRoutes from "./routes/stats.js";
 import internalRoutes from "./routes/internal.js";
 import { startScheduler } from "./lib/scheduler.js";
@@ -34,6 +35,7 @@ app.use(express.json());
 // Routes
 app.use(healthRoutes);
 app.use(campaignsRoutes);
+app.use(brandsRoutes);
 app.use(statsRoutes);
 app.use(internalRoutes);
 

--- a/src/lib/brand-pause.ts
+++ b/src/lib/brand-pause.ts
@@ -1,0 +1,51 @@
+import { sql, and, eq, inArray, type SQL } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { brandPause, campaigns } from "../db/schema.js";
+
+/**
+ * SQL predicate: the campaign is NOT held by a brand pause.
+ *
+ * A campaign is HELD when ANY brandId in its `brand_ids` array belongs to a paused brand
+ * (brand_pause.paused = true) in the SAME org. This clause is the negation — true for
+ * campaigns that should still run.
+ *
+ * Injected into every scheduler query that filters status='ongoing' (reRunDueCampaigns claim,
+ * claimStuckCampaigns, loadOngoingSnapshot) so a paused brand's campaigns are excluded
+ * atomically via a LOCAL join — no per-tick HTTP. When the brand un-pauses, the row flips and
+ * those campaigns are picked up again on the next tick with zero re-launch.
+ *
+ * The inner subquery is self-contained (its own alias `c`), so it composes identically inside
+ * a core UPDATE, a core SELECT, and a relational findMany regardless of the outer query's alias.
+ */
+export function notPausedBrandClause(): SQL {
+  return sql`${campaigns.id} NOT IN (
+    SELECT c.id FROM ${campaigns} c
+    JOIN ${brandPause} bp
+      ON bp.org_id = c.org_id
+      AND bp.paused = true
+      AND bp.brand_id = ANY(c.brand_ids)
+  )`;
+}
+
+/**
+ * Does ANY of the given brands belong to a paused brand in this org?
+ *
+ * Single-campaign equivalent of notPausedBrandClause, used by gate-check to HOLD a campaign
+ * whose run was already in flight when its brand was paused. Org-scoped so a pause in one org
+ * can never hold another org's campaign.
+ */
+export async function anyBrandPaused(orgId: string, brandIds: string[]): Promise<boolean> {
+  if (brandIds.length === 0) return false;
+  const rows = await db
+    .select({ brandId: brandPause.brandId })
+    .from(brandPause)
+    .where(
+      and(
+        eq(brandPause.orgId, orgId),
+        eq(brandPause.paused, true),
+        inArray(brandPause.brandId, brandIds),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -2,6 +2,7 @@ import { listRuns, updateRun, getStatsBudget, type Run, type BudgetWindow, type 
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { eq } from "drizzle-orm";
+import { anyBrandPaused } from "./brand-pause.js";
 
 const STALE_THRESHOLD_MS = 3 * 60 * 60 * 1000; // 3 hours
 
@@ -32,6 +33,14 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   // Campaign must be ongoing
   if (campaign.status !== "ongoing") {
     return { allowed: false, reason: "Campaign is not ongoing" };
+  }
+
+  // Brand pause — HOLD if ANY target brand is paused (same org). Defense-in-depth: the
+  // scheduler already excludes paused-brand campaigns from its claim, but a run already in
+  // flight when the brand was paused still reaches this gate. NOT a terminal stop — the
+  // campaign stays 'ongoing'; internal.ts backs it off and the next un-pause resumes it.
+  if (await anyBrandPaused(campaign.orgId, campaign.brandIds)) {
+    return { allowed: false, reason: "Brand paused" };
   }
 
   const identity: IdentityHeaders = {

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -3,6 +3,7 @@ import { campaigns } from "../db/schema.js";
 import { eq, and, lte, isNotNull, isNull } from "drizzle-orm";
 import { executeCampaignWorkflow } from "./workflows.js";
 import { listRuns } from "@distribute/runs-client";
+import { notPausedBrandClause } from "./brand-pause.js";
 
 // Cadence while a campaign is actively running (a run is in-flight). At this
 // rate the scheduler catches /end-run reschedules and stuck-run detection.
@@ -84,6 +85,8 @@ export async function reRunDueCampaigns(): Promise<number> {
         eq(campaigns.status, "ongoing"),
         isNotNull(campaigns.nextRunAt),
         lte(campaigns.nextRunAt, now),
+        // Hold campaigns of paused brands — never claimed while any target brand is paused.
+        notPausedBrandClause(),
       ),
     )
     .returning({
@@ -174,6 +177,8 @@ export async function claimStuckCampaigns(): Promise<number> {
     where: and(
       eq(campaigns.status, "ongoing"),
       isNull(campaigns.nextRunAt),
+      // Hold campaigns of paused brands — a paused brand's stuck campaign is not re-claimed.
+      notPausedBrandClause(),
     ),
     columns: { id: true, orgId: true },
   });
@@ -240,7 +245,13 @@ export function computeNextDelayMs(
 /** Load the ongoing-campaign snapshot used to pick the next tick delay. */
 async function loadOngoingSnapshot(): Promise<Array<{ nextRunAt: Date | null }>> {
   return db.query.campaigns.findMany({
-    where: eq(campaigns.status, "ongoing"),
+    // Exclude paused-brand campaigns from the cadence snapshot too: an all-paused brand then
+    // yields an empty snapshot → IDLE_MAX_MS, so the Neon compute can suspend instead of being
+    // pinned at the 60s active cadence by a paused (nextRunAt=null) campaign.
+    where: and(
+      eq(campaigns.status, "ongoing"),
+      notPausedBrandClause(),
+    ),
     columns: { nextRunAt: true },
   });
 }

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -1,0 +1,79 @@
+import { Router } from "express";
+import { and, eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { brandPause } from "../db/schema.js";
+import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/auth.js";
+import { validateBody } from "../middleware/validate.js";
+import { UpdateBrandPauseBody } from "../schemas.js";
+import { wakeScheduler } from "../lib/scheduler.js";
+
+const router = Router();
+
+/**
+ * GET /brands/:brandId/pause — read a brand's pause state.
+ *
+ * Org-scoped: reads the row keyed on (brandId, orgId) so one org can never see another org's
+ * pause state. No row → default paused=false, updatedAt=null (orgId echoed from the authed org).
+ */
+router.get("/brands/:brandId/pause", requireApiKey, serviceAuth, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId } = req.params;
+    const orgId = req.orgId!;
+
+    const row = await db.query.brandPause.findFirst({
+      where: and(eq(brandPause.brandId, brandId), eq(brandPause.orgId, orgId)),
+    });
+
+    res.json({
+      brandId,
+      orgId,
+      paused: row?.paused ?? false,
+      updatedAt: row ? row.updatedAt.toISOString() : null,
+    });
+  } catch (error) {
+    console.error("[campaign-service] Get brand pause error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * PATCH /brands/:brandId/pause — set a brand's pause state (upsert in place).
+ *
+ * ONE mutable row per brand. Un-pausing wakes the scheduler so the brand's held campaigns
+ * resume promptly instead of waiting out the current idle sleep.
+ */
+router.patch("/brands/:brandId/pause", requireApiKey, serviceAuth, validateBody(UpdateBrandPauseBody), async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId } = req.params;
+    const orgId = req.orgId!;
+    const { paused } = req.body as { paused: boolean };
+    const now = new Date();
+
+    const [row] = await db
+      .insert(brandPause)
+      .values({ brandId, orgId, paused, updatedAt: now })
+      .onConflictDoUpdate({
+        target: brandPause.brandId,
+        set: { orgId, paused, updatedAt: now },
+      })
+      .returning();
+
+    // Un-pause → wake the scheduler so the brand's ongoing campaigns are re-claimed on the
+    // next tick rather than waiting out a deep idle sleep. (Pausing needs no wake.)
+    if (!paused) {
+      wakeScheduler();
+    }
+
+    res.json({
+      brandId: row.brandId,
+      orgId: row.orgId,
+      paused: row.paused,
+      updatedAt: row.updatedAt.toISOString(),
+    });
+  } catch (error) {
+    console.error("[campaign-service] Update brand pause error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -95,9 +95,11 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
       // recharge. Trace it at info level, like a passing check, so it never surfaces as
       // a warning/error in logs. Genuine fail-closed blocks keep warn level.
       // A brand reaching its daily budget is the same class of expected business state
-      // (pacing ceiling hit, not a fault) → also benign/info.
+      // (pacing ceiling hit, not a fault) → also benign/info. A user-paused brand is likewise
+      // an intentional, expected hold — not an anomaly.
       const benignBlock = result.reason === "Insufficient credits" ||
-                          result.reason === "Brand daily budget reached";
+                          result.reason === "Brand daily budget reached" ||
+                          result.reason === "Brand paused";
       traceEvent(req.runId, {
         service: "campaign-service",
         event: "gate-check-result",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -80,6 +80,19 @@ export const UpdateCampaignBody = z.object({
   notifyDestination: z.string().optional(),
 }).openapi("UpdateCampaignBody");
 
+// --- Brand pause ---
+
+export const UpdateBrandPauseBody = z.object({
+  paused: z.boolean(),
+}).openapi("UpdateBrandPauseBody");
+
+export const BrandPauseResponse = z.object({
+  brandId: z.string(),
+  orgId: z.string(),
+  paused: z.boolean(),
+  updatedAt: z.string().nullable(),
+}).openapi("BrandPauseResponse");
+
 // --- Stats ---
 
 export const StatsGroupByEnum = z.enum([

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,11 +1,23 @@
 import { db, sql } from "../../src/db/index.js";
-import { campaigns } from "../../src/db/schema.js";
+import { campaigns, brandPause } from "../../src/db/schema.js";
 
 /**
  * Clean all test data from the database
  */
 export async function cleanTestData() {
   await db.delete(campaigns);
+  await db.delete(brandPause);
+}
+
+/** Upsert a brand_pause row (mirror the route's upsert-in-place semantics). */
+export async function setBrandPause(orgId: string, brandId: string, paused: boolean) {
+  await db
+    .insert(brandPause)
+    .values({ brandId, orgId, paused, updatedAt: new Date() })
+    .onConflictDoUpdate({
+      target: brandPause.brandId,
+      set: { orgId, paused, updatedAt: new Date() },
+    });
 }
 
 /**

--- a/tests/integration/brand-pause.test.ts
+++ b/tests/integration/brand-pause.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+
+// Keep workflow + runs-client inert so the scheduler under test never actually fires a flow
+// and always sees "no live run" (→ campaigns are eligible to claim unless a pause holds them).
+const { mockExecute } = vi.hoisted(() => ({ mockExecute: vi.fn() }));
+
+vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
+  return { ...original, executeCampaignWorkflow: mockExecute };
+});
+
+vi.mock("@distribute/runs-client", () => ({
+  listRuns: vi.fn().mockResolvedValue({ runs: [] }),
+  createRun: vi.fn().mockResolvedValue({ id: "run-1" }),
+  updateRun: vi.fn(),
+  getStatsBudget: vi.fn(),
+}));
+
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import app from "../../src/index.js";
+import { db } from "../../src/db/index.js";
+import { campaigns } from "../../src/db/schema.js";
+import { cleanTestData, closeDb, insertTestCampaign, setBrandPause } from "../helpers/test-db.js";
+import { reRunDueCampaigns, claimStuckCampaigns } from "../../src/lib/scheduler.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+const orgId = "brand-pause-org";
+const past = () => new Date(Date.now() - 60_000);
+
+function getPause(brandId: string, org = orgId) {
+  return request(app).get(`/brands/${brandId}/pause`).set("x-api-key", API_KEY).set("x-org-id", org);
+}
+function patchPause(brandId: string, paused: boolean, org = orgId) {
+  return request(app)
+    .patch(`/brands/${brandId}/pause`)
+    .set("x-api-key", API_KEY)
+    .set("x-org-id", org)
+    .set("Content-Type", "application/json")
+    .send({ paused });
+}
+
+// One afterAll at FILE scope (single shared pg pool across describe blocks).
+afterAll(async () => {
+  await cleanTestData();
+  await closeDb();
+});
+
+describe("Brand pause routes", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue(undefined);
+  });
+
+  it("GET returns paused=false, updatedAt=null when no row exists", async () => {
+    const brandId = crypto.randomUUID();
+    const res = await getPause(brandId).expect(200);
+    expect(res.body).toEqual({ brandId, orgId, paused: false, updatedAt: null });
+  });
+
+  it("PATCH {paused:true} then GET returns paused=true", async () => {
+    const brandId = crypto.randomUUID();
+    const patched = await patchPause(brandId, true).expect(200);
+    expect(patched.body.paused).toBe(true);
+    expect(patched.body.brandId).toBe(brandId);
+    expect(patched.body.orgId).toBe(orgId);
+    expect(patched.body.updatedAt).not.toBeNull();
+
+    const got = await getPause(brandId).expect(200);
+    expect(got.body.paused).toBe(true);
+  });
+
+  it("PATCH upserts in place (single row, flips value)", async () => {
+    const brandId = crypto.randomUUID();
+    await patchPause(brandId, true).expect(200);
+    await patchPause(brandId, false).expect(200);
+
+    const got = await getPause(brandId).expect(200);
+    expect(got.body.paused).toBe(false);
+
+    // Exactly one row exists for the brand.
+    const rows = await db.query.brandPause.findMany({ where: (b, { eq: e }) => e(b.brandId, brandId) });
+    expect(rows).toHaveLength(1);
+  });
+
+  it("PATCH rejects a non-boolean paused body (400, fail-loud)", async () => {
+    const brandId = crypto.randomUUID();
+    await request(app)
+      .patch(`/brands/${brandId}/pause`)
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", orgId)
+      .send({ paused: "yes" })
+      .expect(400);
+  });
+
+  it("is org-scoped: org B cannot see org A's pause state", async () => {
+    const brandId = crypto.randomUUID();
+    await patchPause(brandId, true, "org-A").expect(200);
+
+    const otherOrg = await getPause(brandId, "org-B").expect(200);
+    expect(otherOrg.body.paused).toBe(false);
+    expect(otherOrg.body.orgId).toBe("org-B");
+  });
+
+  it("requires x-org-id (400)", async () => {
+    const brandId = crypto.randomUUID();
+    await request(app).get(`/brands/${brandId}/pause`).set("x-api-key", API_KEY).expect(400);
+  });
+
+  it("requires a valid api key (401)", async () => {
+    const brandId = crypto.randomUUID();
+    await request(app).get(`/brands/${brandId}/pause`).set("x-api-key", "wrong").set("x-org-id", orgId).expect(401);
+  });
+});
+
+describe("Scheduler holds paused-brand campaigns", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue(undefined);
+  });
+
+  it("reRunDueCampaigns does NOT claim a due campaign whose brand is paused, and leaves status=ongoing", async () => {
+    const brandId = crypto.randomUUID();
+    const campaign = await insertTestCampaign(orgId, {
+      status: "ongoing",
+      nextRunAt: past(),
+      brandIds: [brandId],
+      featureSlug: "sales-cold-email-v1",
+      createdByUserId: "user-x",
+    });
+    await setBrandPause(orgId, brandId, true);
+
+    const count = await reRunDueCampaigns();
+    expect(count).toBe(0);
+    expect(mockExecute).not.toHaveBeenCalled();
+
+    const after = await db.query.campaigns.findFirst({ where: eq(campaigns.id, campaign.id) });
+    expect(after!.status).toBe("ongoing"); // held, NOT stopped
+    expect(after!.nextRunAt).not.toBeNull(); // nextRunAt untouched (not claimed)
+  });
+
+  it("reRunDueCampaigns DOES claim a due campaign whose brand is not paused", async () => {
+    const brandId = crypto.randomUUID();
+    await insertTestCampaign(orgId, {
+      status: "ongoing",
+      nextRunAt: past(),
+      brandIds: [brandId],
+      featureSlug: "sales-cold-email-v1",
+      createdByUserId: "user-x",
+    });
+    // No pause row (or paused=false) → unaffected.
+    await setBrandPause(orgId, brandId, false);
+
+    const count = await reRunDueCampaigns();
+    expect(count).toBe(1);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds a multi-brand campaign if ANY one of its brands is paused", async () => {
+    const b1 = crypto.randomUUID();
+    const b2 = crypto.randomUUID();
+    await insertTestCampaign(orgId, {
+      status: "ongoing",
+      nextRunAt: past(),
+      brandIds: [b1, b2],
+      featureSlug: "sales-cold-email-v1",
+      createdByUserId: "user-x",
+    });
+    await setBrandPause(orgId, b2, true); // only the second brand is paused
+
+    const count = await reRunDueCampaigns();
+    expect(count).toBe(0);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("a pause in a DIFFERENT org does not hold this org's campaign", async () => {
+    const brandId = crypto.randomUUID();
+    await insertTestCampaign(orgId, {
+      status: "ongoing",
+      nextRunAt: past(),
+      brandIds: [brandId],
+      featureSlug: "sales-cold-email-v1",
+      createdByUserId: "user-x",
+    });
+    await setBrandPause("some-other-org", brandId, true); // same brandId, wrong org
+
+    const count = await reRunDueCampaigns();
+    expect(count).toBe(1); // not held — pause is org-scoped
+  });
+
+  it("claimStuckCampaigns does NOT claim a stuck campaign whose brand is paused", async () => {
+    const brandId = crypto.randomUUID();
+    const campaign = await insertTestCampaign(orgId, {
+      status: "ongoing",
+      nextRunAt: null, // stuck shape: ongoing + no nextRunAt
+      brandIds: [brandId],
+    });
+    await setBrandPause(orgId, brandId, true);
+
+    const claimed = await claimStuckCampaigns();
+    expect(claimed).toBe(0);
+
+    const after = await db.query.campaigns.findFirst({ where: eq(campaigns.id, campaign.id) });
+    expect(after!.nextRunAt).toBeNull(); // not claimed
+  });
+
+  it("un-pausing resumes: held while paused, claimed on the next tick after un-pause", async () => {
+    const brandId = crypto.randomUUID();
+    await insertTestCampaign(orgId, {
+      status: "ongoing",
+      nextRunAt: past(),
+      brandIds: [brandId],
+      featureSlug: "sales-cold-email-v1",
+      createdByUserId: "user-x",
+    });
+    await setBrandPause(orgId, brandId, true);
+
+    expect(await reRunDueCampaigns()).toBe(0); // held
+
+    await setBrandPause(orgId, brandId, false); // un-pause
+    expect(await reRunDueCampaigns()).toBe(1); // resumed, zero re-launch
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -5,6 +5,7 @@ const {
   mockUpdateRun,
   mockGetStatsBudget,
   mockDbUpdate,
+  mockAnyBrandPaused,
 } = vi.hoisted(() => {
   const mockSet = vi.fn().mockReturnValue({
     where: vi.fn().mockResolvedValue(undefined),
@@ -14,8 +15,13 @@ const {
     mockUpdateRun: vi.fn(),
     mockGetStatsBudget: vi.fn(),
     mockDbUpdate: vi.fn().mockReturnValue({ set: mockSet }),
+    mockAnyBrandPaused: vi.fn(),
   };
 });
+
+vi.mock("../../src/lib/brand-pause.js", () => ({
+  anyBrandPaused: mockAnyBrandPaused,
+}));
 
 vi.mock("@distribute/runs-client", () => ({
   listRuns: mockListRuns,
@@ -96,6 +102,33 @@ describe("Gate Check", () => {
     mockListRuns.mockResolvedValue({ runs: [] });
     mockGetStatsBudget.mockResolvedValue({ windows: [] });
     mockUpdateRun.mockResolvedValue({});
+    mockAnyBrandPaused.mockResolvedValue(false);
+  });
+
+  describe("Brand pause", () => {
+    it("should HOLD (block, non-terminal) when a target brand is paused", async () => {
+      mockAnyBrandPaused.mockResolvedValue(true);
+      const result = await runGateChecks(makeCampaign({ brandIds: ["brand-1"] }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Brand paused");
+      // HOLD, not terminal: never auto-stops the campaign.
+      expect(result.autoStopped).toBeUndefined();
+      // Short-circuits before the runs fetch — a paused brand never hits runs-service.
+      expect(mockListRuns).not.toHaveBeenCalled();
+    });
+
+    it("should HOLD a multi-brand campaign if ANY one brand is paused", async () => {
+      mockAnyBrandPaused.mockResolvedValue(true);
+      const result = await runGateChecks(makeCampaign({ brandIds: ["b1", "b2", "b3"] }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Brand paused");
+    });
+
+    it("should NOT block when no target brand is paused", async () => {
+      mockAnyBrandPaused.mockResolvedValue(false);
+      const result = await runGateChecks(makeCampaign({ brandIds: ["b1", "b2"] }));
+      expect(result.allowed).toBe(true);
+    });
   });
 
   it("should block if campaign is not ongoing", async () => {

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -62,6 +62,12 @@ vi.mock("drizzle-orm", () => ({
   isNull: vi.fn(),
 }));
 
+// The pause filter is exercised in tests/integration/brand-pause.test.ts against a real DB.
+// Here it's a no-op fragment so the narrowly-mocked db/schema/drizzle-orm stay sufficient.
+vi.mock("../../src/lib/brand-pause.js", () => ({
+  notPausedBrandClause: vi.fn(() => undefined),
+}));
+
 import {
   reRunDueCampaigns,
   claimStuckCampaigns,


### PR DESCRIPTION
## What

Brand-level **Pause/Restart** for the brand overview page (replaces per-campaign management). Pausing a brand **holds all its outreach** — the campaign-service scheduler stops sending — **without losing campaign state**, so Restart resumes instantly on the next tick with zero re-launch.

The pause flag AND its enforcement live in campaign-service because it owns the scheduler/gate that gates sending.

## How

- **New `brand_pause` store** — ONE mutable row per brand (`brand_id` PK, `org_id` NOT NULL, `paused` bool, `updated_at`). Upsert in place. Mirrors the single-scalar-per-brand store pattern. Migration `0033_brand_pause` (hand-authored — drizzle meta is drifted per repo CLAUDE.md; idempotent `IF NOT EXISTS`).
- **Routes** (api-service proxies byte-equal — paths/shape locked):
  - `GET /brands/:brandId/pause` → `{ brandId, orgId, paused, updatedAt: string|null }`. No row → `paused=false, updatedAt=null`. Org-scoped via `x-org-id`.
  - `PATCH /brands/:brandId/pause` `{ paused }` → same shape (upsert). Un-pause calls `wakeScheduler()` so held campaigns resume promptly.
  - Auth: `requireApiKey + serviceAuth` (same as existing campaign routes; org from `x-org-id`).
- **Enforcement — local SQL join, no per-tick HTTP.** `notPausedBrandClause()` (`src/lib/brand-pause.ts`) is injected into **every** scheduler query that filters `status='ongoing'`: `reRunDueCampaigns` (atomic claim), `claimStuckCampaigns`, `loadOngoingSnapshot`. Any ongoing campaign whose `brandIds` includes a paused brand (same org) is **held — skipped, never set to `stopped`**. `gate-check` holds too (defense-in-depth for a run already in flight when pause flips). The `"Brand paused"` block traces at **info** (expected business state, per repo log-level rule).
- openapi.json regenerated.

## Acceptance criteria — all covered by tests

- ✅ PATCH `{paused:true}` → GET `paused:true`; brand's ongoing campaigns NOT claimed by the scheduler; status stays `ongoing`.
- ✅ PATCH `{paused:false}` → campaigns resume on the next tick.
- ✅ Campaign with ANY paused brand → held; no paused brand → unaffected.
- ✅ Multi-brand campaign held if ≥1 target brand paused.
- ✅ GET default-false-when-absent; PATCH upsert-in-place; cross-org isolation.

## Tests

- `tests/unit/gate-check.test.ts` — brand-pause HOLD (non-terminal, short-circuits before runs fetch; multi-brand; unaffected case).
- `tests/integration/brand-pause.test.ts` — routes (GET default, PATCH upsert, org isolation, 400/401) + scheduler enforcement (`reRunDueCampaigns`/`claimStuckCampaigns` hold paused, claim unpaused, multi-brand, cross-org, un-pause resumes).
- Unit 118 ✅ · Integration 120 ✅.

## Triage

Feature → **staging**. No new env vars (local DB only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)