### PR TITLE
feat(selection): vary audience + workflow per run (cost-aware Thompson sampling)

### DIFF
--- a/src/lib/bandit.ts
+++ b/src/lib/bandit.ts
@@ -1,0 +1,105 @@
+// Cost-aware Thompson sampling — the shared selection engine.
+//
+// Used twice per run by campaign-service: to pick the WORKFLOW (at the trigger,
+// over features-service /candidates) and the AUDIENCE (at /start-run, over
+// features-service /audience-stats). Both reduce to the same problem: a set of
+// arms, each with a count of trials, a count of successes, and a cost per trial;
+// pick the arm with the cheapest cost-per-success — but uncertainty-aware, so an
+// arm with little evidence still gets explored instead of being permanently
+// shadowed by a frozen rank #1.
+//
+// Mechanism: model each arm's success rate as Beta(successes+1, trials-successes+1)
+// (uniform prior). Each call, sample one rate per arm from its posterior and
+// pick argmin(costPerTrial / sampledRate) = the cheapest sampled cost-per-success.
+// Low-evidence arms have wide posteriors → sometimes sample high → get tried;
+// high-evidence arms collapse to their true rate → get exploited. No persistent
+// state: the trial/success counts come from the producer's evidence, so this is a
+// pure function of (arms, rng).
+
+export type Rng = () => number;
+
+export interface Arm {
+  trials: number;
+  successes: number;
+  // Cost per trial in any consistent unit (USD cents, USD — only the ordering
+  // matters). null when this arm has no cost signal yet (e.g. zero trials); the
+  // engine substitutes the pooled median cost so it can still be explored.
+  costPerTrial: number | null;
+}
+
+// Standard normal via Box–Muller.
+function sampleNormal(rng: Rng): number {
+  let u = 0;
+  let v = 0;
+  while (u === 0) u = rng();
+  while (v === 0) v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+// Gamma(shape, 1) via Marsaglia–Tsang. Valid for shape >= 1, which always holds
+// here because the Beta parameters are successes+1 and (trials-successes)+1, both >= 1.
+function sampleGamma(shape: number, rng: Rng): number {
+  const d = shape - 1 / 3;
+  const c = 1 / Math.sqrt(9 * d);
+  for (;;) {
+    const x = sampleNormal(rng);
+    const v = (1 + c * x) ** 3;
+    if (v <= 0) continue;
+    const u = rng();
+    if (u < 1 - 0.0331 * x ** 4) return d * v;
+    if (Math.log(u) < 0.5 * x ** 2 + d * (1 - v + Math.log(v))) return d * v;
+  }
+}
+
+// Sample from Beta(alpha, beta) using two Gamma draws.
+export function sampleBeta(alpha: number, beta: number, rng: Rng): number {
+  const x = sampleGamma(alpha, rng);
+  const y = sampleGamma(beta, rng);
+  return x / (x + y);
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Cost-aware Thompson sampling. Returns the index of the chosen arm, or null when
+ * the arm list is empty. With a single arm, returns 0 (no exploration to do).
+ *
+ * For each arm: rate ~ Beta(successes+1, trials-successes+1); sampledCost =
+ * costPerTrial / rate; pick argmin(sampledCost). Cost for a no-signal arm
+ * (costPerTrial null) is the pooled median of the arms that DO have a cost; if no
+ * arm has a cost (all cold), cost is treated as a flat constant so selection
+ * reduces to pure success-rate exploration.
+ */
+export function thompsonArgminCost(arms: Arm[], rng: Rng = Math.random): number | null {
+  if (arms.length === 0) return null;
+  if (arms.length === 1) return 0;
+
+  const knownCosts = arms
+    .map((a) => a.costPerTrial)
+    .filter((c): c is number => c !== null && c > 0);
+  const fallbackCost = median(knownCosts) ?? 1;
+
+  let bestIdx = 0;
+  let bestSampledCost = Infinity;
+
+  for (let i = 0; i < arms.length; i++) {
+    const n = Math.max(0, arms[i].trials);
+    const k = Math.min(Math.max(0, arms[i].successes), n);
+    const rate = sampleBeta(k + 1, n - k + 1, rng); // strictly in (0,1) — no /0
+    const cost = arms[i].costPerTrial != null && arms[i].costPerTrial! > 0
+      ? arms[i].costPerTrial!
+      : fallbackCost;
+    const sampledCost = cost / rate;
+    if (sampledCost < bestSampledCost) {
+      bestSampledCost = sampledCost;
+      bestIdx = i;
+    }
+  }
+
+  return bestIdx;
+}

--- a/src/lib/features-audience-client.ts
+++ b/src/lib/features-audience-client.ts
@@ -1,52 +1,87 @@
 import { buildServiceHeaders, type DownstreamIdentity } from "./downstream-headers.js";
 import type { RuntimeGoal } from "./brand-runtime-client.js";
+import { thompsonArgminCost, type Arm, type Rng } from "./bandit.js";
+
+export interface AudienceEvidence {
+  totalCostInUsdCents: number;
+  completedRuns: number;
+  firstRunAt: string | null;
+  lastRunAt: string | null;
+  contacted: number;
+  opened: number;
+  websiteClicks: number;
+  positiveReplies: number;
+}
 
 export interface AudienceCandidate {
   audienceId: string;
   brandProfileId: string | null;
-  audience: Record<string, unknown>;
-  evidence: Record<string, unknown>;
-  metrics: Record<string, unknown>;
+  audience: {
+    id: string;
+    name: string;
+    status: "active" | "paused" | "archived";
+    filters: Record<string, unknown> | null;
+  };
+  evidence: AudienceEvidence;
+  metrics: { cpcCents: number | null; cpprCents: number | null };
 }
 
+type SortMetric = "cpc" | "cppr";
+
 interface AudienceStatsResponse {
+  sortMetric: SortMetric;
   audiences: AudienceCandidate[];
 }
 
-interface FetchTopAudienceInput {
+interface SelectAudienceInput {
   featureSlug: string;
   brandId: string;
   goal: RuntimeGoal;
   brandProfileId?: string;
   identity: DownstreamIdentity;
+  rng?: Rng;
 }
 
-export async function fetchTopAudience({
+// Maps each active audience to a bandit arm: trials = leads contacted, successes
+// = the goal's outcome (clicks for the signup/cpc goal, positive replies for the
+// cppr goals), cost = spend per contacted lead. Mirrors the metric features-service
+// sorts /audience-stats by, so the bandit optimizes the SAME thing the dashboard shows.
+function toArm(c: AudienceCandidate, sortMetric: SortMetric): Arm {
+  const trials = c.evidence.contacted;
+  const successes = sortMetric === "cpc" ? c.evidence.websiteClicks : c.evidence.positiveReplies;
+  const costPerTrial = trials > 0 ? c.evidence.totalCostInUsdCents / trials : null;
+  return { trials, successes, costPerTrial };
+}
+
+/**
+ * Pull every audience's cost/outcome evidence from features-service and pick one
+ * by cost-aware Thompson sampling — so the contacted audience varies per run
+ * instead of being frozen on rank #1. Only `active` audiences are eligible.
+ * Returns null when no active audience exists.
+ */
+export async function selectAudienceForRun({
   featureSlug,
   brandId,
   goal,
   brandProfileId,
   identity,
-}: FetchTopAudienceInput): Promise<AudienceCandidate | null> {
+  rng,
+}: SelectAudienceInput): Promise<AudienceCandidate | null> {
   const baseUrl = process.env.FEATURES_SERVICE_URL;
   const apiKey = process.env.FEATURES_SERVICE_API_KEY;
   if (!baseUrl || !apiKey) {
     throw new Error("[campaign-service] FEATURES_SERVICE_URL or FEATURES_SERVICE_API_KEY not configured");
   }
 
+  // No `limit` — the bandit needs the full set to explore, not just rank #1.
   const url = new URL(`${baseUrl.replace(/\/$/, "")}/features/${encodeURIComponent(featureSlug)}/audience-stats`);
   url.searchParams.set("brandId", brandId);
   url.searchParams.set("goal", goal);
-  url.searchParams.set("limit", "1");
   if (brandProfileId) {
     url.searchParams.set("brandProfileId", brandProfileId);
   }
 
-  const res = await fetch(url, {
-    method: "GET",
-    headers: buildServiceHeaders(apiKey, identity),
-  });
-
+  const res = await fetch(url, { method: "GET", headers: buildServiceHeaders(apiKey, identity) });
   if (!res.ok) {
     const body = await res.text();
     throw new Error(`[campaign-service] FeatureService audience-stats failed (${res.status}): ${body}`);
@@ -56,5 +91,11 @@ export async function fetchTopAudience({
   if (!Array.isArray(body.audiences)) {
     throw new Error("[campaign-service] FeatureService audience-stats returned an invalid audiences payload");
   }
-  return body.audiences[0] ?? null;
+
+  const eligible = body.audiences.filter((a) => a.audience?.status === "active");
+  if (eligible.length === 0) return null;
+
+  const sortMetric: SortMetric = body.sortMetric === "cpc" ? "cpc" : "cppr";
+  const idx = thompsonArgminCost(eligible.map((a) => toArm(a, sortMetric)), rng);
+  return idx === null ? null : eligible[idx];
 }

--- a/src/lib/features-candidates-client.ts
+++ b/src/lib/features-candidates-client.ts
@@ -1,0 +1,137 @@
+import { buildServiceHeaders, type DownstreamIdentity } from "./downstream-headers.js";
+import { fetchBrandRuntimeContext, type RuntimeGoal } from "./brand-runtime-client.js";
+import { thompsonArgminCost, type Arm, type Rng } from "./bandit.js";
+
+// One (audienceId, workflow) candidate row from features-service /candidates.
+// audienceId is null until features-service populates the audience grain; the
+// workflow-level evidence (cost + sampleSize) is real today regardless, which is
+// all the WORKFLOW bandit needs.
+export interface Candidate {
+  audienceId: string | null;
+  workflow: { workflowDynastySlug: string; workflowDynastyName: string | null };
+  goal: RuntimeGoal;
+  costPerOutcomeUsd: number | null;
+  cost: { costPerLeadUsd: number | null; clickUsd: number | null; replyUsd: number | null };
+  sampleSize: { runs: number; contacted: number; clicks: number; replies: number };
+}
+
+interface CandidatesResponse {
+  candidates: Candidate[];
+}
+
+interface FetchCandidatesInput {
+  featureSlug: string;
+  brandId: string;
+  goal: RuntimeGoal;
+  brandProfileId?: string;
+  identity: DownstreamIdentity;
+}
+
+export async function fetchCandidates({
+  featureSlug,
+  brandId,
+  goal,
+  brandProfileId,
+  identity,
+}: FetchCandidatesInput): Promise<Candidate[]> {
+  const baseUrl = process.env.FEATURES_SERVICE_URL;
+  const apiKey = process.env.FEATURES_SERVICE_API_KEY;
+  if (!baseUrl || !apiKey) {
+    throw new Error("[campaign-service] FEATURES_SERVICE_URL or FEATURES_SERVICE_API_KEY not configured");
+  }
+
+  const url = new URL(`${baseUrl.replace(/\/$/, "")}/features/${encodeURIComponent(featureSlug)}/candidates`);
+  url.searchParams.set("brandId", brandId);
+  url.searchParams.set("goal", goal);
+  if (brandProfileId) {
+    url.searchParams.set("brandProfileId", brandProfileId);
+  }
+
+  const res = await fetch(url, { method: "GET", headers: buildServiceHeaders(apiKey, identity) });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`[campaign-service] FeatureService candidates failed (${res.status}): ${body}`);
+  }
+
+  const body = await res.json() as CandidatesResponse;
+  if (!Array.isArray(body.candidates)) {
+    throw new Error("[campaign-service] FeatureService candidates returned an invalid candidates payload");
+  }
+  return body.candidates;
+}
+
+// Collapse the candidate set to one arm per workflow: aggregate the sample size
+// across that workflow's rows (a workflow may appear once per audience once the
+// audience grain is populated). Cost is the per-workflow unit cost (goal-global,
+// identical across the workflow's rows). Success = the goal's outcome — clicks for
+// signup, positive replies otherwise.
+export function selectWorkflowByThompson(
+  candidates: Candidate[],
+  goal: RuntimeGoal,
+  rng?: Rng,
+): string | null {
+  if (candidates.length === 0) return null;
+
+  const byWorkflow = new Map<string, { arm: Arm }>();
+  for (const c of candidates) {
+    const slug = c.workflow.workflowDynastySlug;
+    const successes = goal === "signup" ? c.sampleSize.clicks : c.sampleSize.replies;
+    const existing = byWorkflow.get(slug);
+    if (existing) {
+      existing.arm.trials += c.sampleSize.contacted;
+      existing.arm.successes += successes;
+      if (existing.arm.costPerTrial == null && c.cost.costPerLeadUsd != null) {
+        existing.arm.costPerTrial = c.cost.costPerLeadUsd;
+      }
+    } else {
+      byWorkflow.set(slug, {
+        arm: {
+          trials: c.sampleSize.contacted,
+          successes,
+          costPerTrial: c.cost.costPerLeadUsd,
+        },
+      });
+    }
+  }
+
+  const slugs = [...byWorkflow.keys()];
+  const idx = thompsonArgminCost(slugs.map((s) => byWorkflow.get(s)!.arm), rng);
+  return idx === null ? null : slugs[idx];
+}
+
+/**
+ * Resolve which workflow to launch for THIS run: resolve the brand's current goal,
+ * pull the candidate workflows from features-service, and Thompson-pick one — so a
+ * campaign's workflow varies run-to-run instead of being frozen on its configured
+ * slug. The workflow MUST be chosen here (at the trigger), because it is the DAG
+ * identity in the /execute URL and cannot change once the DAG is running.
+ *
+ * Falls back to the campaign's configured slug (no behavior change) when there is
+ * no candidate evidence yet OR features-service is unavailable — a selection
+ * optimization must never block a campaign from running.
+ */
+export async function resolveWorkflowSlugForTrigger(args: {
+  featureSlug: string;
+  primaryBrandId: string;
+  identity: DownstreamIdentity;
+  fallbackSlug: string;
+}): Promise<string> {
+  const { featureSlug, primaryBrandId, identity, fallbackSlug } = args;
+  try {
+    const ctx = await fetchBrandRuntimeContext(primaryBrandId, identity);
+    const candidates = await fetchCandidates({
+      featureSlug,
+      brandId: primaryBrandId,
+      goal: ctx.currentGoal,
+      brandProfileId: ctx.brandProfile?.id,
+      identity,
+    });
+    return selectWorkflowByThompson(candidates, ctx.currentGoal) ?? fallbackSlug;
+  } catch (err) {
+    console.warn(
+      `[campaign-service] workflow bandit failed for brand ${primaryBrandId}, using configured workflow ${fallbackSlug}:`,
+      err,
+    );
+    return fallbackSlug;
+  }
+}

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -2,6 +2,7 @@ import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { eq, and, lte, isNotNull, isNull } from "drizzle-orm";
 import { executeCampaignWorkflow } from "./workflows.js";
+import { resolveWorkflowSlugForTrigger } from "./features-candidates-client.js";
 import { listRuns } from "@distribute/runs-client";
 import { notPausedBrandClause } from "./brand-pause.js";
 
@@ -143,19 +144,38 @@ export async function reRunDueCampaigns(): Promise<number> {
       // invisible to gate-check and never cleaned up.
       const runId = campaign.parentRunId || crypto.randomUUID();
 
-      executeCampaignWorkflow(campaign.workflowSlug, {
-        campaignId: campaign.id,
-        orgId: campaign.orgId,
-        brandId: brandIdCsv,
-        userId,
-        runId,
-        featureSlug,
-        activeGoalId: campaign.activeGoalId,
-        brandProfileId: campaign.brandProfileId,
-        audienceId: campaign.audienceId,
-      }).catch((err) => {
+      // Thompson-pick the workflow for THIS run (varies run-to-run) BEFORE execute.
+      // Falls back to the configured slug on any failure (see
+      // resolveWorkflowSlugForTrigger) — selection never blocks a run.
+      try {
+        const workflowSlug = await resolveWorkflowSlugForTrigger({
+          featureSlug,
+          primaryBrandId: campaign.brandIds![0],
+          identity: {
+            orgId: campaign.orgId,
+            userId,
+            runId,
+            campaignId: campaign.id,
+            brandId: brandIdCsv,
+            workflowSlug: campaign.workflowSlug,
+            featureSlug,
+          },
+          fallbackSlug: campaign.workflowSlug,
+        });
+        await executeCampaignWorkflow(workflowSlug, {
+          campaignId: campaign.id,
+          orgId: campaign.orgId,
+          brandId: brandIdCsv,
+          userId,
+          runId,
+          featureSlug,
+          activeGoalId: campaign.activeGoalId,
+          brandProfileId: campaign.brandProfileId,
+          audienceId: campaign.audienceId,
+        });
+      } catch (err) {
         console.error(`[campaign-service] Failed to re-trigger campaign ${campaign.id}:`, err);
-      });
+      }
     } catch (err) {
       console.error(`[campaign-service] Error processing campaign ${campaign.id}:`, err);
     }

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -10,7 +10,7 @@ import { EndRunBody, TransferBrandBody } from "../schemas.js";
 import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext } from "../lib/brand-runtime-client.js";
-import { fetchTopAudience } from "../lib/features-audience-client.js";
+import { selectAudienceForRun } from "../lib/features-audience-client.js";
 import type { DownstreamIdentity } from "../lib/downstream-headers.js";
 
 const router = Router();
@@ -205,7 +205,11 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       featureSlug: featureSlug!,
     };
     const brandRuntimeContext = await fetchBrandRuntimeContext(primaryBrandId, preRunIdentity);
-    const audience = await fetchTopAudience({
+    // Cost-aware Thompson sampling over ALL active audiences (not frozen rank #1),
+    // so the contacted audience varies run-to-run. The chosen audienceId is stamped
+    // on this run AND returned to workflow-service, which threads x-audience-id to
+    // every downstream node (lead-serve, …) — so the bandit's choice reaches the serve.
+    const audience = await selectAudienceForRun({
       featureSlug: featureSlug!,
       brandId: primaryBrandId,
       goal: brandRuntimeContext.currentGoal,

--- a/tests/integration/brand-pause.test.ts
+++ b/tests/integration/brand-pause.test.ts
@@ -4,6 +4,12 @@ import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 // and always sees "no live run" (→ campaigns are eligible to claim unless a pause holds them).
 const { mockExecute } = vi.hoisted(() => ({ mockExecute: vi.fn() }));
 
+// Workflow bandit resolves to the campaign's configured slug (fallback) so the
+// scheduler trigger does not make real network calls during integration tests.
+vi.mock("../../src/lib/features-candidates-client.js", () => ({
+  resolveWorkflowSlugForTrigger: vi.fn(async (a) => a.fallbackSlug),
+}));
+
 vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
   return { ...original, executeCampaignWorkflow: mockExecute };

--- a/tests/integration/delete-campaigns-by-org.test.ts
+++ b/tests/integration/delete-campaigns-by-org.test.ts
@@ -8,6 +8,12 @@ vi.mock("@distribute/runs-client", () => ({
   getStatsBudget: vi.fn(),
 }));
 
+// Workflow bandit resolves to the campaign's configured slug (fallback) so the
+// scheduler trigger does not make real network calls during integration tests.
+vi.mock("../../src/lib/features-candidates-client.js", () => ({
+  resolveWorkflowSlugForTrigger: vi.fn(async (a) => a.fallbackSlug),
+}));
+
 vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
   return { ...original, executeCampaignWorkflow: vi.fn() };

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -8,7 +8,7 @@ const {
   mockExecute,
   mockGateChecks,
   mockFetchBrandRuntimeContext,
-  mockFetchTopAudience,
+  mockSelectAudienceForRun,
 } = vi.hoisted(() => ({
   mockCreateRun: vi.fn(),
   mockUpdateRun: vi.fn(),
@@ -16,7 +16,7 @@ const {
   mockExecute: vi.fn(),
   mockGateChecks: vi.fn(),
   mockFetchBrandRuntimeContext: vi.fn(),
-  mockFetchTopAudience: vi.fn(),
+  mockSelectAudienceForRun: vi.fn(),
 }));
 
 vi.mock("@distribute/runs-client", () => ({
@@ -43,7 +43,7 @@ vi.mock("../../src/lib/brand-runtime-client.js", () => ({
 }));
 
 vi.mock("../../src/lib/features-audience-client.js", () => ({
-  fetchTopAudience: mockFetchTopAudience,
+  selectAudienceForRun: mockSelectAudienceForRun,
 }));
 
 import app from "../../src/index.js";
@@ -119,7 +119,7 @@ describe("Pipeline routes", () => {
       currentGoal: "signup",
       brandProfile: { ...defaultBrandProfile, brandId: brandIds[0] },
     });
-    mockFetchTopAudience.mockResolvedValue(defaultAudience);
+    mockSelectAudienceForRun.mockResolvedValue(defaultAudience);
   });
 
   afterAll(async () => {
@@ -453,7 +453,7 @@ describe("Pipeline routes", () => {
           featureSlug: "sales-cold-email-v1",
         }),
       );
-      expect(mockFetchTopAudience).toHaveBeenCalledWith(
+      expect(mockSelectAudienceForRun).toHaveBeenCalledWith(
         expect.objectContaining({
           featureSlug: "sales-cold-email-v1",
           brandId: brandIds[0],
@@ -480,7 +480,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should return audienceId: null and not stamp the run when no audience is selected", async () => {
-      mockFetchTopAudience.mockResolvedValueOnce(null);
+      mockSelectAudienceForRun.mockResolvedValueOnce(null);
       const campaign = await insertTestCampaign(orgId, { brandIds });
 
       const res = await request(app)
@@ -621,7 +621,7 @@ describe("Pipeline routes", () => {
     });
 
     it("should include audience: null when FeatureService has no audience rows", async () => {
-      mockFetchTopAudience.mockResolvedValueOnce(null);
+      mockSelectAudienceForRun.mockResolvedValueOnce(null);
       const campaign = await insertTestCampaign(orgId, { brandIds });
 
       const res = await request(app)

--- a/tests/integration/scheduler-rerun.test.ts
+++ b/tests/integration/scheduler-rerun.test.ts
@@ -5,6 +5,12 @@ const { mockExecute, mockCreateRun } = vi.hoisted(() => ({
   mockCreateRun: vi.fn(),
 }));
 
+// Workflow bandit resolves to the campaign's configured slug (fallback) so the
+// scheduler trigger does not make real network calls during integration tests.
+vi.mock("../../src/lib/features-candidates-client.js", () => ({
+  resolveWorkflowSlugForTrigger: vi.fn(async (a) => a.fallbackSlug),
+}));
+
 vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
   return {

--- a/tests/unit/bandit.test.ts
+++ b/tests/unit/bandit.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { thompsonArgminCost, sampleBeta, type Arm, type Rng } from "../../src/lib/bandit.js";
+import { selectWorkflowByThompson, type Candidate } from "../../src/lib/features-candidates-client.js";
+
+// Deterministic PRNG so the probabilistic assertions are reproducible.
+function mulberry32(seed: number): Rng {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function distribution(arms: Arm[], seed: number, draws = 2000): number[] {
+  const rng = mulberry32(seed);
+  const counts = new Array(arms.length).fill(0);
+  for (let i = 0; i < draws; i++) counts[thompsonArgminCost(arms, rng)!]++;
+  return counts.map((c) => c / draws);
+}
+
+describe("thompsonArgminCost", () => {
+  it("returns null for an empty arm list", () => {
+    expect(thompsonArgminCost([])).toBeNull();
+  });
+
+  it("returns the only arm with no exploration", () => {
+    expect(thompsonArgminCost([{ trials: 0, successes: 0, costPerTrial: null }])).toBe(0);
+  });
+
+  it("picks the strong low-cost-per-success arm the vast majority of the time", () => {
+    // Arm 0: lots of evidence, cheap per success (high rate, same cost).
+    // Arm 1: lots of evidence, expensive per success (low rate, same cost).
+    const arms: Arm[] = [
+      { trials: 1000, successes: 300, costPerTrial: 100 }, // ~0.33/contact → cheap
+      { trials: 1000, successes: 30, costPerTrial: 100 }, //  ~0.03/contact → 10x dearer
+    ];
+    const [p0] = distribution(arms, 1);
+    expect(p0).toBeGreaterThan(0.95);
+  });
+
+  it("still explores a zero-evidence arm sometimes (not shadowed by a strong arm)", () => {
+    // The known arm must be genuinely good (rate 0.6 > the uniform prior's 0.5),
+    // otherwise an unexplored arm SHOULD win most of the time — optimism under
+    // uncertainty beating a known-mediocre arm is correct, not a bug.
+    const arms: Arm[] = [
+      { trials: 1000, successes: 600, costPerTrial: 100 }, // strong AND good (0.6)
+      { trials: 0, successes: 0, costPerTrial: null }, //     brand new — wide posterior
+    ];
+    const [, p1] = distribution(arms, 7);
+    expect(p1).toBeGreaterThan(0); // explored
+    expect(p1).toBeLessThan(0.5); // but not dominant
+  });
+
+  it("splits ~uniformly when every arm is cold (no evidence)", () => {
+    const arms: Arm[] = [
+      { trials: 0, successes: 0, costPerTrial: null },
+      { trials: 0, successes: 0, costPerTrial: null },
+      { trials: 0, successes: 0, costPerTrial: null },
+    ];
+    const probs = distribution(arms, 3);
+    for (const p of probs) expect(Math.abs(p - 1 / 3)).toBeLessThan(0.08);
+  });
+
+  it("converges on the truth as evidence grows (exploitation dominates)", () => {
+    const arms: Arm[] = [
+      { trials: 100000, successes: 50000, costPerTrial: 100 }, // overwhelmingly best
+      { trials: 100000, successes: 10000, costPerTrial: 100 },
+    ];
+    const [p0] = distribution(arms, 5, 1000);
+    expect(p0).toBeGreaterThan(0.99);
+  });
+});
+
+describe("sampleBeta", () => {
+  it("has mean ≈ alpha/(alpha+beta)", () => {
+    const rng = mulberry32(42);
+    const n = 20000;
+    let sum = 0;
+    for (let i = 0; i < n; i++) sum += sampleBeta(3, 7, rng);
+    expect(Math.abs(sum / n - 3 / 10)).toBeLessThan(0.02);
+  });
+});
+
+describe("selectWorkflowByThompson", () => {
+  const mk = (slug: string, contacted: number, replies: number, clicks: number, cpl: number): Candidate => ({
+    audienceId: null,
+    workflow: { workflowDynastySlug: slug, workflowDynastyName: slug },
+    goal: "meetingBooked",
+    costPerOutcomeUsd: null,
+    cost: { costPerLeadUsd: cpl, clickUsd: null, replyUsd: null },
+    sampleSize: { runs: 1, contacted, clicks, replies },
+  });
+
+  it("returns null for no candidates", () => {
+    expect(selectWorkflowByThompson([], "meetingBooked")).toBeNull();
+  });
+
+  it("picks the cheaper-per-reply workflow most of the time (cppr goal → replies)", () => {
+    const candidates = [
+      mk("wf-good", 1000, 200, 5, 100), // 0.2 reply rate
+      mk("wf-bad", 1000, 20, 300, 100), //  0.02 reply rate (but lots of clicks — irrelevant for this goal)
+    ];
+    const rng = mulberry32(11);
+    let good = 0;
+    for (let i = 0; i < 1000; i++) if (selectWorkflowByThompson(candidates, "meetingBooked", rng) === "wf-good") good++;
+    expect(good / 1000).toBeGreaterThan(0.9);
+  });
+
+  it("uses CLICKS as the success for the signup goal (flips the winner)", () => {
+    const candidates = [
+      mk("wf-replies", 1000, 300, 10, 100), // great replies, poor clicks
+      mk("wf-clicks", 1000, 10, 300, 100), //  poor replies, great clicks
+    ];
+    const rng = mulberry32(13);
+    let clicksWins = 0;
+    for (let i = 0; i < 1000; i++) if (selectWorkflowByThompson(candidates, "signup", rng) === "wf-clicks") clicksWins++;
+    expect(clicksWins / 1000).toBeGreaterThan(0.9);
+  });
+
+  it("aggregates a workflow's evidence across its (audience,workflow) rows", () => {
+    // Same workflow appears twice (two audiences). Combined it has strong replies.
+    const candidates = [
+      mk("wf-split", 500, 100, 5, 100),
+      mk("wf-split", 500, 100, 5, 100),
+      mk("wf-weak", 1000, 20, 5, 100),
+    ];
+    const rng = mulberry32(17);
+    let split = 0;
+    for (let i = 0; i < 1000; i++) if (selectWorkflowByThompson(candidates, "meetingBooked", rng) === "wf-split") split++;
+    expect(split / 1000).toBeGreaterThan(0.9);
+  });
+});

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 const {
   mockExecuteCampaignWorkflow,
+  mockResolveWorkflowSlug,
   mockDbReturning,
   mockDbFindMany,
   mockListRuns,
 } = vi.hoisted(() => {
   return {
     mockExecuteCampaignWorkflow: vi.fn(),
+    mockResolveWorkflowSlug: vi.fn(),
     mockDbReturning: vi.fn(),
     mockDbFindMany: vi.fn(),
     mockListRuns: vi.fn(),
@@ -16,6 +18,12 @@ const {
 
 vi.mock("../../src/lib/workflows.js", () => ({
   executeCampaignWorkflow: mockExecuteCampaignWorkflow,
+}));
+
+// The workflow bandit resolves to the campaign's configured slug here (the
+// fallback), so the existing executeCampaignWorkflow assertions on slug still hold.
+vi.mock("../../src/lib/features-candidates-client.js", () => ({
+  resolveWorkflowSlugForTrigger: mockResolveWorkflowSlug,
 }));
 
 vi.mock("@distribute/runs-client", () => ({
@@ -85,6 +93,7 @@ describe("Scheduler - reRunDueCampaigns", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
+    mockResolveWorkflowSlug.mockImplementation(async (a: { fallbackSlug: string }) => a.fallbackSlug);
     mockDbReturning.mockResolvedValue([]);
     mockListRuns.mockResolvedValue({ runs: [], limit: 50, offset: 0 });
   });
@@ -555,6 +564,7 @@ describe("Scheduler - logging hygiene", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
+    mockResolveWorkflowSlug.mockImplementation(async (a: { fallbackSlug: string }) => a.fallbackSlug);
     mockDbReturning.mockResolvedValue([]);
     mockDbFindMany.mockResolvedValue([]);
     mockListRuns.mockResolvedValue({ runs: [], limit: 50, offset: 0 });
@@ -664,6 +674,7 @@ describe("Scheduler - lifecycle (timers)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecuteCampaignWorkflow.mockResolvedValue(undefined);
+    mockResolveWorkflowSlug.mockImplementation(async (a: { fallbackSlug: string }) => a.fallbackSlug);
     mockDbReturning.mockResolvedValue([]);
     mockDbFindMany.mockResolvedValue([]);
     mockListRuns.mockResolvedValue({ runs: [], limit: 50, offset: 0 });


### PR DESCRIPTION
## What
Stop contacting the **same audience** and running the **same workflow** every run. Replace the frozen rank-#1 picks from features-service with **cost-aware Thompson sampling** — mostly exploit the best, regularly explore the others, so no arm stays permanently shadowed.

## How
- **`src/lib/bandit.ts`** — shared Thompson engine. Each arm's success rate ~ `Beta(successes+1, trials−successes+1)` from the producer's own evidence; pick `argmin(costPerTrial / sampledRate)` = cheapest sampled cost-per-success. Low-evidence arms have wide posteriors → explored; high-evidence collapse to truth → exploited. **No persistent state** (counts come from features-service).
- **Audience — every run** (`/start-run`): Thompson over **all active** audiences from `/audience-stats` (dropped `limit=1`) instead of top-1. Chosen `audienceId` flows downstream unchanged (returned to workflow-service → threaded as `x-audience-id` to lead-serve, which honors it).
- **Workflow — run 2+** (scheduler re-trigger): Thompson over `/candidates` per-workflow evidence instead of the frozen `campaign.workflowSlug`. Each run is already a fresh `/execute` (verified in prod: 1 execute = 1 start-run = 1 lead-serve), so this only changes which slug the next execute uses — no mid-flight switch. **Falls back to the configured slug** when there's no evidence yet or features-service is unavailable — selection never blocks a run. (Campaign create/activate keep the configured slug for the seed run; the scheduler varies it from run 2.)

## Safety
- No schema / migration / endpoint change. No new env vars.
- Fail-soft on the workflow leg (configured slug fallback); audience leg fails loud (existing behavior).
- **272 tests green** (unit + integration).

## Follow-up (separate)
features-service `hat-yai-v3` is populating the **audience grain** in `/candidates` so the audience leg can be *conditioned on the chosen workflow* (true joint couple). Until then the audience bandit runs over `/audience-stats` (workflow-agnostic) — already fixes "same audience every run".

🤖 Generated with [Claude Code](https://claude.com/claude-code)