### PR TITLE
fix(gate): pace per-brand daily cap on committed spend, not actual

### DIFF
--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -181,14 +181,22 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
         windows: [{ label: "today", since: startOfToday().toISOString() }],
       });
       const today = brandSpend.windows.find(w => w.label === "today");
-      // Pace on ACTUAL (realized) spend, NOT actual+provisioned. A provisioned row is a
-      // worst-case affordability RESERVATION (~26¢/LLM call here) held only until the call
-      // reconciles to its real cost (~0.7¢) + the hold is cancelled. Counting those open
-      // worst-case holds made actual+provisioned cross the ceiling while real spend was far
-      // under it — falsely blocking the campaign for ~15min (GATE_BLOCK_BACKOFF_MS) on every
-      // re-check until the day rolled over. checkAffordability below stays the hard money
-      // gate (org credit balance); this is just daily pacing, for which realized cost is right.
-      const spentCents = today ? parseFloat(today.actualCostInUsdCents) || 0 : 0;
+      // Pace on COMMITTED spend = actual + provisioned (the window's totalCostInUsdCents).
+      // This DELIBERATELY REVERSES #223 ("pace on actual, not actual+provisioned") FOR THIS
+      // per-brand daily cap ONLY. #223's concern was real: a provisioned row can be a worst-case
+      // affordability RESERVATION (an LLM call reserves ~26¢, reconciles to ~0.7¢, then cancels
+      // the hold), so counting open holds could block on phantom spend for ~15min until the day
+      // rolls over. The product owner has weighed that tradeoff and accepted it: in practice the
+      // bulk of the committed-minus-actual gap is genuine instantly-account-email-sent holds for
+      // already-scheduled follow-up sends (real future spend), and the dashboard already shows
+      // the brand's "Budget spent today" as this same committed number. Pacing the cap on
+      // committed makes the enforced ceiling match what the customer sees and stops a campaign
+      // from committing NEW work above the daily budget while reserved follow-up holds sit
+      // uncounted. The worst-case-LLM-hold over-block is the accepted cost of that alignment.
+      // checkAffordability below stays the hard money gate (org credit balance); this is daily
+      // pacing. NOTE: the campaign budget WINDOWS (block 3 above) still pace on ACTUAL — only
+      // this brand daily cap moves to committed.
+      const spentCents = today ? parseFloat(today.totalCostInUsdCents) || 0 : 0;
 
       if (spentCents >= dailyBudgetCents) {
         return { allowed: false, reason: "Brand daily budget reached" };

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -96,8 +96,9 @@ function makeBudgetResponse(
   return {
     windows: windows.map(w => {
       // Default: actual == total (provisioned 0). Pass actualCostInUsdCents explicitly to
-      // model an in-flight worst-case provisioned hold (total > actual) — the gate must
-      // pace on ACTUAL, so a high total with a low actual should NOT block.
+      // model an in-flight worst-case provisioned hold (total > actual). Pacing differs by
+      // gate: the campaign budget WINDOWS pace on ACTUAL (a high total with low actual does
+      // NOT block them), while the per-brand daily cap paces on COMMITTED total (it DOES block).
       const actual = w.actualCostInUsdCents ?? w.totalCostInUsdCents;
       const provisioned = (parseFloat(w.totalCostInUsdCents) - parseFloat(actual)).toString();
       return {
@@ -549,20 +550,23 @@ describe("Gate Check", () => {
       expect(result.allowed).toBe(true);
     });
 
-    it("allows when ACTUAL is under the ceiling even though provisioned pushes total over (regression)", async () => {
-      // The bug: worst-case provisioned holds (~26¢ each, later cancelled to ~0.7¢ actual)
-      // made actual+provisioned cross the $7 ceiling while realized spend was far under,
-      // falsely blocking the campaign for 15min on every re-check. Gate must pace on actual.
+    it("blocks when COMMITTED (actual + provisioned) is over the ceiling even though actual alone is under", async () => {
+      // Committed-pacing decision (supersedes #223 for this brand daily cap): the cap now
+      // counts reserved follow-up-send holds toward the daily budget, matching the dashboard's
+      // committed "Budget spent today". Actual alone (999 < 1000) is under the ceiling, but
+      // committed total 5999 (provisioned 5000) is over — so the gate MUST block. This is the
+      // deliberate reversal of the old #223 regression test (which asserted this case allows).
       mockDailyBudget("1000"); // ceiling 1000 cents
       mockGetStatsBudget.mockResolvedValue(
         makeBudgetResponse([
-          // actual 999 (< 1000) but total 5999 (provisioned 5000) — must NOT block.
+          // actual 999 (< 1000) but committed total 5999 (provisioned 5000) — must BLOCK.
           { label: "today", totalCostInUsdCents: "5999", actualCostInUsdCents: "999" },
         ])
       );
 
       const result = await runGateChecks(makeCampaign({ brandIds: ["brand-1"] }));
-      expect(result.allowed).toBe(true);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Brand daily budget reached");
     });
 
     it("treats an unset budget (null) as unbounded — no cap", async () => {


### PR DESCRIPTION
## What

Pace the **per-brand daily budget cap** (the sales-feature block in `src/lib/gate-check.ts`) on **COMMITTED** spend (actual + provisioned) instead of actual-only, by reading the window's `totalCostInUsdCents` instead of `actualCostInUsdCents`.

## Why

The customer dashboard shows a brand's "Budget spent today" as **committed** spend = actual (billed) + provisioned (open holds reserved for already-scheduled follow-up email sends). But this gate enforced the daily ceiling on **actual** spend only, so:

- the displayed number (committed) and the enforced number (actual) **diverged**, and
- a campaign could keep committing **new** work past the daily budget because the provisioned holds for already-scheduled follow-up sends were uncounted.

Observed live: brand `f4d73dab`, `$14/day` cap — actual today `$14.12` vs committed today `$23.24` (~$9 of real scheduled email-send holds sitting above the cap, uncounted).

Pacing on committed makes the enforced ceiling match what the customer sees and stops over-commitment.

## Scope

- **IN:** the per-brand daily cap (`isSalesFeature` brand-daily block) → ceiling vs committed (`totalCostInUsdCents`).
- **OUT (unchanged, still actual):** the campaign-configured budget WINDOWS (`maxBudget{Daily,Weekly,Monthly,Total}Usd`), especially the `total` window's terminal autoStop. Flipping those to committed risks auto-stopping on phantom holds — a separate decision the owner has not made.
- **Untouched:** `checkAffordability` (org credit balance hard gate).

## Reverses #223 for this gate only

This deliberately reverses #223 ("pace budget on actual, not actual+provisioned") **for the per-brand daily cap only**. #223's worst-case-LLM-hold over-block (a provisioned ~26¢ LLM reservation reconciles to ~0.7¢ then cancels, briefly blocking until day rollover) is real but has been weighed and accepted: in practice the bulk of the committed-minus-actual gap is genuine `instantly-account-email-sent` follow-up holds (real future spend). The inline rationale comment is updated to document the committed-pacing decision and the accepted tradeoff. Fail-loud / fail-closed behavior unchanged (an unreadable cap still blocks the tick).

## Tests

- Reversed the #223 regression test: a brand whose **committed** (but not actual) exceeds the ceiling is now **blocked** (`Brand daily budget reached`).
- Updated the shared `makeBudgetResponse` docstring to reflect the per-gate split (windows pace on actual; brand daily cap on committed).
- All 157 unit tests green; build (TS + OpenAPI regen) green.

## Triage

staging (behavior change to spend pacing, not a prod-down hotfix). Promote to main via staging→main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
