### PR TITLE
refactor(audience): migrate features client to audience-stats endpoint

### DIFF
--- a/src/lib/features-audience-client.ts
+++ b/src/lib/features-audience-client.ts
@@ -1,19 +1,19 @@
 import { buildServiceHeaders, type DownstreamIdentity } from "./downstream-headers.js";
 import type { RuntimeGoal } from "./brand-runtime-client.js";
 
-export interface CustomerPersonaCandidate {
+export interface AudienceCandidate {
   audienceId: string;
   brandProfileId: string | null;
-  persona: Record<string, unknown>;
+  audience: Record<string, unknown>;
   evidence: Record<string, unknown>;
   metrics: Record<string, unknown>;
 }
 
-interface PersonaStatsResponse {
-  personas: CustomerPersonaCandidate[];
+interface AudienceStatsResponse {
+  audiences: AudienceCandidate[];
 }
 
-interface FetchBestCustomerPersonaInput {
+interface FetchTopAudienceInput {
   featureSlug: string;
   brandId: string;
   goal: RuntimeGoal;
@@ -21,20 +21,20 @@ interface FetchBestCustomerPersonaInput {
   identity: DownstreamIdentity;
 }
 
-export async function fetchBestCustomerPersona({
+export async function fetchTopAudience({
   featureSlug,
   brandId,
   goal,
   brandProfileId,
   identity,
-}: FetchBestCustomerPersonaInput): Promise<CustomerPersonaCandidate | null> {
+}: FetchTopAudienceInput): Promise<AudienceCandidate | null> {
   const baseUrl = process.env.FEATURES_SERVICE_URL;
   const apiKey = process.env.FEATURES_SERVICE_API_KEY;
   if (!baseUrl || !apiKey) {
     throw new Error("[campaign-service] FEATURES_SERVICE_URL or FEATURES_SERVICE_API_KEY not configured");
   }
 
-  const url = new URL(`${baseUrl.replace(/\/$/, "")}/features/${encodeURIComponent(featureSlug)}/persona-stats`);
+  const url = new URL(`${baseUrl.replace(/\/$/, "")}/features/${encodeURIComponent(featureSlug)}/audience-stats`);
   url.searchParams.set("brandId", brandId);
   url.searchParams.set("goal", goal);
   url.searchParams.set("limit", "1");
@@ -49,12 +49,12 @@ export async function fetchBestCustomerPersona({
 
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(`[campaign-service] FeatureService persona-stats failed (${res.status}): ${body}`);
+    throw new Error(`[campaign-service] FeatureService audience-stats failed (${res.status}): ${body}`);
   }
 
-  const body = await res.json() as PersonaStatsResponse;
-  if (!Array.isArray(body.personas)) {
-    throw new Error("[campaign-service] FeatureService persona-stats returned an invalid personas payload");
+  const body = await res.json() as AudienceStatsResponse;
+  if (!Array.isArray(body.audiences)) {
+    throw new Error("[campaign-service] FeatureService audience-stats returned an invalid audiences payload");
   }
-  return body.personas[0] ?? null;
+  return body.audiences[0] ?? null;
 }

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -10,7 +10,7 @@ import { EndRunBody, TransferBrandBody } from "../schemas.js";
 import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext } from "../lib/brand-runtime-client.js";
-import { fetchBestCustomerPersona } from "../lib/features-persona-client.js";
+import { fetchTopAudience } from "../lib/features-audience-client.js";
 import type { DownstreamIdentity } from "../lib/downstream-headers.js";
 
 const router = Router();
@@ -205,15 +205,15 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       featureSlug: featureSlug!,
     };
     const brandRuntimeContext = await fetchBrandRuntimeContext(primaryBrandId, preRunIdentity);
-    const customerPersona = await fetchBestCustomerPersona({
+    const audience = await fetchTopAudience({
       featureSlug: featureSlug!,
       brandId: primaryBrandId,
       goal: brandRuntimeContext.currentGoal,
       brandProfileId: brandRuntimeContext.brandProfile?.id,
       identity: preRunIdentity,
     });
-    // audience.id == the selected persona/profile id (human-service saved filter-set UUID).
-    const audienceId = customerPersona?.audienceId ?? null;
+    // audience.audienceId == the selected audience id (human-service saved filter-set UUID).
+    const audienceId = audience?.audienceId ?? null;
 
     // Create run in runs-service (x-run-id from caller becomes parentRunId), stamping the
     // chosen audience so this run's own costs are attributed too.
@@ -235,7 +235,10 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
     const searchParams: Record<string, unknown> = {
       ...(featureInputs ?? {}),
       brandProfile: brandRuntimeContext.brandProfile,
-      customerPersona,
+      // Keep the legacy `customerPersona` key: a windmill workflow prompt template may
+      // reference it (not greppable). `audience` is the forward-named alias for the same value.
+      customerPersona: audience,
+      audience,
     };
 
     if (req.runId) {

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -8,7 +8,7 @@ const {
   mockExecute,
   mockGateChecks,
   mockFetchBrandRuntimeContext,
-  mockFetchBestCustomerPersona,
+  mockFetchTopAudience,
 } = vi.hoisted(() => ({
   mockCreateRun: vi.fn(),
   mockUpdateRun: vi.fn(),
@@ -16,7 +16,7 @@ const {
   mockExecute: vi.fn(),
   mockGateChecks: vi.fn(),
   mockFetchBrandRuntimeContext: vi.fn(),
-  mockFetchBestCustomerPersona: vi.fn(),
+  mockFetchTopAudience: vi.fn(),
 }));
 
 vi.mock("@distribute/runs-client", () => ({
@@ -42,8 +42,8 @@ vi.mock("../../src/lib/brand-runtime-client.js", () => ({
   fetchBrandRuntimeContext: mockFetchBrandRuntimeContext,
 }));
 
-vi.mock("../../src/lib/features-persona-client.js", () => ({
-  fetchBestCustomerPersona: mockFetchBestCustomerPersona,
+vi.mock("../../src/lib/features-audience-client.js", () => ({
+  fetchTopAudience: mockFetchTopAudience,
 }));
 
 import app from "../../src/index.js";
@@ -65,10 +65,10 @@ const defaultBrandProfile = {
   createdAt: "2026-06-18T00:00:00.000Z",
 };
 
-const defaultCustomerPersona = {
+const defaultAudience = {
   audienceId: "customer-profile-best",
   brandProfileId: "brand-profile-current",
-  persona: {
+  audience: {
     id: "customer-profile-best",
     name: "Revenue leaders",
     status: "active",
@@ -119,7 +119,7 @@ describe("Pipeline routes", () => {
       currentGoal: "signup",
       brandProfile: { ...defaultBrandProfile, brandId: brandIds[0] },
     });
-    mockFetchBestCustomerPersona.mockResolvedValue(defaultCustomerPersona);
+    mockFetchTopAudience.mockResolvedValue(defaultAudience);
   });
 
   afterAll(async () => {
@@ -392,7 +392,7 @@ describe("Pipeline routes", () => {
     it("should return persona/profile attribution for attributed campaigns", async () => {
       // Stored campaign attribution surfaced on /start-run. The renamed audience column
       // is NOT round-tripped here — /start-run returns the per-run freshly-selected
-      // audienceId (from persona-stats), not the stored column.
+      // audienceId (from audience-stats), not the stored column.
       const attribution = {
         activeGoalId: "goal_internal_test",
         brandProfileId: "brand_profile_internal_test",
@@ -437,7 +437,8 @@ describe("Pipeline routes", () => {
 
       expect(res.body.searchParams).toEqual({
         brandProfile: { ...defaultBrandProfile, brandId: brandIds[0] },
-        customerPersona: defaultCustomerPersona,
+        customerPersona: defaultAudience,
+        audience: defaultAudience,
       });
       // Audience is re-selected BEFORE the run row is created, so these fetches trace
       // under the parent (workflow/execute-workflow) run, not this campaign-service run.
@@ -453,7 +454,7 @@ describe("Pipeline routes", () => {
           featureSlug: "sales-cold-email-v1",
         }),
       );
-      expect(mockFetchBestCustomerPersona).toHaveBeenCalledWith(
+      expect(mockFetchTopAudience).toHaveBeenCalledWith(
         expect.objectContaining({
           featureSlug: "sales-cold-email-v1",
           brandId: brandIds[0],
@@ -480,7 +481,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should return audienceId: null and not stamp the run when no audience is selected", async () => {
-      mockFetchBestCustomerPersona.mockResolvedValueOnce(null);
+      mockFetchTopAudience.mockResolvedValueOnce(null);
       const campaign = await insertTestCampaign(orgId, { brandIds });
 
       const res = await request(app)
@@ -616,12 +617,13 @@ describe("Pipeline routes", () => {
         mediaType: "podcast",
         region: "US",
         brandProfile: { ...defaultBrandProfile, brandId: brandIds[0] },
-        customerPersona: defaultCustomerPersona,
+        customerPersona: defaultAudience,
+        audience: defaultAudience,
       });
     });
 
     it("should include customerPersona: null when FeatureService has no persona rows", async () => {
-      mockFetchBestCustomerPersona.mockResolvedValueOnce(null);
+      mockFetchTopAudience.mockResolvedValueOnce(null);
       const campaign = await insertTestCampaign(orgId, { brandIds });
 
       const res = await request(app)
@@ -632,6 +634,7 @@ describe("Pipeline routes", () => {
       expect(res.body.searchParams).toEqual({
         brandProfile: { ...defaultBrandProfile, brandId: brandIds[0] },
         customerPersona: null,
+        audience: null,
       });
     });
 


### PR DESCRIPTION
## What

Migrate the features-service client to the audience-named endpoint, dropping "persona" vocabulary in this client. **No change to audience selection behavior.**

- Call `GET /features/:slug/audience-stats` (was `/persona-stats`), read `audiences[0].audienceId` (was `personas[0].audienceId`). Same data — `audience-stats` is the audience-named twin returning identical rows under `audiences` / `audience` (persona-stats remains a deprecated alias).
- Rename client surface: `features-persona-client.ts` → `features-audience-client.ts`; `fetchBestCustomerPersona` → `fetchTopAudience`; `CustomerPersonaCandidate` → `AudienceCandidate` (inner `persona` field → `audience`); `PersonaStatsResponse` → `AudienceStatsResponse`. Updated `internal.ts` call site + local var `customerPersona` → `audience`.

## Preserved (no-gos)

- **`searchParams.customerPersona` key still emitted** — zero backend readers fleet-wide, but a windmill workflow prompt template may reference it (not greppable). Verified the enclosing `searchParams` object IS consumed: it flows through the DAG into `workflow-service/scripts/nodes/lead-service.ts` → `POST lead-service /buffer/next` (carries `featureInputs` lead-targeting inputs). Added `searchParams.audience` as a forward-named alias for the same value.
- `customerPersonaId` attribution field / `x-customer-persona-id` header / `customer_persona_id` db column — **untouched** (separate concept, still used fleet-wide).

## Verification

- `pnpm run build` ✅
- `pnpm test:unit` ✅ 126
- `pnpm test:integration` ✅ 135

## Deploy ordering

features-service `/features/:slug/audience-stats` is **already live on staging** (verified via registry). For **prod promotion**: features-service must be promoted before/with campaign-service (the endpoint must exist in prod before this consumer reads it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
