### PR TITLE
fix(gate): scope daily budget by feature spend

### DIFF
--- a/packages/runs-client/src/index.ts
+++ b/packages/runs-client/src/index.ts
@@ -83,6 +83,7 @@ export interface StatsBudgetParams {
   campaignId?: string;
   brandId?: string;
   workflowSlug?: string;
+  featureSlug?: string;
   windows: BudgetWindow[];
 }
 

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -14,6 +14,7 @@ export interface GateCheckInput {
   brandId: string;
   brandIds: string[];
   workflowSlug?: string;
+  featureSlug?: string;
   status: string;
   // Legacy storage/API field. Daily spend is enforced at brand level via billing-service,
   // not as a campaign-scoped runs window.
@@ -125,13 +126,14 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     }
   }
 
-  // 3c. Per-brand daily budget pacing — the brand is the optimization bucket.
+  // 3c. Per-brand daily budget pacing — scoped to the same feature.
   // billing-service stores + serves each brand's daily spend ceiling (cents); ENFORCEMENT
-  // is ours. For each brand in scope, compare today's platform spend (runs-service,
-  // brandId-keyed) against that ceiling. A brand at/over its ceiling pauses the loop for
-  // now — NOT a terminal stop: the block carries no nextRunAt, so internal.ts backs it off
-  // ~15min and re-checks. Raising the ceiling re-enables work on the next loop, and the day
-  // rollover naturally resets today's spend. An unset ceiling (null) = unbounded (no cap).
+  // is ours. For each brand in scope, compare today's platform spend for THIS campaign's
+  // feature (runs-service, brandId + featureSlug keyed) against that ceiling. A brand at/over
+  // its ceiling pauses that feature loop for now — NOT a terminal stop: the block carries no
+  // nextRunAt, so internal.ts backs it off ~15min and re-checks. Raising the ceiling re-enables
+  // work on the next loop, and the day rollover naturally resets today's spend. An unset
+  // ceiling (null) = unbounded (no cap).
   // Multi-brand tick: blocked if ANY in-scope brand has reached its ceiling (most campaigns
   // are solo-brand; per-brand downstream fan-out is out of scope here).
   //
@@ -148,6 +150,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     const brandSpend = await getStatsBudget({
       orgId: campaign.orgId,
       brandId,
+      featureSlug: campaign.featureSlug,
       windows: [{ label: "today", since: startOfToday().toISOString() }],
     });
     const today = brandSpend.windows.find(w => w.label === "today");

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -85,6 +85,7 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
       brandId: resolvedBrandIds.join(","),
       brandIds: resolvedBrandIds,
       workflowSlug: req.workflowSlug || campaign.workflowSlug,
+      featureSlug: req.featureSlug || campaign.featureSlug || undefined,
       status: campaign.status,
       maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
       maxBudgetWeeklyUsd: campaign.maxBudgetWeeklyUsd,

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -328,6 +328,7 @@ describe("Pipeline routes", () => {
           campaignId: campaign.id,
           orgId,
           brandId: brandIds.join(","),
+          featureSlug: "sales-cold-email-v1",
           status: "ongoing",
           maxBudgetDailyUsd: "50.00",
           maxLeads: 100,

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -54,6 +54,7 @@ function makeCampaign(overrides: Partial<GateCheckInput> = {}): GateCheckInput {
     campaignId: "campaign-1",
     orgId: "org-1",
     brandId: "brand-1",
+    featureSlug: "sales-cold-email-outreach",
     // Empty by default so the per-brand daily-budget loop is a no-op in tests that exercise
     // the OTHER gates. The brand-budget describe block sets brandIds explicitly.
     brandIds: [],
@@ -454,7 +455,7 @@ describe("Gate Check", () => {
       });
     }
 
-    it("blocks (paced, not stopped) when today's brand spend reaches the ceiling", async () => {
+    it("blocks (paced, not stopped) when today's feature spend for the brand reaches the ceiling", async () => {
       mockDailyBudget("1000"); // ceiling 1000 cents
       mockGetStatsBudget.mockResolvedValue(
         makeBudgetResponse([
@@ -558,23 +559,24 @@ describe("Gate Check", () => {
       expect(result.reason).toBe("Brand daily budget reached");
     });
 
-    it("aggregates brand-day spend across all campaign work for the brand", async () => {
+    it("compares the daily cap against same-feature brand-day spend only", async () => {
       mockDailyBudget("1000");
       mockGetStatsBudget.mockResolvedValue(
-        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "1250" }])
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "750" }])
       );
 
       const result = await runGateChecks(makeCampaign({
         campaignId: "campaign-active",
         brandIds: ["brand-1"],
         maxBudgetDailyUsd: "999999.00",
+        featureSlug: "sales-cold-email-outreach",
       }));
 
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toBe("Brand daily budget reached");
+      expect(result.allowed).toBe(true);
       expect(mockGetStatsBudget).toHaveBeenCalledWith({
         orgId: "org-1",
         brandId: "brand-1",
+        featureSlug: "sales-cold-email-outreach",
         windows: [expect.objectContaining({ label: "today" })],
       });
       const brandSpendCall = mockGetStatsBudget.mock.calls[0][0];


### PR DESCRIPTION
## Summary
- Pass campaign featureSlug into gate checks and runs-service budget aggregation
- Scope per-brand daily budget spend to the same feature instead of all brand spend
- Add regression coverage for same-feature daily budget checks

## Verification
- pnpm vitest run tests/unit/gate-check.test.ts tests/integration/internal-routes.test.ts
- pnpm run build