### PR TITLE
feat(audience): stamp + propagate chosen audience id from start-run

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -529,6 +529,10 @@
             "type": "string",
             "nullable": true
           },
+          "audienceId": {
+            "type": "string",
+            "nullable": true
+          },
           "searchParams": {
             "type": "object",
             "nullable": true,
@@ -550,6 +554,7 @@
           "brandProfileId",
           "customerPersonaId",
           "customerProfileId",
+          "audienceId",
           "searchParams"
         ]
       },

--- a/packages/runs-client/src/index.ts
+++ b/packages/runs-client/src/index.ts
@@ -33,6 +33,8 @@ export interface IdentityHeaders {
   brandId?: string;
   workflowSlug?: string;
   featureSlug?: string;
+  /** Priority audience (human-service saved filter-set UUID) → x-audience-id header. */
+  audienceId?: string;
 }
 
 export interface CreateRunParams {
@@ -45,6 +47,8 @@ export interface CreateRunParams {
   parentRunId?: string;
   workflowSlug?: string;
   featureSlug?: string;
+  /** Priority audience (human-service saved filter-set UUID) → x-audience-id header. */
+  audienceId?: string;
 }
 
 export interface ListRunsParams {
@@ -97,6 +101,7 @@ function buildIdentityHeaders(identity?: IdentityHeaders): Record<string, string
   if (identity?.brandId) h["x-brand-id"] = identity.brandId;
   if (identity?.workflowSlug) h["x-workflow-slug"] = identity.workflowSlug;
   if (identity?.featureSlug) h["x-feature-slug"] = identity.featureSlug;
+  if (identity?.audienceId) h["x-audience-id"] = identity.audienceId;
   return h;
 }
 
@@ -134,11 +139,11 @@ async function runsRequest<T>(
  * parentRunId is sent as x-run-id header.
  */
 export async function createRun(params: CreateRunParams): Promise<Run> {
-  const { orgId, userId, parentRunId, brandId, campaignId, workflowSlug, featureSlug, ...body } = params;
+  const { orgId, userId, parentRunId, brandId, campaignId, workflowSlug, featureSlug, audienceId, ...body } = params;
   return runsRequest<Run>("/v1/runs", {
     method: "POST",
     body,
-    identity: { orgId, userId, runId: parentRunId, brandId, campaignId, workflowSlug, featureSlug },
+    identity: { orgId, userId, runId: parentRunId, brandId, campaignId, workflowSlug, featureSlug, audienceId },
   });
 }
 

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -183,9 +183,40 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       }, req.headers).catch(() => {});
     }
 
-    // Create run in runs-service (x-run-id from caller becomes parentRunId)
     const parentRunId = req.runId;
     const brandIdCsv = campaign.brandIds!.join(",");
+    const primaryBrandId = campaign.brandIds[0];
+    const workflowSlug = req.workflowSlug || campaign.workflowSlug;
+
+    // Re-decide the priority audience for THIS run with fresh cost data, BEFORE creating
+    // the run row — so the chosen audience is stamped on campaign-service's own run AND
+    // returned to workflow-service, which propagates it (x-audience-id) to every downstream
+    // DAG node so the whole execution's costs are attributed to the audience.
+    //
+    // These two fetches run before the campaign-service run row exists, so they trace under
+    // the parent (workflow/execute-workflow) run rather than this run.
+    const preRunIdentity: DownstreamIdentity = {
+      orgId,
+      userId: req.userId!,
+      runId: parentRunId!,
+      campaignId,
+      brandId: primaryBrandId,
+      workflowSlug,
+      featureSlug: featureSlug!,
+    };
+    const brandRuntimeContext = await fetchBrandRuntimeContext(primaryBrandId, preRunIdentity);
+    const customerPersona = await fetchBestCustomerPersona({
+      featureSlug: featureSlug!,
+      brandId: primaryBrandId,
+      goal: brandRuntimeContext.currentGoal,
+      brandProfileId: brandRuntimeContext.brandProfile?.id,
+      identity: preRunIdentity,
+    });
+    // audience.id == the selected persona/profile id (human-service saved filter-set UUID).
+    const audienceId = customerPersona?.customerProfileId ?? null;
+
+    // Create run in runs-service (x-run-id from caller becomes parentRunId), stamping the
+    // chosen audience so this run's own costs are attributed too.
     const run = await createRun({
       orgId,
       serviceName: "campaign-service",
@@ -194,27 +225,9 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       brandId: brandIdCsv,
       userId: campaign.createdByUserId || undefined,
       parentRunId: parentRunId || undefined,
-      workflowSlug: req.workflowSlug || campaign.workflowSlug,
-      featureSlug,
-    });
-    const primaryBrandId = campaign.brandIds[0];
-    const workflowSlug = req.workflowSlug || campaign.workflowSlug;
-    const downstreamIdentity: DownstreamIdentity = {
-      orgId,
-      userId: req.userId!,
-      runId: run.id,
-      campaignId,
-      brandId: primaryBrandId,
       workflowSlug,
-      featureSlug: featureSlug!,
-    };
-    const brandRuntimeContext = await fetchBrandRuntimeContext(primaryBrandId, downstreamIdentity);
-    const customerPersona = await fetchBestCustomerPersona({
-      featureSlug: featureSlug!,
-      brandId: primaryBrandId,
-      goal: brandRuntimeContext.currentGoal,
-      brandProfileId: brandRuntimeContext.brandProfile?.id,
-      identity: downstreamIdentity,
+      featureSlug,
+      audienceId: audienceId ?? undefined,
     });
 
     // Build searchParams from campaign featureInputs, then enrich with current runtime context.
@@ -229,8 +242,8 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       traceEvent(req.runId, {
         service: "campaign-service",
         event: "run-created",
-        detail: `Run created id=${run.id} for campaign ${campaignId} — parentRunId=${parentRunId ?? "none"}`,
-        data: { runId: run.id, campaignId, parentRunId },
+        detail: `Run created id=${run.id} for campaign ${campaignId} — parentRunId=${parentRunId ?? "none"}, audienceId=${audienceId ?? "none"}`,
+        data: { runId: run.id, campaignId, parentRunId, audienceId },
       }, req.headers).catch(() => {});
     }
 
@@ -248,6 +261,7 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       brandProfileId: campaign.brandProfileId ?? null,
       customerPersonaId: campaign.customerPersonaId ?? null,
       customerProfileId: campaign.customerProfileId ?? null,
+      audienceId,
       searchParams,
     });
   } catch (error) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -170,6 +170,10 @@ export const StartRunResponse = z.object({
   brandProfileId: z.string().nullable(),
   customerPersonaId: z.string().nullable(),
   customerProfileId: z.string().nullable(),
+  // Priority audience chosen for THIS run (human-service saved filter-set UUID).
+  // workflow-service propagates this as x-audience-id to every downstream DAG node
+  // so all run costs are attributed to the audience. Null when none is selected.
+  audienceId: z.string().nullable(),
   searchParams: z.record(z.string(), z.unknown()).nullable(),
 }).openapi("StartRunResponse");
 

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -428,19 +428,21 @@ describe("Pipeline routes", () => {
 
       const res = await request(app)
         .post("/start-run")
-        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id, "x-run-id": "parent-run-1" }))
         .expect(200);
 
       expect(res.body.searchParams).toEqual({
         brandProfile: { ...defaultBrandProfile, brandId: brandIds[0] },
         customerPersona: defaultCustomerPersona,
       });
+      // Audience is re-selected BEFORE the run row is created, so these fetches trace
+      // under the parent (workflow/execute-workflow) run, not this campaign-service run.
       expect(mockFetchBrandRuntimeContext).toHaveBeenCalledWith(
         brandIds[0],
         expect.objectContaining({
           orgId,
           userId: "user_test",
-          runId: "run-123",
+          runId: "parent-run-1",
           campaignId: campaign.id,
           brandId: brandIds[0],
           workflowSlug: "sales-email-cold-outreach",
@@ -453,8 +455,38 @@ describe("Pipeline routes", () => {
           brandId: brandIds[0],
           goal: "signup",
           brandProfileId: "brand-profile-current",
-          identity: expect.objectContaining({ runId: "run-123" }),
+          identity: expect.objectContaining({ runId: "parent-run-1" }),
         }),
+      );
+    });
+
+    it("should stamp the selected audience on the run (x-audience-id) and return it", async () => {
+      const campaign = await insertTestCampaign(orgId, { brandIds });
+
+      const res = await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      // audience.id == the selected persona/profile id (customer-profile-best from the mock)
+      expect(res.body.audienceId).toBe("customer-profile-best");
+      expect(mockCreateRun).toHaveBeenCalledWith(
+        expect.objectContaining({ audienceId: "customer-profile-best" }),
+      );
+    });
+
+    it("should return audienceId: null and not stamp the run when no audience is selected", async () => {
+      mockFetchBestCustomerPersona.mockResolvedValueOnce(null);
+      const campaign = await insertTestCampaign(orgId, { brandIds });
+
+      const res = await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      expect(res.body.audienceId).toBeNull();
+      expect(mockCreateRun).toHaveBeenCalledWith(
+        expect.objectContaining({ audienceId: undefined }),
       );
     });
 


### PR DESCRIPTION
## What
Per-run audience attribution, campaign-service slice of a 3-repo feature (campaign-service + workflow-service + runs-service).

`/start-run` already re-selects the priority **audience** each run with fresh cost data (`fetchBestCustomerPersona` → `customerProfileId`, which **is** the human-service saved-filter-set `audience.id`). This PR:

- Re-selects the audience **before** creating the campaign-service run row, then stamps `x-audience-id` on that run via `runs-client.createRun`.
- Returns a top-level **`audienceId: string | null`** on the `/start-run` response so workflow-service can propagate it.

## Run-tree context (verified in prod)
One execution = `workflow/execute-workflow` (root) → `{ campaign-service marker, lead-service/lead-serve }` (siblings). The root is born at `/execute`, **before** the audience is chosen, so we can't stamp the root + inherit. Instead the audience is re-decided in `/start-run` and **workflow-service propagates** `x-audience-id` forward to every downstream node (lead-serve, email…) so all costs are attributed.

## Cross-repo (LOCKED contract)
- Header `x-audience-id` = `audience.id` (UUID).
- `/start-run` 200 response gains `audienceId`.
- **workflow-service** (separate PR): add `x-audience-id` to its forward allowlist + inject it from `/start-run` output into all subsequent node calls.
- **runs-service** (`KevinLourd/audience-attribution`, in flight): header storage + parent-inheritance + `groupBy=audienceId`.

## Safety
Additive + zero blast radius: runs-service ignores `x-audience-id` and workflow-service ignores `audienceId` until their parallel changes land. Behavior otherwise unchanged (same fetches/selection, just reordered ahead of `createRun`; pre-selection fetches now trace under the parent run).

## Tests
Build + OpenAPI regenerated. 126 unit + 135 integration green, incl. 2 new audience cases (stamp+return id; null when no audience).

🤖 Generated with [Claude Code](https://claude.com/claude-code)