### PR TITLE
feat(brand-pause): persist pause on/off transition history + per-(org,brand) timeline (#270)

### DIFF
--- a/drizzle/0037_brand_pause_transitions.sql
+++ b/drizzle/0037_brand_pause_transitions.sql
@@ -1,0 +1,14 @@
+-- Brand pause transition log: APPEND-ONLY history of pause on/off flips per (org, brand).
+-- brand_pause holds only the current scalar state; this records one immutable row per state
+-- CHANGE (paused = the new state after the flip), written by PATCH /brands/:brandId/pause in the
+-- same transaction. Feeds the Customer Success health board pause timeline via
+-- GET /brands/:brandId/pause-history. Forward-only (no backfill of pre-ship flips).
+-- Idempotent (IF NOT EXISTS) so a partial-apply replay is safe.
+CREATE TABLE IF NOT EXISTS "brand_pause_transitions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"brand_id" text NOT NULL,
+	"org_id" text NOT NULL,
+	"paused" boolean NOT NULL,
+	"transitioned_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "idx_brand_pause_transitions_org_brand_at" ON "brand_pause_transitions" USING btree ("org_id","brand_id","transitioned_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1776100000000,
       "tag": "0036_drop_customer_persona_id",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1776200000000,
+      "tag": "0037_brand_pause_transitions",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -367,6 +367,43 @@
           "paused"
         ]
       },
+      "BrandPauseHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string"
+          },
+          "orgId": {
+            "type": "string"
+          },
+          "transitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BrandPauseTransition"
+            }
+          }
+        },
+        "required": [
+          "brandId",
+          "orgId",
+          "transitions"
+        ]
+      },
+      "BrandPauseTransition": {
+        "type": "object",
+        "properties": {
+          "paused": {
+            "type": "boolean"
+          },
+          "transitionedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "paused",
+          "transitionedAt"
+        ]
+      },
       "StatsResponse": {
         "type": "object",
         "properties": {
@@ -1092,6 +1129,62 @@
           },
           "400": {
             "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/brands/{brandId}/pause-history": {
+      "get": {
+        "tags": [
+          "Brands"
+        ],
+        "summary": "Get a brand's pause on/off transition timeline",
+        "description": "Forward-only, per-(org, brand) history of pause/resume flips (oldest first) for the Customer Success health board. Each transition's `paused` is the new state after the flip. No-op PATCHes (same value) record nothing; flips before this shipped are not backfilled. No transitions → empty array. Org-scoped via x-org-id. Does not affect GET /brands/{brandId}/pause.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Brand pause transition timeline",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandPauseHistoryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing x-org-id",
             "content": {
               "application/json": {
                 "schema": {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -22,6 +22,7 @@ import {
   DeleteCampaignsByOrgResponse,
   UpdateBrandPauseBody,
   BrandPauseResponse,
+  BrandPauseHistoryResponse,
 } from "../src/schemas.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -166,6 +167,21 @@ registry.registerPath({
   responses: {
     200: { description: "Updated brand pause state", content: { "application/json": { schema: BrandPauseResponse } } },
     400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
+    401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/brands/{brandId}/pause-history",
+  tags: ["Brands"],
+  summary: "Get a brand's pause on/off transition timeline",
+  description: "Forward-only, per-(org, brand) history of pause/resume flips (oldest first) for the Customer Success health board. Each transition's `paused` is the new state after the flip. No-op PATCHes (same value) record nothing; flips before this shipped are not backfilled. No transitions → empty array. Org-scoped via x-org-id. Does not affect GET /brands/{brandId}/pause.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: { params: z.object({ brandId: z.string() }) },
+  responses: {
+    200: { description: "Brand pause transition timeline", content: { "application/json": { schema: BrandPauseHistoryResponse } } },
+    400: { description: "Missing x-org-id", content: { "application/json": { schema: ErrorResponse } } },
     401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
   },
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -89,3 +89,30 @@ export const brandPause = pgTable(
 
 export type BrandPause = typeof brandPause.$inferSelect;
 export type NewBrandPause = typeof brandPause.$inferInsert;
+
+// Brand pause transition log — APPEND-ONLY history of pause on/off flips per (org, brand).
+//
+// The brand_pause table above holds only the CURRENT scalar state (upsert-in-place). It cannot
+// answer "when was this brand paused / resumed?" for the Customer Success health board. This
+// table records one immutable row per state CHANGE: when PATCH /brands/:brandId/pause flips the
+// paused boolean, brands.ts inserts a transition here in the same transaction. A no-op PATCH
+// (same value) writes nothing. Forward-only — pre-existing flips before this table shipped were
+// never recorded and are not backfilled. Read via GET /brands/:brandId/pause-history
+// (features-service customer-health board). paused = the NEW state after the flip.
+export const brandPauseTransitions = pgTable(
+  "brand_pause_transitions",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    brandId: text("brand_id").notNull(),
+    orgId: text("org_id").notNull(),
+    paused: boolean("paused").notNull(),
+    transitionedAt: timestamp("transitioned_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // Serves the per-(org, brand) ordered history read directly.
+    index("idx_brand_pause_transitions_org_brand_at").on(table.orgId, table.brandId, table.transitionedAt),
+  ]
+);
+
+export type BrandPauseTransition = typeof brandPauseTransitions.$inferSelect;
+export type NewBrandPauseTransition = typeof brandPauseTransitions.$inferInsert;

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { brandPause } from "../db/schema.js";
+import { brandPause, brandPauseTransitions } from "../db/schema.js";
 import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { UpdateBrandPauseBody } from "../schemas.js";
@@ -51,6 +51,12 @@ router.patch("/brands/:brandId/pause", requireApiKey, serviceAuth, validateBody(
     const now = new Date();
 
     const row = await db.transaction(async (tx) => {
+      // Prior state — no row means the brand was effectively un-paused (default false).
+      const existing = await tx.query.brandPause.findFirst({
+        where: and(eq(brandPause.brandId, brandId), eq(brandPause.orgId, orgId)),
+      });
+      const priorPaused = existing?.paused ?? false;
+
       if (!paused) {
         await ensureRunnableSalesOutreachCampaign(tx, {
           orgId,
@@ -74,6 +80,17 @@ router.patch("/brands/:brandId/pause", requireApiKey, serviceAuth, validateBody(
         throw new Error(`Cannot update brand pause for brand ${brandId}`);
       }
 
+      // Append a transition row ONLY on an actual state flip — a no-op PATCH (same value)
+      // records nothing. Forward-only history for the CS health board.
+      if (paused !== priorPaused) {
+        await tx.insert(brandPauseTransitions).values({
+          brandId,
+          orgId,
+          paused,
+          transitionedAt: now,
+        });
+      }
+
       return updated;
     });
 
@@ -91,6 +108,37 @@ router.patch("/brands/:brandId/pause", requireApiKey, serviceAuth, validateBody(
     });
   } catch (error) {
     console.error("[campaign-service] Update brand pause error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * GET /brands/:brandId/pause-history — read the forward-only pause on/off transition timeline.
+ *
+ * Org-scoped (same (brandId, orgId) key as the current-state read). Returns transitions oldest
+ * first so the Customer Success health board can render "paused <date>, resumed <date>". No row →
+ * empty transitions array. Does NOT change the current-state read (GET /brands/:brandId/pause).
+ */
+router.get("/brands/:brandId/pause-history", requireApiKey, serviceAuth, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId } = req.params;
+    const orgId = req.orgId!;
+
+    const rows = await db.query.brandPauseTransitions.findMany({
+      where: and(eq(brandPauseTransitions.brandId, brandId), eq(brandPauseTransitions.orgId, orgId)),
+      orderBy: asc(brandPauseTransitions.transitionedAt),
+    });
+
+    res.json({
+      brandId,
+      orgId,
+      transitions: rows.map((r) => ({
+        paused: r.paused,
+        transitionedAt: r.transitionedAt.toISOString(),
+      })),
+    });
+  } catch (error) {
+    console.error("[campaign-service] Get brand pause history error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { eq, and, sql, or, ne, isNotNull } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { brandPause, campaigns } from "../db/schema.js";
+import { brandPause, brandPauseTransitions, campaigns } from "../db/schema.js";
 import { requireApiKey, requirePipelineHeaders, trackingHeaders, type AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun, type IdentityHeaders } from "@distribute/runs-client";
@@ -514,9 +514,15 @@ router.delete("/internal/campaigns/by-org/:orgId", requireApiKey, async (req, re
         .where(eq(brandPause.orgId, orgId))
         .returning({ brandId: brandPause.brandId });
 
+      const deletedBrandPauseTransitions = await tx
+        .delete(brandPauseTransitions)
+        .where(eq(brandPauseTransitions.orgId, orgId))
+        .returning({ id: brandPauseTransitions.id });
+
       return {
         disabledCampaignCount: disabledCampaigns.length,
         deletedBrandPauseCount: deletedBrandPause.length,
+        deletedBrandPauseTransitionCount: deletedBrandPauseTransitions.length,
       };
     });
 
@@ -524,6 +530,7 @@ router.delete("/internal/campaigns/by-org/:orgId", requireApiKey, async (req, re
       updatedTables: [
         { tableName: "campaigns", count: result.disabledCampaignCount },
         { tableName: "brand_pause", count: result.deletedBrandPauseCount },
+        { tableName: "brand_pause_transitions", count: result.deletedBrandPauseTransitionCount },
       ],
     });
   } catch (error) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -102,6 +102,19 @@ export const BrandPauseResponse = z.object({
   updatedAt: z.string().nullable(),
 }).openapi("BrandPauseResponse");
 
+// One dated pause/resume flip. paused = the new state after the flip.
+export const BrandPauseTransition = z.object({
+  paused: z.boolean(),
+  transitionedAt: z.string(),
+}).openapi("BrandPauseTransition");
+
+// Forward-only, per-(org, brand) history of pause on/off transitions, oldest first.
+export const BrandPauseHistoryResponse = z.object({
+  brandId: z.string(),
+  orgId: z.string(),
+  transitions: z.array(BrandPauseTransition),
+}).openapi("BrandPauseHistoryResponse");
+
 // --- Stats ---
 
 export const StatsGroupByEnum = z.enum([

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,5 +1,5 @@
 import { db, sql } from "../../src/db/index.js";
-import { campaigns, brandPause } from "../../src/db/schema.js";
+import { campaigns, brandPause, brandPauseTransitions } from "../../src/db/schema.js";
 
 /**
  * Clean all test data from the database
@@ -7,6 +7,7 @@ import { campaigns, brandPause } from "../../src/db/schema.js";
 export async function cleanTestData() {
   await db.delete(campaigns);
   await db.delete(brandPause);
+  await db.delete(brandPauseTransitions);
 }
 
 /** Upsert a brand_pause row (mirror the route's upsert-in-place semantics). */

--- a/tests/integration/brand-pause.test.ts
+++ b/tests/integration/brand-pause.test.ts
@@ -38,6 +38,9 @@ const past = () => new Date(Date.now() - 60_000);
 function getPause(brandId: string, org = orgId) {
   return request(app).get(`/brands/${brandId}/pause`).set("x-api-key", API_KEY).set("x-org-id", org);
 }
+function getPauseHistory(brandId: string, org = orgId) {
+  return request(app).get(`/brands/${brandId}/pause-history`).set("x-api-key", API_KEY).set("x-org-id", org);
+}
 function patchPause(brandId: string, paused: boolean, org = orgId) {
   return request(app)
     .patch(`/brands/${brandId}/pause`)
@@ -219,6 +222,89 @@ describe("Brand pause routes", () => {
   it("requires a valid api key (401)", async () => {
     const brandId = crypto.randomUUID();
     await request(app).get(`/brands/${brandId}/pause`).set("x-api-key", "wrong").set("x-org-id", orgId).expect(401);
+  });
+});
+
+describe("Brand pause history", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue(undefined);
+  });
+
+  it("returns an empty timeline when no transition was ever recorded", async () => {
+    const brandId = crypto.randomUUID();
+    const res = await getPauseHistory(brandId).expect(200);
+    expect(res.body).toEqual({ brandId, orgId, transitions: [] });
+  });
+
+  it("records a dated transition for each pause/resume flip, oldest first", async () => {
+    const brandId = crypto.randomUUID();
+    await patchPause(brandId, true).expect(200);
+    await patchPause(brandId, false).expect(200);
+    await patchPause(brandId, true).expect(200);
+
+    const res = await getPauseHistory(brandId).expect(200);
+    expect(res.body.brandId).toBe(brandId);
+    expect(res.body.orgId).toBe(orgId);
+    expect(res.body.transitions.map((t: { paused: boolean }) => t.paused)).toEqual([true, false, true]);
+    for (const t of res.body.transitions) {
+      expect(typeof t.transitionedAt).toBe("string");
+      expect(Number.isNaN(Date.parse(t.transitionedAt))).toBe(false);
+    }
+    // Timestamps are non-decreasing (oldest first).
+    const times = res.body.transitions.map((t: { transitionedAt: string }) => Date.parse(t.transitionedAt));
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+  });
+
+  it("does NOT record a transition for a no-op PATCH (same value repeated)", async () => {
+    const brandId = crypto.randomUUID();
+    await patchPause(brandId, true).expect(200);
+    await patchPause(brandId, true).expect(200); // no-op
+    await patchPause(brandId, true).expect(200); // no-op
+
+    const res = await getPauseHistory(brandId).expect(200);
+    expect(res.body.transitions).toHaveLength(1);
+    expect(res.body.transitions[0].paused).toBe(true);
+  });
+
+  it("first PATCH paused=false on a never-paused brand records nothing (no real flip)", async () => {
+    const brandId = crypto.randomUUID();
+    await patchPause(brandId, false).expect(200); // prior state is default-false → no flip
+
+    const res = await getPauseHistory(brandId).expect(200);
+    expect(res.body.transitions).toHaveLength(0);
+  });
+
+  it("the current-state read is unchanged by the history feature", async () => {
+    const brandId = crypto.randomUUID();
+    await patchPause(brandId, true).expect(200);
+    await patchPause(brandId, false).expect(200);
+
+    const cur = await getPause(brandId).expect(200);
+    expect(cur.body.paused).toBe(false);
+    expect(cur.body.brandId).toBe(brandId);
+    expect(cur.body.orgId).toBe(orgId);
+    expect(cur.body.updatedAt).not.toBeNull();
+  });
+
+  it("history is org-scoped: org B cannot see org A's transitions", async () => {
+    const brandId = crypto.randomUUID();
+    await patchPause(brandId, true, "org-A").expect(200);
+
+    const other = await getPauseHistory(brandId, "org-B").expect(200);
+    expect(other.body.transitions).toHaveLength(0);
+    expect(other.body.orgId).toBe("org-B");
+  });
+
+  it("requires x-org-id (400)", async () => {
+    const brandId = crypto.randomUUID();
+    await request(app).get(`/brands/${brandId}/pause-history`).set("x-api-key", API_KEY).expect(400);
+  });
+
+  it("requires a valid api key (401)", async () => {
+    const brandId = crypto.randomUUID();
+    await request(app).get(`/brands/${brandId}/pause-history`).set("x-api-key", "wrong").set("x-org-id", orgId).expect(401);
   });
 });
 

--- a/tests/integration/delete-campaigns-by-org.test.ts
+++ b/tests/integration/delete-campaigns-by-org.test.ts
@@ -25,7 +25,7 @@ vi.mock("../../src/lib/gate-check.js", () => ({
 
 import app from "../../src/index.js";
 import { db } from "../../src/db/index.js";
-import { brandPause, campaigns } from "../../src/db/schema.js";
+import { brandPause, brandPauseTransitions, campaigns } from "../../src/db/schema.js";
 import { eq } from "drizzle-orm";
 import { cleanTestData, closeDb, insertTestCampaign, setBrandPause } from "../helpers/test-db.js";
 
@@ -70,6 +70,9 @@ describe("DELETE /internal/campaigns/by-org/:orgId", () => {
     });
     await setBrandPause(orgId, orgBrandId, true);
     await setBrandPause(otherOrgId, otherBrandId, true);
+    // A recorded pause transition for this org (cascade target) + one for the other org (survives).
+    await db.insert(brandPauseTransitions).values({ brandId: orgBrandId, orgId, paused: true });
+    await db.insert(brandPauseTransitions).values({ brandId: otherBrandId, orgId: otherOrgId, paused: true });
 
     const res = await request(app)
       .delete(`/internal/campaigns/by-org/${orgId}`)
@@ -79,6 +82,7 @@ describe("DELETE /internal/campaigns/by-org/:orgId", () => {
     expect(res.body.updatedTables).toEqual([
       { tableName: "campaigns", count: 2 },
       { tableName: "brand_pause", count: 1 },
+      { tableName: "brand_pause_transitions", count: 1 },
     ]);
 
     const queuedAfter = await db.query.campaigns.findFirst({ where: eq(campaigns.id, queuedCampaign.id) });
@@ -101,6 +105,11 @@ describe("DELETE /internal/campaigns/by-org/:orgId", () => {
     expect(orgPauseRows).toHaveLength(0);
     const otherPauseRows = await db.query.brandPause.findMany({ where: eq(brandPause.orgId, otherOrgId) });
     expect(otherPauseRows).toHaveLength(1);
+
+    const orgTransitions = await db.query.brandPauseTransitions.findMany({ where: eq(brandPauseTransitions.orgId, orgId) });
+    expect(orgTransitions).toHaveLength(0);
+    const otherTransitions = await db.query.brandPauseTransitions.findMany({ where: eq(brandPauseTransitions.orgId, otherOrgId) });
+    expect(otherTransitions).toHaveLength(1);
   });
 
   it("is idempotent when no org state exists", async () => {
@@ -112,6 +121,7 @@ describe("DELETE /internal/campaigns/by-org/:orgId", () => {
     expect(res.body.updatedTables).toEqual([
       { tableName: "campaigns", count: 0 },
       { tableName: "brand_pause", count: 0 },
+      { tableName: "brand_pause_transitions", count: 0 },
     ]);
   });
 
@@ -135,6 +145,7 @@ describe("DELETE /internal/campaigns/by-org/:orgId", () => {
     expect(retry.body.updatedTables).toEqual([
       { tableName: "campaigns", count: 0 },
       { tableName: "brand_pause", count: 0 },
+      { tableName: "brand_pause_transitions", count: 0 },
     ]);
   });
 


### PR DESCRIPTION
## Job
Staff Customer Success health board needs a **timeline** of a customer's brand pause on/off transitions ("paused 2026-07-01, resumed 2026-07-06"), not just the current `paused` boolean. Today only current state exists → the board renders `pauseHistory: not tracked yet`. Closes #270.

## What shipped (campaign-service — owner of brand pause state)
- **New append-only table `brand_pause_transitions`** `(id, brand_id, org_id, paused, transitioned_at)` — one immutable row per pause state **change**. `paused` = the new state after the flip. Migration `0037` boot-safe (`CREATE TABLE IF NOT EXISTS`) + journal entry.
- **Capture** on the existing `PATCH /brands/:brandId/pause`: inserts a transition in the same transaction **only when `paused` actually flips** vs the prior row. No-op PATCHes (same value) record nothing. Forward-only — pre-ship flips are not backfilled (no fabricated history).
- **Read** `GET /brands/:brandId/pause-history` (`requireApiKey` + `serviceAuth`, org from `x-org-id`, same key as the current-state read) → `{ brandId, orgId, transitions: [{ paused, transitionedAt }] }`, oldest first. For the features-service health board.
- Current-state read `GET /brands/:brandId/pause` **unchanged**.
- Org teardown `DELETE /internal/campaigns/by-org/:orgId` cascades the new table.

## AC (consumer-observable)
- ✅ A pause/resume toggled now is retrievable later as a dated transition for that (org, brand) via internal service-auth read.
- ✅ Current pause read behavior unchanged.
- ✅ Migration is boot-safe + idempotent.
- ✅ Org-scoped (org B cannot see org A's transitions).

## Verification
315 tests pass (`pnpm test`). New coverage: history timeline ordering, no-op dedup, first-`false`-records-nothing, org-scoping, current-read-unchanged, teardown cascade + other-org survival.

Triage: **staging feature**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
