### PR TITLE
test: guard brand budget pivot from Stripe subscriptions

### DIFF
--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -108,4 +108,37 @@ describe('No Legacy Patterns - CRITICAL', () => {
     expect(content).not.toMatch(/keySource\s*:/);
     expect(content).not.toMatch(/["']key_source["']/);
   });
+
+  it('should NOT use Stripe subscription lifecycle calls', () => {
+    const roots = [
+      srcDir,
+      path.join(__dirname, '../../packages'),
+      path.join(__dirname, '../../scripts'),
+    ].filter((dir) => fs.existsSync(dir));
+    const violations: { file: string; line: number; code: string }[] = [];
+
+    for (const root of roots) {
+      const files = getAllTsFiles(root);
+      for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+        const lines = content.split('\n');
+
+        lines.forEach((line, index) => {
+          const lower = line.toLowerCase();
+          if (lower.includes('stripe') || lower.includes('subscription')) {
+            violations.push({
+              file: path.relative(path.join(__dirname, '../..'), file),
+              line: index + 1,
+              code: line.trim().substring(0, 80),
+            });
+          }
+        });
+      }
+    }
+
+    expect(
+      violations,
+      `Campaign-service must not create/update/pause/cancel Stripe subscriptions:\n${violations.map(v => `  ${v.file}:${v.line}\n    ${v.code}`).join('\n')}`
+    ).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Add a no-legacy regression test that scans campaign-service source/package/script TypeScript files for Stripe or subscription references.
- Protect the brand-level daily budget pivot from reintroducing Stripe daily subscription lifecycle calls.

## Verification
- `pnpm exec vitest run tests/unit/gate-check.test.ts tests/unit/no-legacy.test.ts`
- `pnpm test:unit`
- `pnpm test:integration` (first full run had a transient stats route 404; rerun passed 120/120)
- `pnpm test`
- `pnpm build`
- `rg -n -i "stripe|subscription" src packages scripts || true`
- `rg -n "daily budget exceeded|No budget defined|nextDayStart" src tests || true`

Closes #184