### PR TITLE
fix(scheduler): audience-scoped exhaustion — stop a campaign only when ALL its audiences are exhausted

### DIFF
--- a/drizzle/0040_campaign_audience_exhaustion.sql
+++ b/drizzle/0040_campaign_audience_exhaustion.sql
@@ -1,0 +1,14 @@
+-- Per-(campaign, audience) exhaustion marks. Written by POST /internal/end-run when a run's
+-- single bandit-picked audience returns no leads (the DAG's stopCampaign=true, reinterpreted
+-- as AUDIENCE-scoped exhaustion rather than a whole-campaign stop). The audience bandit
+-- excludes any audience with a mark fresher than the 24h TTL; the campaign is auto-stopped
+-- only when EVERY targeted audience is exhausted. The 24h TTL re-probes each audience daily
+-- because Apollo can add new matching leads to an audience over time, so an exhaustion is
+-- never permanent. Idempotent (IF NOT EXISTS) so a partial-apply replay is safe.
+CREATE TABLE IF NOT EXISTS "campaign_audience_exhaustion" (
+	"campaign_id" text NOT NULL,
+	"audience_id" text NOT NULL,
+	"exhausted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "campaign_audience_exhaustion_pk" PRIMARY KEY("campaign_id","audience_id")
+);
+CREATE INDEX IF NOT EXISTS "idx_cae_campaign_exhausted_at" ON "campaign_audience_exhaustion" USING btree ("campaign_id","exhausted_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1776400000000,
       "tag": "0039_campaign_own_config",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1776500000000,
+      "tag": "0040_campaign_audience_exhaustion",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, index, uniqueIndex, date, decimal, integer, jsonb, boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, index, uniqueIndex, date, decimal, integer, jsonb, boolean, primaryKey } from "drizzle-orm/pg-core";
 
 // Campaigns table
 export const campaigns = pgTable(
@@ -154,3 +154,26 @@ export const brandPauseTransitions = pgTable(
 
 export type BrandPauseTransition = typeof brandPauseTransitions.$inferSelect;
 export type NewBrandPauseTransition = typeof brandPauseTransitions.$inferInsert;
+
+// Per-(campaign, audience) exhaustion marks. A run narrows to ONE bandit-picked audience;
+// when that audience's serve returns no leads the DAG sends stopCampaign=true — which is
+// AUDIENCE-scoped, not campaign-scoped. We record the audience here so the bandit skips it,
+// and only auto-stop the campaign when EVERY targeted audience is exhausted. The mark expires
+// after a 24h TTL (getFreshExhaustedAudienceIds) so audiences are re-probed daily — Apollo can
+// add new matching leads to an audience over time, so "exhausted" is never permanent.
+export const campaignAudienceExhaustion = pgTable(
+  "campaign_audience_exhaustion",
+  {
+    campaignId: text("campaign_id").notNull(),
+    audienceId: text("audience_id").notNull(),
+    exhaustedAt: timestamp("exhausted_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.campaignId, table.audienceId] }),
+    // Serves the per-campaign fresh-within-TTL read directly.
+    index("idx_cae_campaign_exhausted_at").on(table.campaignId, table.exhaustedAt),
+  ]
+);
+
+export type CampaignAudienceExhaustion = typeof campaignAudienceExhaustion.$inferSelect;
+export type NewCampaignAudienceExhaustion = typeof campaignAudienceExhaustion.$inferInsert;

--- a/src/lib/audience-exhaustion.ts
+++ b/src/lib/audience-exhaustion.ts
@@ -1,0 +1,48 @@
+import { and, eq, gt } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { campaignAudienceExhaustion } from "../db/schema.js";
+
+// A run narrows to ONE bandit-picked audience; when that audience's serve returns no leads the
+// DAG sends stopCampaign=true. That is AUDIENCE-scoped exhaustion, not "the whole campaign is
+// done" — the run says nothing about the campaign's other audiences. We mark the audience
+// exhausted so the bandit skips it, and stop the campaign only when EVERY targeted audience is
+// exhausted.
+//
+// The mark expires after this TTL so the audience is re-probed daily: Apollo can add new
+// matching leads to an audience over time (and a cross-audience-suppressed audience frees up
+// as its re-contact window rolls), so an exhaustion is never permanent. 1 day.
+export const AUDIENCE_EXHAUSTION_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Record (or refresh) an audience's exhaustion mark for a campaign. */
+export async function markAudienceExhausted(campaignId: string, audienceId: string): Promise<void> {
+  const now = new Date();
+  await db
+    .insert(campaignAudienceExhaustion)
+    .values({ campaignId, audienceId, exhaustedAt: now })
+    .onConflictDoUpdate({
+      target: [campaignAudienceExhaustion.campaignId, campaignAudienceExhaustion.audienceId],
+      set: { exhaustedAt: now },
+    });
+}
+
+/**
+ * Audience ids currently exhausted for a campaign — i.e. marked within the TTL window.
+ * Marks older than the TTL are ignored (the audience is due for a re-probe), so they never
+ * appear here and the bandit will consider that audience again on the next run.
+ */
+export async function getFreshExhaustedAudienceIds(
+  campaignId: string,
+  now: Date = new Date(),
+): Promise<string[]> {
+  const cutoff = new Date(now.getTime() - AUDIENCE_EXHAUSTION_TTL_MS);
+  const rows = await db
+    .select({ audienceId: campaignAudienceExhaustion.audienceId })
+    .from(campaignAudienceExhaustion)
+    .where(
+      and(
+        eq(campaignAudienceExhaustion.campaignId, campaignId),
+        gt(campaignAudienceExhaustion.exhaustedAt, cutoff),
+      ),
+    );
+  return rows.map((r) => r.audienceId);
+}

--- a/src/lib/features-audience-client.ts
+++ b/src/lib/features-audience-client.ts
@@ -55,6 +55,12 @@ interface SelectAudienceInput {
   // audiences is active, selection returns null (the campaign contacts none of them) rather
   // than falling back to an untargeted audience. NULL/empty → no restriction (inherit brand).
   requiredAudienceIds?: string[];
+  // Audiences currently marked exhausted for this campaign (their served pool is dry within
+  // the 24h TTL). They are removed from the eligible set so the bandit never re-picks a
+  // known-dry audience. If exclusion empties the set, selection returns null — the caller
+  // treats "no serveable audience" as the real all-audiences-exhausted stop signal (this is
+  // an AUTHORITATIVE filter, no fallback, applied last).
+  excludedAudienceIds?: string[];
 }
 
 // Maps each active audience to a bandit arm: trials = leads contacted, successes
@@ -83,6 +89,7 @@ export async function selectAudienceForRun({
   rng,
   eligibleAudienceIds,
   requiredAudienceIds,
+  excludedAudienceIds,
 }: SelectAudienceInput): Promise<AudienceCandidate | null> {
   const baseUrl = process.env.FEATURES_SERVICE_URL;
   const apiKey = process.env.FEATURES_SERVICE_API_KEY;
@@ -130,6 +137,15 @@ export async function selectAudienceForRun({
     const allow = new Set(eligibleAudienceIds);
     const scoped = candidates.filter((a) => allow.has(a.audienceId));
     if (scoped.length > 0) eligible = scoped;
+  }
+
+  // Drop audiences currently marked exhausted (served pool dry within the TTL). AUTHORITATIVE,
+  // applied last, no fallback: if this empties the set, the campaign has no serveable audience
+  // right now → return null so the caller can stop it only when EVERY audience is exhausted.
+  if (excludedAudienceIds && excludedAudienceIds.length > 0) {
+    const excluded = new Set(excludedAudienceIds);
+    eligible = eligible.filter((a) => !excluded.has(a.audienceId));
+    if (eligible.length === 0) return null;
   }
 
   const sortMetric: SortMetric = body.sortMetric === "cpc" ? "cpc" : "cppr";

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -11,6 +11,7 @@ import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "../lib/brand-runtime-client.js";
 import { selectAudienceForRun } from "../lib/features-audience-client.js";
+import { markAudienceExhausted, getFreshExhaustedAudienceIds } from "../lib/audience-exhaustion.js";
 import { fetchWorkflowProjectionRows, audienceIdsForWorkflow } from "../lib/features-workflow-projection-client.js";
 import type { DownstreamIdentity } from "../lib/downstream-headers.js";
 
@@ -241,6 +242,10 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
     // rank #1), so the contacted audience varies run-to-run. The chosen audienceId is
     // stamped on this run AND returned to workflow-service, which threads x-audience-id
     // to every downstream node (lead-serve, …) — so the bandit's choice reaches the serve.
+    // Skip audiences marked exhausted (their served pool ran dry within the last 24h). A run
+    // whose chosen audience returns no leads records it (see /end-run); excluding it here means
+    // the bandit keeps serving the campaign's OTHER audiences instead of re-picking a dry one.
+    const excludedAudienceIds = await getFreshExhaustedAudienceIds(campaignId);
     const audience = await selectAudienceForRun({
       featureSlug: featureSlug!,
       brandId: primaryBrandId,
@@ -252,6 +257,7 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       // brand's audiences, the bandit may ONLY pick from it — the campaign never contacts
       // an audience it doesn't target. NULL/empty → target the brand's full active set.
       requiredAudienceIds: campaign.audienceIds ?? undefined,
+      excludedAudienceIds,
     });
     // audience.audienceId == the selected audience id (human-service saved filter-set UUID).
     const audienceId = audience?.audienceId ?? null;
@@ -318,6 +324,53 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
     res.status(500).json({ error: "Internal server error" });
   }
 });
+
+/**
+ * Does the campaign still have at least one serveable, non-exhausted audience?
+ *
+ * Mirrors /start-run's bandit eligibility (active audiences ∩ the campaign's targeted subset)
+ * but drops the workflow soft-filter — an audience serveable under ANY workflow keeps the
+ * campaign alive — and excludes audiences currently marked exhausted. Returns true when the
+ * bandit would find at least one audience to pick, false when every targeted audience is
+ * exhausted (the only legitimate campaign-wide stop condition).
+ *
+ * Throws on a features/brand-service error so the caller can fail SAFE (never stop on an
+ * infra hiccup — a false stop is the bug this whole change fixes).
+ */
+async function hasServeableAudience(
+  campaign: typeof campaigns.$inferSelect,
+  req: AuthenticatedRequest,
+): Promise<boolean> {
+  const primaryBrandId = campaign.brandIds![0];
+  const featureSlug = req.featureSlug || campaign.featureSlug;
+  if (!featureSlug) {
+    // No feature slug to query audience-stats with → cannot prove exhaustion. Fail safe:
+    // treat as still-serveable so we never stop the campaign on missing context.
+    return true;
+  }
+  const identity: DownstreamIdentity = {
+    orgId: campaign.orgId,
+    userId: req.userId!,
+    runId: req.runId!,
+    campaignId: campaign.id,
+    brandId: primaryBrandId,
+    workflowSlug: req.workflowSlug || campaign.workflowSlug,
+    featureSlug,
+  };
+  const brandRuntimeContext = await fetchBrandRuntimeContext(primaryBrandId, identity);
+  const runtimeGoal: RuntimeGoal = (campaign.goal as RuntimeGoal | null) ?? brandRuntimeContext.currentGoal;
+  const excludedAudienceIds = await getFreshExhaustedAudienceIds(campaign.id);
+  const audience = await selectAudienceForRun({
+    featureSlug,
+    brandId: primaryBrandId,
+    goal: runtimeGoal,
+    brandProfileId: brandRuntimeContext.brandProfile?.id,
+    identity,
+    requiredAudienceIds: campaign.audienceIds ?? undefined,
+    excludedAudienceIds,
+  });
+  return audience !== null;
+}
 
 /**
  * POST /end-run
@@ -387,17 +440,45 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
     // Respond immediately, then handle re-trigger asynchronously
     res.json({ status });
 
-    // stopCampaign → auto-stop campaign, no re-trigger
+    // The DAG sends stopCampaign=true when THIS run's single served audience returned no leads
+    // (fetch-lead.found == false). That is AUDIENCE-scoped exhaustion, NOT "the campaign is
+    // done": the bandit narrows each run to one audience, so one audience running dry says
+    // nothing about the campaign's other audiences. Reinterpret it — mark this audience
+    // exhausted (24h TTL; the bandit then skips it) and auto-stop the campaign ONLY when it has
+    // no serveable, non-exhausted audience left. Otherwise fall through to the normal reschedule
+    // so the next tick re-draws from the remaining audiences.
     if (stopCampaign === true) {
       try {
-        await db.update(campaigns)
-          .set({ status: "stopped", updatedAt: new Date() })
-          .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
-        console.warn(`[campaign-service] stopCampaign=true — auto-stopped campaign ${campaignId}`);
+        const exhaustedAudienceId = req.audienceId;
+        if (exhaustedAudienceId) {
+          await markAudienceExhausted(campaignId, exhaustedAudienceId);
+        } else {
+          console.warn(`[campaign-service] stopCampaign=true for campaign ${campaignId} with no x-audience-id — cannot mark a specific audience exhausted`);
+        }
+
+        const campaign = await db.query.campaigns.findFirst({
+          where: and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)),
+        });
+        // Only decide on a still-ongoing campaign with brands to serve. A serveable audience
+        // remaining → keep going (fall through to reschedule); none → the real all-exhausted stop.
+        const serveable =
+          !!campaign && campaign.status === "ongoing" && !!campaign.brandIds?.length
+            ? await hasServeableAudience(campaign, req)
+            : false;
+
+        if (!serveable) {
+          await db.update(campaigns)
+            .set({ status: "stopped", nextRunAt: null, updatedAt: new Date() })
+            .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
+          console.log(`[campaign-service] All targeted audiences exhausted — auto-stopped campaign ${campaignId}`);
+          return;
+        }
+        // Serveable audiences remain → do NOT stop; fall through to the reschedule below.
       } catch (err) {
-        console.error(`[campaign-service] Failed to auto-stop campaign:`, err);
+        // Fail SAFE: a false stop is exactly the bug being fixed, so on ANY error in the
+        // exhaustion handling do NOT stop the campaign — fall through to reschedule and retry.
+        console.error(`[campaign-service] audience-exhaustion handling failed for campaign ${campaignId}, not stopping:`, err);
       }
-      return;
     }
 
     // Schedule re-trigger via nextRunAt — the scheduler picks it up on the next tick.

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,5 +1,5 @@
 import { db, sql } from "../../src/db/index.js";
-import { campaigns, brandPause, brandPauseTransitions } from "../../src/db/schema.js";
+import { campaigns, brandPause, brandPauseTransitions, campaignAudienceExhaustion } from "../../src/db/schema.js";
 
 /**
  * Clean all test data from the database
@@ -8,6 +8,7 @@ export async function cleanTestData() {
   await db.delete(campaigns);
   await db.delete(brandPause);
   await db.delete(brandPauseTransitions);
+  await db.delete(campaignAudienceExhaustion);
 }
 
 /** Upsert a brand_pause row (mirror the route's upsert-in-place semantics). */

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -58,8 +58,8 @@ vi.mock("../../src/lib/features-workflow-projection-client.js", async (importOri
 
 import app from "../../src/index.js";
 import { db } from "../../src/db/index.js";
-import { campaigns } from "../../src/db/schema.js";
-import { eq } from "drizzle-orm";
+import { campaigns, campaignAudienceExhaustion } from "../../src/db/schema.js";
+import { eq, and } from "drizzle-orm";
 import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
 
 const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
@@ -1034,10 +1034,12 @@ describe("Pipeline routes", () => {
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
-    it("should auto-stop campaign and NOT re-trigger when stopCampaign is true", async () => {
+    it("stopCampaign=true marks THIS run's audience exhausted and reschedules (does NOT stop) while other audiences remain serveable", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,
         status: "ongoing",
+        featureSlug: "sales-cold-email-v1",
+        createdByUserId: "user_test",
       });
 
       mockListRuns.mockResolvedValue({
@@ -1045,23 +1047,68 @@ describe("Pipeline routes", () => {
           { id: "run-789", status: "running", startedAt: new Date().toISOString() },
         ],
       });
+      // A serveable (non-exhausted) audience still exists → the campaign must keep going.
+      mockSelectAudienceForRun.mockResolvedValue(defaultAudience);
 
       const res = await request(app)
         .post("/end-run")
         .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .set("x-audience-id", "aud-dry")
         .send({ success: true, stopCampaign: true })
         .expect(200);
 
       expect(res.body.status).toBe("completed");
-      expect(mockUpdateRun).toHaveBeenCalledWith("run-789", "completed", expect.objectContaining({ orgId }));
 
-      // Wait for async auto-stop
-      await new Promise((r) => setTimeout(r, 100));
+      // Wait for async handling
+      await new Promise((r) => setTimeout(r, 150));
 
-      // Should NOT re-trigger
+      // The served audience is marked exhausted for this campaign.
+      const marks = await db
+        .select()
+        .from(campaignAudienceExhaustion)
+        .where(and(
+          eq(campaignAudienceExhaustion.campaignId, campaign.id),
+          eq(campaignAudienceExhaustion.audienceId, "aud-dry"),
+        ));
+      expect(marks).toHaveLength(1);
+
+      // Campaign stays ongoing and is rescheduled (NOT stopped) — other audiences remain.
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.status).toBe("ongoing");
+      expect(updated!.nextRunAt).not.toBeNull();
+    });
+
+    it("stopCampaign=true auto-stops the campaign ONLY when no serveable audience remains (all exhausted)", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        status: "ongoing",
+        featureSlug: "sales-cold-email-v1",
+        createdByUserId: "user_test",
+      });
+
+      mockListRuns.mockResolvedValue({
+        runs: [
+          { id: "run-790", status: "running", startedAt: new Date().toISOString() },
+        ],
+      });
+      // No serveable audience left (every targeted audience is exhausted) → legitimate stop.
+      mockSelectAudienceForRun.mockResolvedValue(null);
+
+      const res = await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .set("x-audience-id", "aud-last")
+        .send({ success: true, stopCampaign: true })
+        .expect(200);
+
+      expect(res.body.status).toBe("completed");
+
+      await new Promise((r) => setTimeout(r, 150));
+
+      // NOT re-triggered, and stopped with nextRunAt cleared.
       expect(mockExecute).not.toHaveBeenCalled();
-
-      // Should auto-stop in DB and NOT set nextRunAt
       const updated = await db.query.campaigns.findFirst({
         where: eq(campaigns.id, campaign.id),
       });

--- a/tests/unit/features-audience-client.test.ts
+++ b/tests/unit/features-audience-client.test.ts
@@ -94,3 +94,58 @@ describe("selectAudienceForRun — Campaign v2 hard targeting subset", () => {
     expect(picked?.audienceId).toBe("aud-b");
   });
 });
+
+describe("selectAudienceForRun — excludedAudienceIds (exhausted-audience skip)", () => {
+  beforeEach(() => {
+    process.env.FEATURES_SERVICE_URL = "http://features.test";
+    process.env.FEATURES_SERVICE_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("never picks an excluded (exhausted) audience", async () => {
+    // aud-a is exhausted; only aud-b remains serveable.
+    global.fetch = mockStats([audience("aud-a"), audience("aud-b")]);
+    const picked = await selectAudienceForRun({
+      ...baseInput,
+      excludedAudienceIds: ["aud-a"],
+    });
+    expect(picked?.audienceId).toBe("aud-b");
+  });
+
+  it("returns null when EVERY active audience is excluded (all exhausted → stop signal)", async () => {
+    global.fetch = mockStats([audience("aud-a"), audience("aud-b")]);
+    const picked = await selectAudienceForRun({
+      ...baseInput,
+      excludedAudienceIds: ["aud-a", "aud-b"],
+    });
+    expect(picked).toBeNull();
+  });
+
+  it("applies exclusion WITHIN the hard targeted subset (one exhausted of two targeted → picks the other)", async () => {
+    global.fetch = mockStats([audience("aud-a"), audience("aud-b"), audience("aud-z")]);
+    const picked = await selectAudienceForRun({
+      ...baseInput,
+      requiredAudienceIds: ["aud-a", "aud-b"],
+      excludedAudienceIds: ["aud-a"],
+    });
+    expect(picked?.audienceId).toBe("aud-b");
+  });
+
+  it("returns null when the whole targeted subset is exhausted (no fallback to untargeted)", async () => {
+    global.fetch = mockStats([audience("aud-a"), audience("aud-b"), audience("aud-z")]);
+    const picked = await selectAudienceForRun({
+      ...baseInput,
+      requiredAudienceIds: ["aud-a", "aud-b"],
+      excludedAudienceIds: ["aud-a", "aud-b"],
+    });
+    expect(picked).toBeNull();
+  });
+
+  it("no exclusion when excludedAudienceIds is empty/absent", async () => {
+    global.fetch = mockStats([audience("aud-a")]);
+    const picked = await selectAudienceForRun({ ...baseInput, excludedAudienceIds: [] });
+    expect(picked?.audienceId).toBe("aud-a");
+  });
+});


### PR DESCRIPTION
## Problem
A multi-audience sales campaign was WRONGLY auto-stopped. The workflow DAG sends `stopCampaign=true` whenever a run's single bandit-picked audience returns no leads (`fetch-lead.found == false`). campaign-service obeyed it literally and stopped the whole campaign — but the bandit narrows each run to ONE audience, so one audience running dry says nothing about the others.

Prod incident (brand `75d7e3e8`): campaign stopped at 14:01 the moment the bandit picked its one exhausted audience (`729e06f0`), while 7 other audiences still had tens of thousands of reachable leads (`exhausted=false`, e.g. one served 583 of a 19,500 pool). Confirmed via `run_events`: `end-run … stopCampaign=true` on that one run.

Verified upstream (apollo/human/lead/workflow): all three services report exhaustion HONESTLY and per-audience. `stopCampaign` is a hardcoded literal in the DAG (`= !found`), evaluated on the single served audience — no cross-audience aggregation. The fix belongs in campaign-service, which owns the audience set and the stop decision.

## Change (single repo, no DAG / workflow-service change)
- **Migration 0040** `campaign_audience_exhaustion(campaign_id, audience_id, exhausted_at)` — records the served audience when a run returns no leads.
- **`/end-run`**: reinterpret `stopCampaign=true` as AUDIENCE-scoped — mark `req.audienceId` exhausted, then auto-stop the campaign ONLY when it has no serveable non-exhausted audience left (`hasServeableAudience`); otherwise reschedule so the next tick re-draws from the remaining audiences. Fail-safe: any error → do NOT stop.
- **`selectAudienceForRun`** gains `excludedAudienceIds`; `/start-run` excludes fresh exhausted audiences so the bandit never re-picks a known-dry one.
- **24h TTL** — marks expire so audiences are re-probed daily (Apollo can add new matching leads over time; exhaustion is never permanent).

## Tests
- `selectAudienceForRun` exclusion (unit): skips excluded, returns null when all excluded, respects hard subset.
- `/end-run` (integration): stopCampaign=true + serveable remains → marks audience + reschedules, stays `ongoing`; all exhausted → `stopped`.
- Full suite: 352 passed.

## Triage
staging (feature/bugfix): migration + stop-path logic. Prod-impacting (campaigns wrongly stopped) — promote promptly after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
