### PR TITLE
docs: run-tree shape + forward-propagated audience attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,15 @@ Unit tests (`pnpm test:unit`) need neither — they fully mock db/runs-client.
 ## Scheduler in-flight guard — check ANY live run for the campaign, never the campaign-service marker
 
 The `campaign-service / <campaignId>` parent run (created by the workflow DAG's start-run) is an **ephemeral ~2s marker** — `start-run → end-run` within seconds — NOT an enclosing span. The genuinely-long work (lead-service `buffer/next`, observed up to **755s**) runs in a separate `lead-service / lead-serve` run that is **not linked** under the marker via `parent_run_id`. So `src/lib/scheduler.ts`'s "is a flow still alive?" check MUST query `listRuns` scoped to **`campaignId` + `status=running` + `startedAfter=freshnessCutoff`** (any service) via `hasLiveRunForCampaign()` — **never** `(serviceName="campaign-service", taskName=campaignId)`, which only sees the 2s corpse and re-fires mid-fill → `lead-service` `409 Concurrent buffer/next` storm. `STUCK_RUN_FRESHNESS_THRESHOLD_MS` must stay **strictly greater than** lead-service's max fill (`PULL_NEXT_TIMEOUT` 600s; observed 755s) — currently 15min. `reRunDueCampaigns` and `claimStuckCampaigns` MUST share the same helper. (Set 2026-06-13, v0.25.1 / DIS-277.)
+
+## Execution run tree + audience attribution — propagate forward from /start-run, do NOT root-stamp
+
+Verified prod shape of one execution's run tree (single common ancestor):
+```
+workflow / execute-workflow      ← ROOT (created by workflow-service at /execute)
+ ├─ campaign-service / <campaignId>   (the ~2s marker, parent = execute-workflow)
+ └─ lead-service / lead-serve         (the expensive work, parent = execute-workflow)
+```
+The marker and `lead-serve` are **siblings** — both chain to the `execute-workflow` root. (`lead-serve` is "not linked under the **marker**" per the scheduler note above, but it IS chained to the **root**.) So the per-execution attribution anchor is the `execute-workflow` root, NOT campaign-service's marker — stamping the marker would NOT attribute `lead-serve` (the bulk of spend) via inheritance.
+
+**Audience attribution is FORWARD-PROPAGATED, not root-stamped.** The priority audience (`audience.id` — a human-service saved-filter-set UUID; == the persona/profile id returned by features-service `persona-stats`) is **re-decided every run** inside `/start-run` (`fetchBestCustomerPersona`), which runs AFTER the root is created. So `/start-run`: (1) selects the audience BEFORE `createRun`, stamps `x-audience-id` on its own marker run; (2) returns top-level `audienceId` on its response. workflow-service reads that `audienceId` and threads `x-audience-id` into every downstream node call (`lead-serve`, email, …); runs-service stores `audience_id` per run + cost and exposes `groupBy=audienceId`. Header is byte-equal `x-audience-id` across campaign/workflow/runs services. `customerProfileId`/`x-customer-profile-id` is the deprecated alias for the SAME id — do not use for new work. (Set 2026-06-20, campaign-service#204 + workflow-service#307 + runs-service#154.)


### PR DESCRIPTION
Documents the verified execution run tree (`execute-workflow` root → {campaign-service marker, lead-service/lead-serve} siblings) and that audience attribution is **forward-propagated from /start-run** (re-decided per run), not root-stamped. Anchors future attribution work. Doc-only.

Follows the shipped feature: campaign-service#204 + workflow-service#307 + runs-service#154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)