### PR TITLE
fix(gate): pace the total budget window on committed too

### DIFF
--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -127,21 +127,21 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
       for (const budgetLimit of budgetLimits) {
         const limitCents = parseFloat(budgetLimit.limit) * 100;
         const windowResult = budgetResult.windows.find(w => w.label === budgetLimit.label);
-        // Pacing source splits by window type:
-        // - Non-terminal windows (daily/weekly/monthly, autoStop:false) pace on COMMITTED
-        //   spend = actual + provisioned (totalCostInUsdCents). Same committed-pacing decision
-        //   as the per-brand daily cap (block 3c) — count reserved follow-up-send holds so the
-        //   enforced ceiling matches the dashboard's committed "Budget spent today" and a
-        //   campaign stops committing new work above its configured cap. The accepted cost is
-        //   the worst-case-LLM-hold over-block (a ~26¢ reservation reconciles to ~0.7¢ then
-        //   cancels), which only delays a re-check by ~15min until the hold settles or the
-        //   window rolls over — a non-terminal pause, so it self-heals.
-        // - The TOTAL window (autoStop:true) stays on ACTUAL (realized) spend ON PURPOSE: it
-        //   triggers a TERMINAL autoStop, and stopping a campaign permanently on phantom
-        //   worst-case holds is unacceptable. Only realized spend can end a campaign for good.
-        const spentCents = windowResult
-          ? parseFloat(budgetLimit.autoStop ? windowResult.actualCostInUsdCents : windowResult.totalCostInUsdCents) || 0
-          : 0;
+        // ALL campaign budget windows — daily, weekly, monthly AND total — pace on COMMITTED
+        // spend = actual + provisioned (totalCostInUsdCents). Same committed-pacing decision as
+        // the per-brand daily cap (block 3c): count reserved follow-up-send holds so the enforced
+        // ceiling matches the dashboard's committed "Budget spent today" and a campaign stops
+        // committing new work above its configured cap.
+        //
+        // The TOTAL window (autoStop:true) now also uses committed, by product-owner decision.
+        // TRADEOFF (accepted): for the non-terminal windows the worst-case-LLM-hold over-block
+        // (a ~26¢ reservation reconciles to ~0.7¢ then cancels) only causes a ~15min pause that
+        // self-heals; for the TOTAL window the same inflated holds can trigger the TERMINAL
+        // autoStop, so a temporary committed spike near the lifetime cap can stop a campaign for
+        // good before the holds settle. That stop is recoverable (re-activating the campaign
+        // resumes it), and the owner has chosen committed-pacing for the total cap for full
+        // coherence with the dashboard over avoiding that edge.
+        const spentCents = windowResult ? parseFloat(windowResult.totalCostInUsdCents) || 0 : 0;
 
         if (spentCents >= limitCents) {
           if (budgetLimit.autoStop) {
@@ -205,8 +205,8 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
       // from committing NEW work above the daily budget while reserved follow-up holds sit
       // uncounted. The worst-case-LLM-hold over-block is the accepted cost of that alignment.
       // checkAffordability below stays the hard money gate (org credit balance); this is daily
-      // pacing. NOTE: the campaign budget WINDOWS (block 3 above) still pace on ACTUAL — only
-      // this brand daily cap moves to committed.
+      // pacing. NOTE: the campaign budget WINDOWS (block 3 above) — daily, weekly, monthly AND
+      // total — now ALL pace on committed too, for full coherence with the dashboard.
       const spentCents = today ? parseFloat(today.totalCostInUsdCents) || 0 : 0;
 
       if (spentCents >= dailyBudgetCents) {

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -96,10 +96,10 @@ function makeBudgetResponse(
   return {
     windows: windows.map(w => {
       // Default: actual == total (provisioned 0). Pass actualCostInUsdCents explicitly to
-      // model an in-flight worst-case provisioned hold (total > actual). Pacing differs by
-      // gate: NON-TERMINAL caps pace on COMMITTED total (the per-brand daily cap AND the
-      // campaign daily/weekly/monthly windows — a high total with low actual DOES block them),
-      // while the TERMINAL total window paces on ACTUAL (it does NOT auto-stop on phantom holds).
+      // model an in-flight worst-case provisioned hold (total > actual). ALL budget caps now
+      // pace on COMMITTED total — the per-brand daily cap AND every campaign window (daily,
+      // weekly, monthly, total) — so a high total with low actual DOES block (and the total
+      // window DOES auto-stop) on committed spend.
       const actual = w.actualCostInUsdCents ?? w.totalCostInUsdCents;
       const provisioned = (parseFloat(w.totalCostInUsdCents) - parseFloat(actual)).toString();
       return {
@@ -702,10 +702,12 @@ describe("Gate Check", () => {
       expect(result.reason).toBe("weekly budget exceeded");
     });
 
-    it("paces the TOTAL (terminal autoStop) window on ACTUAL — does NOT auto-stop on phantom holds", async () => {
-      // The total window stays on actual ON PURPOSE: actual 4000 (< $50 = 5000) but committed
-      // total 9000 (provisioned 5000). A terminal autoStop must never fire on worst-case holds,
-      // so this MUST allow even though committed is over the cap.
+    it("paces the TOTAL (terminal autoStop) window on COMMITTED — auto-stops when committed is over", async () => {
+      // Committed-pacing now applies to the total window too (product-owner decision for full
+      // dashboard coherence): actual 4000 (< $50 = 5000) but committed total 9000 (provisioned
+      // 5000) is over the cap → terminal autoStop fires on committed. (Accepted tradeoff: a
+      // temporary committed spike near the lifetime cap can stop a campaign before holds settle;
+      // recoverable by re-activating.)
       mockGetStatsBudget.mockResolvedValue(
         makeBudgetResponse([{ label: "total", totalCostInUsdCents: "9000", actualCostInUsdCents: "4000" }])
       );
@@ -715,8 +717,9 @@ describe("Gate Check", () => {
         maxBudgetDailyUsd: null,
         maxBudgetTotalUsd: "50.00",
       }));
-      expect(result.allowed).toBe(true);
-      expect(result.autoStopped).toBeUndefined();
+      expect(result.allowed).toBe(false);
+      expect(result.autoStopped).toBe(true);
+      expect(result.nextRunAt).toBeUndefined();
     });
 
     it("should return nextRunAt when weekly budget is exceeded", async () => {


### PR DESCRIPTION
## What

Final step of the committed-pacing rollout: the campaign **TOTAL** budget window now also paces on **COMMITTED** spend (actual + provisioned, `totalCostInUsdCents`). With this, **every** budget cap in `gate-check.ts` — per-brand daily cap, campaign daily/weekly/monthly, and total — is committed-paced and coherent with the dashboard's "Budget spent today".

## Why / decision

Product-owner decision (follow-up to #245 + #248): flip the total window too for full coherence. Previously kept on actual because the total window triggers a **terminal autoStop**.

## ⚠️ Accepted tradeoff

The total window auto-stops a campaign **permanently** when hit. Committed includes worst-case LLM holds (reserve ~26¢, settle to ~0.7¢, then cancel). So a temporary committed spike near the lifetime cap can now auto-stop a campaign **before the holds settle**. This is **recoverable** — re-activating the campaign resumes it — and the owner has chosen dashboard coherence over avoiding that edge. Documented in the inline comment.

## Not in this PR — `checkAffordability` (org credit gate)

The org credit affordability gate consumes a `boolean` from billing-service (`/internal/campaigns/{id}/affordability`) — it has **no actual/committed knob in this repo**. Making the org credit balance count provisioned holds is a **billing-service** change (its balance computation). Tracked separately; not changeable in campaign-service.

## Tests

- Total-window regression test reversed: committed-over-cap now auto-stops (`autoStopped: true`).
- Shared helper docstring + block-3c cross-reference updated.
- 158 unit tests green; build (TS + OpenAPI) green.

## Triage

staging → promote to main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
