### PR TITLE
refactor: purge deprecated customerProfileId → audienceId

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ A new Conductor workspace has no built local package and no test DB. Before `pnp
 
 Unit tests (`pnpm test:unit`) need neither — they fully mock db/runs-client.
 
+**`db:push` HANGS on a column RENAME against an existing `campaign_test`.** drizzle-kit `push` can't tell a rename from a drop+create, so it prompts interactively ("is `audience_id` a rename of `customer_profile_id`?") — in a non-interactive/background shell it blocks forever (produces 0B output, never exits). When a schema change RENAMES a column, don't rely on `db:push` to materialize it on the test DB: apply the `ALTER TABLE … RENAME COLUMN` directly (`psql postgresql://test:test@localhost/campaign_test -c '…'`), mirroring the prod migration. `db:push` is still fine for additive changes (new column/table). (Set 2026-06-20, customer_profile_id → audience_id rename.)
+
 ## Architecture
 
 - `src/schemas.ts` — Zod schemas (source of truth for validation + OpenAPI)

--- a/drizzle/0035_rename_customer_profile_to_audience.sql
+++ b/drizzle/0035_rename_customer_profile_to_audience.sql
@@ -1,0 +1,13 @@
+-- Rename the deprecated campaign attribution column customer_profile_id → audience_id.
+-- audience_id holds the human-service saved-filter-set UUID (== audience.id). The old
+-- customerProfileId vocabulary is purged fleet-wide; this column is its last home here.
+-- Idempotent + boot-safe: only renames when the old column still exists.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'campaigns' AND column_name = 'customer_profile_id'
+  ) THEN
+    ALTER TABLE "campaigns" RENAME COLUMN "customer_profile_id" TO "audience_id";
+  END IF;
+END $$;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1775900000000,
       "tag": "0034_campaign_persona_attribution",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1776000000000,
+      "tag": "0035_rename_customer_profile_to_audience",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -75,7 +75,7 @@
             "type": "string",
             "nullable": true
           },
-          "customerProfileId": {
+          "audienceId": {
             "type": "string",
             "nullable": true
           },
@@ -146,7 +146,7 @@
           "activeGoalId",
           "brandProfileId",
           "customerPersonaId",
-          "customerProfileId",
+          "audienceId",
           "maxBudgetDailyUsd",
           "maxBudgetWeeklyUsd",
           "maxBudgetMonthlyUsd",
@@ -222,7 +222,7 @@
             "nullable": true,
             "minLength": 1
           },
-          "customerProfileId": {
+          "audienceId": {
             "type": "string",
             "nullable": true,
             "minLength": 1
@@ -303,7 +303,7 @@
             "nullable": true,
             "minLength": 1
           },
-          "customerProfileId": {
+          "audienceId": {
             "type": "string",
             "nullable": true,
             "minLength": 1
@@ -525,10 +525,6 @@
             "type": "string",
             "nullable": true
           },
-          "customerProfileId": {
-            "type": "string",
-            "nullable": true
-          },
           "audienceId": {
             "type": "string",
             "nullable": true
@@ -553,7 +549,6 @@
           "activeGoalId",
           "brandProfileId",
           "customerPersonaId",
-          "customerProfileId",
           "audienceId",
           "searchParams"
         ]

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -31,7 +31,7 @@ export const campaigns = pgTable(
     activeGoalId: text("active_goal_id"),
     brandProfileId: text("brand_profile_id"),
     customerPersonaId: text("customer_persona_id"),
-    customerProfileId: text("customer_profile_id"),
+    audienceId: text("audience_id"),
 
     // Legacy campaign budget limits. Daily spend control is brand-level via billing-service.
     maxBudgetDailyUsd: decimal("max_budget_daily_usd", { precision: 10, scale: 2 }),

--- a/src/lib/features-persona-client.ts
+++ b/src/lib/features-persona-client.ts
@@ -2,7 +2,7 @@ import { buildServiceHeaders, type DownstreamIdentity } from "./downstream-heade
 import type { RuntimeGoal } from "./brand-runtime-client.js";
 
 export interface CustomerPersonaCandidate {
-  customerProfileId: string;
+  audienceId: string;
   brandProfileId: string | null;
   persona: Record<string, unknown>;
   evidence: Record<string, unknown>;

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -100,7 +100,7 @@ export async function reRunDueCampaigns(): Promise<number> {
       activeGoalId: campaigns.activeGoalId,
       brandProfileId: campaigns.brandProfileId,
       customerPersonaId: campaigns.customerPersonaId,
-      customerProfileId: campaigns.customerProfileId,
+      audienceId: campaigns.audienceId,
     });
 
   if (dueCampaigns.length === 0) return 0;
@@ -154,7 +154,7 @@ export async function reRunDueCampaigns(): Promise<number> {
         activeGoalId: campaign.activeGoalId,
         brandProfileId: campaign.brandProfileId,
         customerPersonaId: campaign.customerPersonaId,
-        customerProfileId: campaign.customerProfileId,
+        audienceId: campaign.audienceId,
       }).catch((err) => {
         console.error(`[campaign-service] Failed to re-trigger campaign ${campaign.id}:`, err);
       });

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -8,7 +8,7 @@ export interface WorkflowExecutionInputs {
   activeGoalId?: string | null;
   brandProfileId?: string | null;
   customerPersonaId?: string | null;
-  customerProfileId?: string | null;
+  audienceId?: string | null;
 }
 
 const REQUIRED_FIELDS: (keyof WorkflowExecutionInputs)[] = [
@@ -70,7 +70,7 @@ export async function executeCampaignWorkflow(
   if (inputs.activeGoalId) headers["x-active-goal-id"] = inputs.activeGoalId;
   if (inputs.brandProfileId) headers["x-brand-profile-id"] = inputs.brandProfileId;
   if (inputs.customerPersonaId) headers["x-customer-persona-id"] = inputs.customerPersonaId;
-  if (inputs.customerProfileId) headers["x-customer-profile-id"] = inputs.customerProfileId;
+  if (inputs.audienceId) headers["x-audience-id"] = inputs.audienceId;
 
   const res = await fetch(executeUrl, {
     method: "POST",
@@ -84,7 +84,7 @@ export async function executeCampaignWorkflow(
         activeGoalId: inputs.activeGoalId ?? null,
         brandProfileId: inputs.brandProfileId ?? null,
         customerPersonaId: inputs.customerPersonaId ?? null,
-        customerProfileId: inputs.customerProfileId ?? null,
+        audienceId: inputs.audienceId ?? null,
       },
     }),
   });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -11,7 +11,7 @@ export interface AuthenticatedRequest extends Request {
   activeGoalId?: string;
   brandProfileId?: string;
   customerPersonaId?: string;
-  customerProfileId?: string;
+  audienceId?: string;
 }
 
 /** Parse the x-brand-id header as a comma-separated list of UUIDs. */
@@ -82,7 +82,7 @@ export function trackingHeaders(
   const activeGoalId = req.headers["x-active-goal-id"] as string | undefined;
   const brandProfileId = req.headers["x-brand-profile-id"] as string | undefined;
   const customerPersonaId = req.headers["x-customer-persona-id"] as string | undefined;
-  const customerProfileId = req.headers["x-customer-profile-id"] as string | undefined;
+  const audienceId = req.headers["x-audience-id"] as string | undefined;
 
   if (orgId && !req.orgId) req.orgId = orgId;
   if (userId && !req.userId) req.userId = userId;
@@ -94,7 +94,7 @@ export function trackingHeaders(
   if (activeGoalId) req.activeGoalId = activeGoalId;
   if (brandProfileId) req.brandProfileId = brandProfileId;
   if (customerPersonaId) req.customerPersonaId = customerPersonaId;
-  if (customerProfileId) req.customerProfileId = customerProfileId;
+  if (audienceId) req.audienceId = audienceId;
 
   next();
 }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -107,7 +107,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       activeGoalId,
       brandProfileId,
       customerPersonaId,
-      customerProfileId,
+      audienceId,
       maxBudgetDailyUsd,
       maxBudgetWeeklyUsd,
       maxBudgetMonthlyUsd,
@@ -170,7 +170,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         activeGoalId: activeGoalId ?? null,
         brandProfileId: brandProfileId ?? null,
         customerPersonaId: customerPersonaId ?? null,
-        customerProfileId: customerProfileId ?? null,
+        audienceId: audienceId ?? null,
         maxBudgetDailyUsd,
         maxBudgetWeeklyUsd,
         maxBudgetMonthlyUsd,
@@ -205,7 +205,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       activeGoalId: campaign.activeGoalId,
       brandProfileId: campaign.brandProfileId,
       customerPersonaId: campaign.customerPersonaId,
-      customerProfileId: campaign.customerProfileId,
+      audienceId: campaign.audienceId,
     };
     executeCampaignWorkflow(campaign.workflowSlug, workflowInputs).catch((err) => {
       console.error(`[campaign-service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
@@ -298,7 +298,7 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         activeGoalId: updated.activeGoalId,
         brandProfileId: updated.brandProfileId,
         customerPersonaId: updated.customerPersonaId,
-        customerProfileId: updated.customerProfileId,
+        audienceId: updated.audienceId,
       };
       executeCampaignWorkflow(updated.workflowSlug, activateInputs).catch((err) => {
         console.error(`[campaign-service] Failed to trigger workflow for campaign ${id}:`, err);

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -213,7 +213,7 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       identity: preRunIdentity,
     });
     // audience.id == the selected persona/profile id (human-service saved filter-set UUID).
-    const audienceId = customerPersona?.customerProfileId ?? null;
+    const audienceId = customerPersona?.audienceId ?? null;
 
     // Create run in runs-service (x-run-id from caller becomes parentRunId), stamping the
     // chosen audience so this run's own costs are attributed too.
@@ -260,7 +260,6 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       activeGoalId: campaign.activeGoalId ?? null,
       brandProfileId: campaign.brandProfileId ?? null,
       customerPersonaId: campaign.customerPersonaId ?? null,
-      customerProfileId: campaign.customerProfileId ?? null,
       audienceId,
       searchParams,
     });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -22,7 +22,7 @@ export const CampaignSchema = z.object({
   activeGoalId: z.string().nullable(),
   brandProfileId: z.string().nullable(),
   customerPersonaId: z.string().nullable(),
-  customerProfileId: z.string().nullable(),
+  audienceId: z.string().nullable(),
   maxBudgetDailyUsd: z.string().nullable(),
   maxBudgetWeeklyUsd: z.string().nullable(),
   maxBudgetMonthlyUsd: z.string().nullable(),
@@ -51,7 +51,7 @@ export const CreateCampaignBody = z.object({
   activeGoalId: z.string().min(1).nullable().optional(),
   brandProfileId: z.string().min(1).nullable().optional(),
   customerPersonaId: z.string().min(1).nullable().optional(),
-  customerProfileId: z.string().min(1).nullable().optional(),
+  audienceId: z.string().min(1).nullable().optional(),
   maxBudgetDailyUsd: z.string().optional(),
   maxBudgetWeeklyUsd: z.string().optional(),
   maxBudgetMonthlyUsd: z.string().optional(),
@@ -78,7 +78,7 @@ export const UpdateCampaignBody = z.object({
   activeGoalId: z.string().min(1).nullable().optional(),
   brandProfileId: z.string().min(1).nullable().optional(),
   customerPersonaId: z.string().min(1).nullable().optional(),
-  customerProfileId: z.string().min(1).nullable().optional(),
+  audienceId: z.string().min(1).nullable().optional(),
   maxBudgetDailyUsd: z.string().optional(),
   maxBudgetWeeklyUsd: z.string().optional(),
   maxBudgetMonthlyUsd: z.string().optional(),
@@ -169,7 +169,6 @@ export const StartRunResponse = z.object({
   activeGoalId: z.string().nullable(),
   brandProfileId: z.string().nullable(),
   customerPersonaId: z.string().nullable(),
-  customerProfileId: z.string().nullable(),
   // Priority audience chosen for THIS run (human-service saved filter-set UUID).
   // workflow-service propagates this as x-audience-id to every downstream DAG node
   // so all run costs are attributed to the audience. Null when none is selected.

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -41,7 +41,7 @@ export async function insertTestCampaign(
     activeGoalId?: string | null;
     brandProfileId?: string | null;
     customerPersonaId?: string | null;
-    customerProfileId?: string | null;
+    audienceId?: string | null;
     nextRunAt?: Date | null;
     createdByUserId?: string;
     parentRunId?: string;
@@ -60,7 +60,7 @@ export async function insertTestCampaign(
       activeGoalId: data.activeGoalId ?? null,
       brandProfileId: data.brandProfileId ?? null,
       customerPersonaId: data.customerPersonaId ?? null,
-      customerProfileId: data.customerProfileId ?? null,
+      audienceId: data.audienceId ?? null,
       maxBudgetDailyUsd: data.maxBudgetDailyUsd || "10.00",
       maxBudgetWeeklyUsd: data.maxBudgetWeeklyUsd || null,
       maxBudgetMonthlyUsd: data.maxBudgetMonthlyUsd || null,

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -25,7 +25,7 @@ describe("Campaign CRUD", () => {
     activeGoalId: "goal_test_crud",
     brandProfileId: "brand_profile_test_crud",
     customerPersonaId: "persona_test_crud",
-    customerProfileId: "customer_profile_test_crud",
+    audienceId: "audience_test_crud",
   };
 
   /** Helper: create a campaign with all required headers */
@@ -51,7 +51,7 @@ describe("Campaign CRUD", () => {
       expect(res.body.campaign.activeGoalId).toBeNull();
       expect(res.body.campaign.brandProfileId).toBeNull();
       expect(res.body.campaign.customerPersonaId).toBeNull();
-      expect(res.body.campaign.customerProfileId).toBeNull();
+      expect(res.body.campaign.audienceId).toBeNull();
     });
 
     it("should preserve persona/profile attribution through create and read", async () => {

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -66,7 +66,7 @@ const defaultBrandProfile = {
 };
 
 const defaultCustomerPersona = {
-  customerProfileId: "customer-profile-best",
+  audienceId: "customer-profile-best",
   brandProfileId: "brand-profile-current",
   persona: {
     id: "customer-profile-best",
@@ -384,21 +384,24 @@ describe("Pipeline routes", () => {
       expect(res.body.activeGoalId).toBeNull();
       expect(res.body.brandProfileId).toBeNull();
       expect(res.body.customerPersonaId).toBeNull();
-      expect(res.body.customerProfileId).toBeNull();
+      expect(res.body).not.toHaveProperty("customerProfileId");
       expect(res.body).not.toHaveProperty("appId");
       expect(res.body).not.toHaveProperty("keySource");
     });
 
     it("should return persona/profile attribution for attributed campaigns", async () => {
+      // Stored campaign attribution surfaced on /start-run. The renamed audience column
+      // is NOT round-tripped here — /start-run returns the per-run freshly-selected
+      // audienceId (from persona-stats), not the stored column.
       const attribution = {
         activeGoalId: "goal_internal_test",
         brandProfileId: "brand_profile_internal_test",
         customerPersonaId: "persona_internal_test",
-        customerProfileId: "customer_profile_internal_test",
       };
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         ...attribution,
+        audienceId: "stored_audience_internal_test",
       });
 
       const res = await request(app)
@@ -407,6 +410,7 @@ describe("Pipeline routes", () => {
         .expect(200);
 
       expect(res.body).toMatchObject(attribution);
+      expect(res.body).not.toHaveProperty("customerProfileId");
     });
 
     it("should not return sales-specific fields", async () => {

--- a/tests/integration/scheduler-rerun.test.ts
+++ b/tests/integration/scheduler-rerun.test.ts
@@ -31,7 +31,7 @@ const attribution = {
   activeGoalId: "goal_scheduler_test",
   brandProfileId: "brand_profile_scheduler_test",
   customerPersonaId: "persona_scheduler_test",
-  customerProfileId: "customer_profile_scheduler_test",
+  audienceId: "audience_scheduler_test",
 };
 
 describe("Scheduler - reRunDueCampaigns (integration)", () => {

--- a/tests/integration/workflow-activation.test.ts
+++ b/tests/integration/workflow-activation.test.ts
@@ -40,7 +40,7 @@ const attribution = {
   activeGoalId: "goal_activation_test",
   brandProfileId: "brand_profile_activation_test",
   customerPersonaId: "persona_activation_test",
-  customerProfileId: "customer_profile_activation_test",
+  audienceId: "audience_activation_test",
 };
 
 /** Helper: create a campaign with all required headers */
@@ -142,7 +142,7 @@ describe("Workflow trigger", () => {
           activeGoalId: null,
           brandProfileId: null,
           customerPersonaId: null,
-          customerProfileId: null,
+          audienceId: null,
         }),
       );
     });

--- a/tests/unit/sales-outreach-campaign.test.ts
+++ b/tests/unit/sales-outreach-campaign.test.ts
@@ -21,7 +21,7 @@ function campaign(overrides: Partial<Campaign> = {}): Campaign {
     activeGoalId: null,
     brandProfileId: null,
     customerPersonaId: null,
-    customerProfileId: null,
+    audienceId: null,
     maxBudgetDailyUsd: null,
     maxBudgetWeeklyUsd: null,
     maxBudgetMonthlyUsd: null,

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -54,7 +54,7 @@ vi.mock("../../src/db/schema.js", () => ({
     activeGoalId: "active_goal_id",
     brandProfileId: "brand_profile_id",
     customerPersonaId: "customer_persona_id",
-    customerProfileId: "customer_profile_id",
+    audienceId: "audience_id",
   },
 }));
 
@@ -177,7 +177,7 @@ describe("Scheduler - reRunDueCampaigns", () => {
         activeGoalId: "goal-1",
         brandProfileId: "brand-profile-1",
         customerPersonaId: "persona-1",
-        customerProfileId: "customer-profile-1",
+        audienceId: "customer-profile-1",
       },
     ]);
 
@@ -189,7 +189,7 @@ describe("Scheduler - reRunDueCampaigns", () => {
         activeGoalId: "goal-1",
         brandProfileId: "brand-profile-1",
         customerPersonaId: "persona-1",
-        customerProfileId: "customer-profile-1",
+        audienceId: "customer-profile-1",
       }),
     );
   });

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -62,7 +62,7 @@ describe("trackingHeaders middleware", () => {
       "x-active-goal-id": "goal-1",
       "x-brand-profile-id": "brand-profile-1",
       "x-customer-persona-id": "persona-1",
-      "x-customer-profile-id": "customer-profile-1",
+      "x-audience-id": "customer-profile-1",
     });
 
     trackingHeaders(req, {} as Response, (() => {}) as NextFunction);
@@ -70,7 +70,7 @@ describe("trackingHeaders middleware", () => {
     expect(req.activeGoalId).toBe("goal-1");
     expect(req.brandProfileId).toBe("brand-profile-1");
     expect(req.customerPersonaId).toBe("persona-1");
-    expect(req.customerProfileId).toBe("customer-profile-1");
+    expect(req.audienceId).toBe("customer-profile-1");
   });
 
   it("should not set properties when headers are absent", () => {
@@ -86,7 +86,7 @@ describe("trackingHeaders middleware", () => {
     expect(req.activeGoalId).toBeUndefined();
     expect(req.brandProfileId).toBeUndefined();
     expect(req.customerPersonaId).toBeUndefined();
-    expect(req.customerProfileId).toBeUndefined();
+    expect(req.audienceId).toBeUndefined();
     expect(nextCalled).toBe(true);
   });
 

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -74,12 +74,12 @@ describe("Workflow module", () => {
         activeGoalId: null,
         brandProfileId: null,
         customerPersonaId: null,
-        customerProfileId: null,
+        audienceId: null,
       });
       expect(opts.headers).not.toHaveProperty("x-active-goal-id");
       expect(opts.headers).not.toHaveProperty("x-brand-profile-id");
       expect(opts.headers).not.toHaveProperty("x-customer-persona-id");
-      expect(opts.headers).not.toHaveProperty("x-customer-profile-id");
+      expect(opts.headers).not.toHaveProperty("x-audience-id");
     });
 
     it("should send optional persona/profile attribution in headers and body", async () => {
@@ -94,21 +94,21 @@ describe("Workflow module", () => {
         activeGoalId: "goal-1",
         brandProfileId: "brand-profile-1",
         customerPersonaId: "persona-1",
-        customerProfileId: "customer-profile-1",
+        audienceId: "customer-profile-1",
       });
 
       const [, opts] = mockFetch.mock.calls[0];
       expect(opts.headers["x-active-goal-id"]).toBe("goal-1");
       expect(opts.headers["x-brand-profile-id"]).toBe("brand-profile-1");
       expect(opts.headers["x-customer-persona-id"]).toBe("persona-1");
-      expect(opts.headers["x-customer-profile-id"]).toBe("customer-profile-1");
+      expect(opts.headers["x-audience-id"]).toBe("customer-profile-1");
 
       const body = JSON.parse(opts.body);
       expect(body.inputs).toMatchObject({
         activeGoalId: "goal-1",
         brandProfileId: "brand-profile-1",
         customerPersonaId: "persona-1",
-        customerProfileId: "customer-profile-1",
+        audienceId: "customer-profile-1",
       });
     });
 


### PR DESCRIPTION
## What

Purge the deprecated `customerProfileId` / `customer_profile_id` / `x-customer-profile-id` vocabulary from campaign-service entirely. Replace with `audienceId` (== human-service `audience.id`) end-to-end. No deprecated alias kept.

Safe now: features-service persona-stats already returns `audienceId`; runs/workflow already accept `x-audience-id`.

## Changes
- **features-persona-client**: `CustomerPersonaCandidate.audienceId`; consume `personas[0].audienceId`.
- **/start-run** (`internal.ts`): source `audienceId` from persona-stats; **drop** the redundant stored-column passthrough — the per-run `audienceId` is canonical, so `customerProfileId` is removed from `StartRunResponse` (the only contract-shape change).
- **workflows**: send `x-audience-id` header + `audienceId` input.
- **auth**: read `x-audience-id` → `req.audienceId`.
- **db**: rename column `customer_profile_id` → `audience_id` via migration `0035` (idempotent `IF EXISTS` rename, boot-safe).
- **campaigns / scheduler / schemas**: 1:1 rename; openapi regenerated.

`customerPersonaId` is a separate, kept column — untouched (brief scoped to `customerProfileId` only).

## Verification
- `git grep -i customerprofile src` → empty ✅
- Build + openapi regen green ✅
- Full suite green: **126 unit + 135 integration** ✅
- Audience still selected from persona-stats via `audienceId` + stamped `x-audience-id` on the run ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)