### PR TITLE
fix: add org campaign teardown endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -550,6 +550,36 @@
           "sourceOrgId",
           "targetOrgId"
         ]
+      },
+      "DeleteCampaignsByOrgResponse": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string"
+          },
+          "deletedTables": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tableName": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "tableName",
+                "count"
+              ]
+            }
+          }
+        },
+        "required": [
+          "orgId",
+          "deletedTables"
+        ]
       }
     },
     "parameters": {}
@@ -1625,6 +1655,63 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/campaigns/by-org/{orgId}": {
+      "delete": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Delete campaign-owned org state for org teardown",
+        "description": "Deletes campaign-service-owned org-scoped state needed to stop future scheduling and campaign execution. Idempotent: missing org state returns success with zero counts. Does not call other services.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "orgId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Org campaign state deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteCampaignsByOrgResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
             "content": {
               "application/json": {
                 "schema": {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -21,6 +21,7 @@ import {
   TransferBrandResponse,
   UpdateBrandPauseBody,
   BrandPauseResponse,
+  DeleteCampaignsByOrgResponse,
 } from "../src/schemas.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -312,6 +313,23 @@ registry.registerPath({
     200: { description: "Transfer result", content: { "application/json": { schema: TransferBrandResponse } } },
     400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
     401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/internal/campaigns/by-org/{orgId}",
+  tags: ["Internal"],
+  summary: "Delete campaign-owned org state for org teardown",
+  description: "Deletes campaign-service-owned org-scoped state needed to stop future scheduling and campaign execution. Idempotent: missing org state returns success with zero counts. Does not call other services.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: {
+    params: z.object({ orgId: z.string().uuid() }),
+  },
+  responses: {
+    200: { description: "Org campaign state deleted", content: { "application/json": { schema: DeleteCampaignsByOrgResponse } } },
+    401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
+    500: { description: "Internal error", content: { "application/json": { schema: ErrorResponse } } },
   },
 });
 

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { campaigns } from "../db/schema.js";
+import { brandPause, campaigns } from "../db/schema.js";
 import { requireApiKey, requirePipelineHeaders, trackingHeaders, type AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun, type IdentityHeaders } from "@distribute/runs-client";
@@ -410,6 +410,50 @@ router.post("/internal/transfer-brand", requireApiKey, validateBody(TransferBran
     });
   } catch (error) {
     console.error("[campaign-service] transfer-brand error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * DELETE /internal/campaigns/by-org/:orgId
+ *
+ * Deletes campaign-service-owned org-scoped state during client-service org teardown.
+ *
+ * Idempotent: an org with no campaign-service-owned state returns 200 with zero counts.
+ * No cross-service fan-out: client-service remains the cascade coordinator.
+ */
+router.delete("/internal/campaigns/by-org/:orgId", requireApiKey, async (req, res) => {
+  try {
+    const { orgId } = req.params;
+
+    const result = await db.transaction(async (tx) => {
+      const deletedCampaigns = await tx
+        .delete(campaigns)
+        .where(eq(campaigns.orgId, orgId))
+        .returning({ id: campaigns.id });
+
+      const deletedBrandPause = await tx
+        .delete(brandPause)
+        .where(eq(brandPause.orgId, orgId))
+        .returning({ brandId: brandPause.brandId });
+
+      return {
+        campaigns: deletedCampaigns.length,
+        brandPause: deletedBrandPause.length,
+      };
+    });
+
+    console.log(`[campaign-service] org teardown: deleted ${result.campaigns} campaigns and ${result.brandPause} brand_pause rows for orgId=${orgId}`);
+
+    res.json({
+      orgId,
+      deletedTables: [
+        { tableName: "campaigns", count: result.campaigns },
+        { tableName: "brand_pause", count: result.brandPause },
+      ],
+    });
+  } catch (error) {
+    console.error("[campaign-service] org teardown error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -182,3 +182,12 @@ export const TransferBrandResponse = z.object({
   })),
 }).openapi("TransferBrandResponse");
 
+// --- Internal: Org Teardown ---
+
+export const DeleteCampaignsByOrgResponse = z.object({
+  orgId: z.string(),
+  deletedTables: z.array(z.object({
+    tableName: z.string(),
+    count: z.number().int(),
+  })),
+}).openapi("DeleteCampaignsByOrgResponse");

--- a/tests/integration/org-teardown.test.ts
+++ b/tests/integration/org-teardown.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from "vitest";
+import request from "supertest";
+
+// Mock external deps used by other internal routes (required for app import)
+vi.mock("@distribute/runs-client", () => ({
+  createRun: vi.fn(),
+  updateRun: vi.fn(),
+  listRuns: vi.fn(),
+  getStatsBudget: vi.fn(),
+}));
+
+vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
+  return { ...original, executeCampaignWorkflow: vi.fn() };
+});
+
+vi.mock("../../src/lib/gate-check.js", () => ({
+  runGateChecks: vi.fn(),
+}));
+
+import app from "../../src/index.js";
+import { db } from "../../src/db/index.js";
+import { brandPause, campaigns } from "../../src/db/schema.js";
+import { and, eq } from "drizzle-orm";
+import { cleanTestData, closeDb, insertTestCampaign, setBrandPause } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+
+describe("DELETE /internal/campaigns/by-org/:orgId", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("deletes campaign-owned org state and leaves other orgs untouched", async () => {
+    const orgId = crypto.randomUUID();
+    const otherOrgId = crypto.randomUUID();
+    const brandId = crypto.randomUUID();
+    const otherBrandId = crypto.randomUUID();
+    const campaign = await insertTestCampaign(orgId, {
+      name: "Active Org Campaign",
+      brandIds: [brandId],
+      status: "ongoing",
+      nextRunAt: new Date(Date.now() - 60_000),
+      createdByUserId: crypto.randomUUID(),
+      featureSlug: "sales-cold-email-v1",
+    });
+    const stoppedCampaign = await insertTestCampaign(orgId, {
+      name: "Stopped Org Campaign",
+      brandIds: [crypto.randomUUID()],
+      status: "stopped",
+    });
+    const otherCampaign = await insertTestCampaign(otherOrgId, {
+      name: "Other Org Campaign",
+      brandIds: [otherBrandId],
+      status: "ongoing",
+    });
+    await setBrandPause(orgId, brandId, true);
+    await setBrandPause(otherOrgId, otherBrandId, true);
+
+    const res = await request(app)
+      .delete(`/internal/campaigns/by-org/${orgId}`)
+      .set("x-api-key", API_KEY)
+      .expect(200);
+
+    expect(res.body).toEqual({
+      orgId,
+      deletedTables: [
+        { tableName: "campaigns", count: 2 },
+        { tableName: "brand_pause", count: 1 },
+      ],
+    });
+
+    const deletedActive = await db.query.campaigns.findFirst({
+      where: eq(campaigns.id, campaign.id),
+    });
+    const deletedStopped = await db.query.campaigns.findFirst({
+      where: eq(campaigns.id, stoppedCampaign.id),
+    });
+    const deletedPause = await db.query.brandPause.findFirst({
+      where: and(eq(brandPause.orgId, orgId), eq(brandPause.brandId, brandId)),
+    });
+    const remainingOtherCampaign = await db.query.campaigns.findFirst({
+      where: eq(campaigns.id, otherCampaign.id),
+    });
+    const remainingOtherPause = await db.query.brandPause.findFirst({
+      where: and(eq(brandPause.orgId, otherOrgId), eq(brandPause.brandId, otherBrandId)),
+    });
+
+    expect(deletedActive).toBeUndefined();
+    expect(deletedStopped).toBeUndefined();
+    expect(deletedPause).toBeUndefined();
+    expect(remainingOtherCampaign).toBeDefined();
+    expect(remainingOtherPause).toBeDefined();
+  });
+
+  it("is idempotent when no campaign-owned org state remains", async () => {
+    const orgId = crypto.randomUUID();
+    const brandId = crypto.randomUUID();
+    await insertTestCampaign(orgId, { brandIds: [brandId] });
+    await setBrandPause(orgId, brandId, true);
+
+    const first = await request(app)
+      .delete(`/internal/campaigns/by-org/${orgId}`)
+      .set("x-api-key", API_KEY)
+      .expect(200);
+    expect(first.body.deletedTables).toEqual([
+      { tableName: "campaigns", count: 1 },
+      { tableName: "brand_pause", count: 1 },
+    ]);
+
+    const second = await request(app)
+      .delete(`/internal/campaigns/by-org/${orgId}`)
+      .set("x-api-key", API_KEY)
+      .expect(200);
+    expect(second.body.deletedTables).toEqual([
+      { tableName: "campaigns", count: 0 },
+      { tableName: "brand_pause", count: 0 },
+    ]);
+  });
+
+  it("returns 200 with zero counts for an org that never had campaign state", async () => {
+    const orgId = crypto.randomUUID();
+
+    const res = await request(app)
+      .delete(`/internal/campaigns/by-org/${orgId}`)
+      .set("x-api-key", API_KEY)
+      .expect(200);
+
+    expect(res.body.deletedTables).toEqual([
+      { tableName: "campaigns", count: 0 },
+      { tableName: "brand_pause", count: 0 },
+    ]);
+  });
+
+  it("requires service API key auth", async () => {
+    await request(app)
+      .delete(`/internal/campaigns/by-org/${crypto.randomUUID()}`)
+      .expect(401);
+
+    await request(app)
+      .delete(`/internal/campaigns/by-org/${crypto.randomUUID()}`)
+      .set("x-api-key", "wrong-key")
+      .expect(401);
+  });
+
+  it("returns non-2xx when the database transaction fails", async () => {
+    const orgId = crypto.randomUUID();
+    vi.spyOn(db, "transaction").mockRejectedValueOnce(new Error("database unavailable"));
+
+    const res = await request(app)
+      .delete(`/internal/campaigns/by-org/${orgId}`)
+      .set("x-api-key", API_KEY)
+      .expect(500);
+
+    expect(res.body.error).toBe("Internal server error");
+  });
+});


### PR DESCRIPTION
## Summary
- Add service-auth DELETE /internal/campaigns/by-org/:orgId for client-service org teardown.
- Delete campaign-service-owned org state for the internal org UUID: campaigns and brand_pause rows.
- Keep the endpoint idempotent and fail-loud: missing state returns 200 with zero counts; DB transaction failure returns non-2xx.
- Regenerate OpenAPI docs.

## Triage
Hotfix to main / prod-direct. This is additive and internal-only, with no cross-service fan-out from campaign-service.

## Cascade teardown note
This is one producer leg for org cascade-teardown V1. client-service remains the cascade coordinator and will treat any non-2xx response as retryable failure.

## Verification
- COREPACK_ENABLE_AUTO_PIN=0 pnpm exec vitest run tests/integration/org-teardown.test.ts
- COREPACK_ENABLE_AUTO_PIN=0 pnpm exec vitest run tests/integration/org-teardown.test.ts tests/integration/transfer-brand.test.ts
- COREPACK_ENABLE_AUTO_PIN=0 pnpm build
- COREPACK_ENABLE_AUTO_PIN=0 pnpm exec vitest run