### PR TITLE
fix(gate): pace campaign daily/weekly/monthly windows on committed too

### DIFF
--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -127,12 +127,23 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
       for (const budgetLimit of budgetLimits) {
         const limitCents = parseFloat(budgetLimit.limit) * 100;
         const windowResult = budgetResult.windows.find(w => w.label === budgetLimit.label);
-        // Pace on ACTUAL (realized) spend, not actual+provisioned — same reasoning as the
-        // per-brand daily cap below: worst-case provisioned reservations get cancelled to a
-        // far smaller actual, so counting them would block on phantom spend.
-        const actualCostCents = windowResult ? parseFloat(windowResult.actualCostInUsdCents) || 0 : 0;
+        // Pacing source splits by window type:
+        // - Non-terminal windows (daily/weekly/monthly, autoStop:false) pace on COMMITTED
+        //   spend = actual + provisioned (totalCostInUsdCents). Same committed-pacing decision
+        //   as the per-brand daily cap (block 3c) — count reserved follow-up-send holds so the
+        //   enforced ceiling matches the dashboard's committed "Budget spent today" and a
+        //   campaign stops committing new work above its configured cap. The accepted cost is
+        //   the worst-case-LLM-hold over-block (a ~26¢ reservation reconciles to ~0.7¢ then
+        //   cancels), which only delays a re-check by ~15min until the hold settles or the
+        //   window rolls over — a non-terminal pause, so it self-heals.
+        // - The TOTAL window (autoStop:true) stays on ACTUAL (realized) spend ON PURPOSE: it
+        //   triggers a TERMINAL autoStop, and stopping a campaign permanently on phantom
+        //   worst-case holds is unacceptable. Only realized spend can end a campaign for good.
+        const spentCents = windowResult
+          ? parseFloat(budgetLimit.autoStop ? windowResult.actualCostInUsdCents : windowResult.totalCostInUsdCents) || 0
+          : 0;
 
-        if (actualCostCents >= limitCents) {
+        if (spentCents >= limitCents) {
           if (budgetLimit.autoStop) {
             await autoStopCampaign(campaign.campaignId);
             return { allowed: false, reason: "Total budget exceeded", autoStopped: true };

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -97,8 +97,9 @@ function makeBudgetResponse(
     windows: windows.map(w => {
       // Default: actual == total (provisioned 0). Pass actualCostInUsdCents explicitly to
       // model an in-flight worst-case provisioned hold (total > actual). Pacing differs by
-      // gate: the campaign budget WINDOWS pace on ACTUAL (a high total with low actual does
-      // NOT block them), while the per-brand daily cap paces on COMMITTED total (it DOES block).
+      // gate: NON-TERMINAL caps pace on COMMITTED total (the per-brand daily cap AND the
+      // campaign daily/weekly/monthly windows — a high total with low actual DOES block them),
+      // while the TERMINAL total window paces on ACTUAL (it does NOT auto-stop on phantom holds).
       const actual = w.actualCostInUsdCents ?? w.totalCostInUsdCents;
       const provisioned = (parseFloat(w.totalCostInUsdCents) - parseFloat(actual)).toString();
       return {
@@ -684,8 +685,10 @@ describe("Gate Check", () => {
   });
 
   describe("nextRunAt on temporal budget exceeded (non-sales feature)", () => {
-    it("paces the weekly budget on ACTUAL, not total (regression)", async () => {
-      // actual 4000 (< $50 = 5000) but total 6000 (provisioned 2000) — must NOT block.
+    it("paces the weekly (non-terminal) budget on COMMITTED, not actual", async () => {
+      // Committed-pacing: actual 4000 (< $50 = 5000) but committed total 6000 (provisioned
+      // 2000) is over the cap — the non-terminal weekly window MUST block (matches the
+      // dashboard's committed spend). Reverses the prior actual-pacing regression assertion.
       mockGetStatsBudget.mockResolvedValue(
         makeBudgetResponse([{ label: "weekly", totalCostInUsdCents: "6000", actualCostInUsdCents: "4000" }])
       );
@@ -695,7 +698,25 @@ describe("Gate Check", () => {
         maxBudgetDailyUsd: null,
         maxBudgetWeeklyUsd: "50.00",
       }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("weekly budget exceeded");
+    });
+
+    it("paces the TOTAL (terminal autoStop) window on ACTUAL — does NOT auto-stop on phantom holds", async () => {
+      // The total window stays on actual ON PURPOSE: actual 4000 (< $50 = 5000) but committed
+      // total 9000 (provisioned 5000). A terminal autoStop must never fire on worst-case holds,
+      // so this MUST allow even though committed is over the cap.
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "total", totalCostInUsdCents: "9000", actualCostInUsdCents: "4000" }])
+      );
+
+      const result = await runGateChecks(makeCampaign({
+        featureSlug: NON_SALES_FEATURE,
+        maxBudgetDailyUsd: null,
+        maxBudgetTotalUsd: "50.00",
+      }));
       expect(result.allowed).toBe(true);
+      expect(result.autoStopped).toBeUndefined();
     });
 
     it("should return nextRunAt when weekly budget is exceeded", async () => {


### PR DESCRIPTION
## What

Extends committed-pacing to the **campaign-configured budget WINDOWS** (non-sales path). The non-terminal windows — `daily` / `weekly` / `monthly` — now pace on **COMMITTED** spend (actual + provisioned, `totalCostInUsdCents`) instead of actual-only. The **`total`** window (terminal autoStop) deliberately **stays on actual**.

## Why

Follow-up to #245 (per-brand daily cap → committed). The product owner asked to flip the campaign windows too for full coherence with the dashboard's committed "Budget spent today". Counting reserved follow-up-send holds toward the configured cap stops a campaign committing new work above its ceiling and makes the enforced number match what the customer sees.

## The asymmetry (load-bearing)

- **daily / weekly / monthly** (`autoStop:false`) → **committed**. Worst-case-LLM-hold over-block (~26¢ reservation reconciles to ~0.7¢ then cancels) is an accepted, non-terminal ~15min pause that self-heals.
- **total** (`autoStop:true`) → **actual**, ON PURPOSE. It triggers a terminal autoStop; a campaign must never be stopped for good on phantom worst-case holds. Only realized spend ends a campaign.

`checkAffordability` (org credit balance) untouched.

## Tests

- Reversed the weekly actual-pacing regression test → now blocks on committed (`weekly budget exceeded`).
- Added a test proving the `total` window does NOT auto-stop when committed is over but actual is under.
- Helper docstring updated for the per-gate split.
- 158 unit tests green; build (TS + OpenAPI) green.

## Triage

staging (behavior change to spend pacing). Promote to main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
