### PR TITLE
feat(lifecycle): extend-audience email when a brand is fully contacted

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ BILLING_SERVICE_API_KEY='your-billing-api-key'
 EMAIL_GATEWAY_SERVICE_URL='https://email-gateway.distribute.you'
 EMAIL_GATEWAY_SERVICE_API_KEY='your-gateway-api-key'
 
+# Transactional Email Service (lifecycle emails: extend-audience nudge)
+TRANSACTIONAL_EMAIL_SERVICE_URL='https://transactional-email.distribute.you'
+TRANSACTIONAL_EMAIL_SERVICE_API_KEY='your-transactional-email-api-key'
+
 # Legacy downstream services (stats aggregation)
 POSTMARK_SERVICE_URL='http://localhost:3006'
 POSTMARK_SERVICE_API_KEY='your-postmark-api-key'

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import brandsRoutes from "./routes/brands.js";
 import statsRoutes from "./routes/stats.js";
 import internalRoutes from "./routes/internal.js";
 import { startScheduler } from "./lib/scheduler.js";
+import { registerExtendAudienceTemplate } from "./lib/transactional-email.js";
 const app = express();
 const PORT = process.env.PORT || 3003;
 
@@ -70,6 +71,9 @@ if (process.env.NODE_ENV !== "test") {
       startScheduler();
       app.listen(Number(PORT), "::", () => {
         console.log(`[campaign-service] Running on port ${PORT}`);
+        // Register lifecycle email templates AFTER port-bind, fire-and-forget: a slow or
+        // down transactional-email-service must never delay boot or fail the deploy.
+        void registerExtendAudienceTemplate();
       });
     })
     .catch((err) => {

--- a/src/lib/transactional-email.ts
+++ b/src/lib/transactional-email.ts
@@ -1,0 +1,210 @@
+// Lifecycle email: nudge the user to extend an audience when a brand's outreach has
+// fully contacted every lead in its active audiences (the sales loop has no next lead
+// left to send). campaign-service is the SENDER/trigger, so it owns registering the
+// template and firing the send; transactional-email-service owns templating, recipient
+// resolution, and the 1x/month-per-brand deduplication.
+//
+// EVERYTHING here is fire-and-forget: it must NEVER block, delay, or fail the outreach
+// loop / run finalization. Every path swallows its error (logged, not thrown).
+import type { Campaign } from "../db/schema.js";
+import { anyBrandPaused } from "./brand-pause.js";
+import { SALES_OUTREACH_FEATURE_SLUG } from "./sales-outreach-campaign.js";
+
+// eventType == template name. transactional-email-service maps a send's eventType to the
+// template of the same name and applies its monthly-per-brand dedup to this eventType.
+export const EXTEND_AUDIENCE_EVENT_TYPE = "audience_fully_contacted";
+
+const DASHBOARD_URL = "https://dashboard.distribute.you";
+
+// The template registered at boot via PUT /platform-templates (API-key only; no user
+// session needed at cold start). Copy is user-facing: plain, no em-dash.
+const EXTEND_AUDIENCE_TEMPLATE = {
+  name: EXTEND_AUDIENCE_EVENT_TYPE,
+  subject: "Your outreach is waiting on new leads",
+  htmlBody: [
+    "<p>Hi there,</p>",
+    "<p>Your outreach has now contacted everyone in your current audiences, so sending has paused.</p>",
+    "<p>Add or widen an audience and we'll pick sending back up automatically.</p>",
+    '<p><a href="{{dashboardUrl}}">Extend an audience</a></p>',
+  ].join("\n"),
+  textBody: [
+    "Hi there,",
+    "",
+    "Your outreach has now contacted everyone in your current audiences, so sending has paused.",
+    "",
+    "Add or widen an audience and we'll pick sending back up automatically.",
+    "",
+    "Extend an audience: {{dashboardUrl}}",
+  ].join("\n"),
+};
+
+function transactionalEmailConfig(): { url: string; apiKey: string } | null {
+  const url = process.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
+  const apiKey = process.env.TRANSACTIONAL_EMAIL_SERVICE_API_KEY;
+  if (!url || !apiKey) return null;
+  return { url, apiKey };
+}
+
+/**
+ * Register the extend-audience template at boot. Idempotent upsert on the template
+ * `name`. Uses PUT /platform-templates (x-api-key only) so no org/user session is
+ * required at cold start. Fire-and-forget: a registration failure logs and is
+ * swallowed so it never blocks boot or the request path.
+ */
+export async function registerExtendAudienceTemplate(): Promise<void> {
+  const cfg = transactionalEmailConfig();
+  if (!cfg) {
+    console.warn(
+      "[campaign-service] TRANSACTIONAL_EMAIL_SERVICE_URL/API_KEY not set — skipping extend-audience template registration",
+    );
+    return;
+  }
+  try {
+    const res = await fetch(`${cfg.url}/platform-templates`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", "x-api-key": cfg.apiKey },
+      body: JSON.stringify({ templates: [EXTEND_AUDIENCE_TEMPLATE] }),
+    });
+    if (!res.ok) {
+      console.error(`[campaign-service] extend-audience template registration failed: ${res.status}`);
+    } else {
+      console.log("[campaign-service] Registered extend-audience email template");
+    }
+  } catch (err) {
+    console.error("[campaign-service] extend-audience template registration error:", err);
+  }
+}
+
+/**
+ * Read whether the org has auto-topup ON from billing-service. User-less internal read
+ * (x-api-key only). Fail-SAFE: any error, non-2xx, 404, or missing field returns false
+ * so we NEVER email an org we cannot confirm is set up to keep spending. Never throws.
+ */
+async function readAutoTopupEnabled(orgId: string): Promise<boolean> {
+  const url = process.env.BILLING_SERVICE_URL;
+  const apiKey = process.env.BILLING_SERVICE_API_KEY;
+  if (!url || !apiKey) return false;
+  try {
+    const res = await fetch(`${url}/internal/accounts/by-org/${orgId}/balance`, {
+      headers: { "x-api-key": apiKey },
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { has_auto_topup?: boolean };
+    return data.has_auto_topup === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a brand's daily budget (cents) from billing-service. Service-to-service read.
+ * Fail-SAFE: any error / non-2xx / unparseable returns null (treated as no budget).
+ * Never throws.
+ */
+async function readBrandDailyBudgetCents(orgId: string, brandId: string): Promise<number | null> {
+  const url = process.env.BILLING_SERVICE_URL;
+  const apiKey = process.env.BILLING_SERVICE_API_KEY;
+  if (!url || !apiKey) return null;
+  try {
+    const res = await fetch(`${url}/internal/brands/${brandId}/daily-budget`, {
+      headers: { "x-api-key": apiKey, "x-org-id": orgId, "x-brand-id": brandId },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { dailyBudgetCents?: string | null };
+    if (data.dailyBudgetCents === null || data.dailyBudgetCents === undefined) return null;
+    const cents = parseFloat(data.dailyBudgetCents);
+    return Number.isFinite(cents) ? cents : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Does the campaign have a positive daily budget configured? The campaign's OWN daily
+ * budget (dailyBudgetCents) takes precedence; when unset, fall back to ANY targeted
+ * brand's daily budget (mirrors the sales gate-check resolution). Fail-safe → false.
+ */
+async function hasPositiveDailyBudget(campaign: Campaign): Promise<boolean> {
+  if (campaign.dailyBudgetCents !== null && campaign.dailyBudgetCents !== undefined) {
+    return campaign.dailyBudgetCents > 0;
+  }
+  const brandIds = campaign.brandIds ?? [];
+  for (const brandId of brandIds) {
+    const cents = await readBrandDailyBudgetCents(campaign.orgId, brandId);
+    if (cents !== null && cents > 0) return true;
+  }
+  return false;
+}
+
+/**
+ * POST the extend-audience lifecycle email. Recipient is resolved by transactional-email
+ * from x-user-id (the campaign's createdByUserId → client-service). Dedup (1x/month per
+ * brand) is enforced downstream by the eventType's monthly-per-brand strategy, so a
+ * duplicate simply returns { sent: false, reason: "duplicate" }. Never throws.
+ */
+async function sendExtendAudienceEmail(campaign: Campaign, userId: string, runId: string): Promise<void> {
+  const cfg = transactionalEmailConfig();
+  if (!cfg) return;
+  const brandIds = campaign.brandIds ?? [];
+  try {
+    const res = await fetch(`${cfg.url}/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": cfg.apiKey,
+        "x-org-id": campaign.orgId,
+        "x-user-id": userId,
+        "x-run-id": runId,
+        "x-campaign-id": campaign.id,
+        "x-brand-id": brandIds.join(","),
+        ...(campaign.featureSlug ? { "x-feature-slug": campaign.featureSlug } : {}),
+      },
+      body: JSON.stringify({
+        eventType: EXTEND_AUDIENCE_EVENT_TYPE,
+        brandIds,
+        campaignId: campaign.id,
+        metadata: { dashboardUrl: DASHBOARD_URL },
+      }),
+    });
+    if (!res.ok) {
+      console.error(`[campaign-service] extend-audience email send failed for campaign ${campaign.id}: ${res.status}`);
+    }
+  } catch (err) {
+    console.error(`[campaign-service] extend-audience email send error for campaign ${campaign.id}:`, err);
+  }
+}
+
+/**
+ * Fire-and-forget: when a brand's outreach is fully contacted (all targeted audiences
+ * exhausted, the campaign is being auto-stopped), email the user to extend an audience.
+ *
+ * Sends ONLY when EVERY condition holds:
+ *   - sales-cold-email-outreach feature (the audience/extend concept applies)
+ *   - the campaign has an owning user (createdByUserId) to resolve as recipient
+ *   - the brand is ACTIVE (not paused)
+ *   - a daily budget is configured (> 0)
+ *   - the org has auto-topup ON
+ *
+ * The 1x/month-per-brand cap is enforced by transactional-email-service dedup, not here.
+ * Any error is logged and swallowed — this must never affect run finalization.
+ */
+export async function maybeSendExtendAudienceEmail(campaign: Campaign, opts: { runId?: string }): Promise<void> {
+  try {
+    if (campaign.featureSlug !== SALES_OUTREACH_FEATURE_SLUG) return;
+
+    const userId = campaign.createdByUserId;
+    if (!userId) return;
+
+    const brandIds = campaign.brandIds ?? [];
+    if (brandIds.length === 0) return;
+
+    if (await anyBrandPaused(campaign.orgId, brandIds)) return;
+    if (!(await hasPositiveDailyBudget(campaign))) return;
+    if (!(await readAutoTopupEnabled(campaign.orgId))) return;
+
+    const runId = opts.runId ?? crypto.randomUUID();
+    await sendExtendAudienceEmail(campaign, userId, runId);
+  } catch (err) {
+    console.error(`[campaign-service] maybeSendExtendAudienceEmail failed for campaign ${campaign.id}:`, err);
+  }
+}

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -11,6 +11,7 @@ import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "../lib/brand-runtime-client.js";
 import { markAudienceExhausted, getFreshExhaustedAudienceIds } from "../lib/audience-exhaustion.js";
+import { maybeSendExtendAudienceEmail } from "../lib/transactional-email.js";
 import {
   fetchWorkflowProjectionRows,
   selectAudienceFromProjection,
@@ -461,6 +462,13 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
             : false;
 
         if (!serveable) {
+          // Fully contacted: every targeted audience is exhausted and the campaign is
+          // being auto-stopped. Nudge the user to extend an audience so outreach can
+          // resume. Fire-and-forget — never blocks or fails run finalization, and the
+          // 1x/month-per-brand cap is enforced by transactional-email-service dedup.
+          if (campaign) {
+            void maybeSendExtendAudienceEmail(campaign, { runId: req.runId });
+          }
           await db.update(campaigns)
             .set({ status: "stopped", nextRunAt: null, updatedAt: new Date() })
             .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));

--- a/tests/unit/transactional-email.test.ts
+++ b/tests/unit/transactional-email.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockAnyBrandPaused } = vi.hoisted(() => ({
+  mockAnyBrandPaused: vi.fn(),
+}));
+
+vi.mock("../../src/lib/brand-pause.js", () => ({
+  anyBrandPaused: mockAnyBrandPaused,
+}));
+
+vi.mock("../../src/lib/sales-outreach-campaign.js", () => ({
+  SALES_OUTREACH_FEATURE_SLUG: "sales-cold-email-outreach",
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { maybeSendExtendAudienceEmail } from "../../src/lib/transactional-email.js";
+import type { Campaign } from "../../src/db/schema.js";
+
+process.env.TRANSACTIONAL_EMAIL_SERVICE_URL = "https://te.test.local";
+process.env.TRANSACTIONAL_EMAIL_SERVICE_API_KEY = "te-key";
+process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+process.env.BILLING_SERVICE_API_KEY = "billing-key";
+
+function makeCampaign(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: "campaign-1",
+    orgId: "org-1",
+    createdByUserId: "user-1",
+    parentRunId: null,
+    name: "Test",
+    workflowSlug: "granite",
+    brandIds: ["brand-1"],
+    featureSlug: "sales-cold-email-outreach",
+    featureInputs: null,
+    activeGoalId: null,
+    brandProfileId: null,
+    audienceId: null,
+    goal: null,
+    audienceIds: null,
+    servicesOffered: null,
+    clickDestinationUrl: null,
+    maxBudgetDailyUsd: null,
+    maxBudgetWeeklyUsd: null,
+    maxBudgetMonthlyUsd: null,
+    maxBudgetTotalUsd: null,
+    dailyBudgetCents: 500,
+    maxLeads: null,
+    startDate: null,
+    endDate: null,
+    status: "ongoing",
+    nextRunAt: null,
+    notifyFrequency: null,
+    notifyChannel: null,
+    notifyDestination: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Campaign;
+}
+
+// Route mock fetch by URL. Default: auto-topup ON, brand budget positive, send OK.
+function routeFetch(opts: { autoTopup?: boolean; brandBudgetCents?: string | null; sendOk?: boolean } = {}) {
+  const { autoTopup = true, brandBudgetCents = "1000", sendOk = true } = opts;
+  mockFetch.mockImplementation((url: string) => {
+    if (url.includes("/internal/accounts/by-org/")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ has_auto_topup: autoTopup }) });
+    }
+    if (url.includes("/daily-budget")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ dailyBudgetCents: brandBudgetCents }) });
+    }
+    if (url.endsWith("/send")) {
+      return Promise.resolve({ ok: sendOk, status: sendOk ? 200 : 500, json: () => Promise.resolve({ results: [] }) });
+    }
+    return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+  });
+}
+
+function sendCall() {
+  return mockFetch.mock.calls.find((c) => String(c[0]).endsWith("/send"));
+}
+
+describe("maybeSendExtendAudienceEmail", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockAnyBrandPaused.mockReset();
+    mockAnyBrandPaused.mockResolvedValue(false);
+    routeFetch();
+  });
+
+  it("sends when exhausted + active + budgeted + auto-topup ON", async () => {
+    await maybeSendExtendAudienceEmail(makeCampaign(), { runId: "run-1" });
+    const call = sendCall();
+    expect(call).toBeTruthy();
+    const body = JSON.parse(String(call![1].body));
+    expect(body.eventType).toBe("audience_fully_contacted");
+    expect(body.brandIds).toEqual(["brand-1"]);
+    expect(call![1].headers["x-user-id"]).toBe("user-1");
+    expect(call![1].headers["x-org-id"]).toBe("org-1");
+    expect(call![1].headers["x-run-id"]).toBe("run-1");
+  });
+
+  it("does NOT send for a non-sales feature", async () => {
+    await maybeSendExtendAudienceEmail(makeCampaign({ featureSlug: "pr-expert-quote-outreach" }), { runId: "r" });
+    expect(sendCall()).toBeUndefined();
+  });
+
+  it("does NOT send when the campaign has no owning user", async () => {
+    await maybeSendExtendAudienceEmail(makeCampaign({ createdByUserId: null }), { runId: "r" });
+    expect(sendCall()).toBeUndefined();
+  });
+
+  it("does NOT send when the brand is paused", async () => {
+    mockAnyBrandPaused.mockResolvedValue(true);
+    await maybeSendExtendAudienceEmail(makeCampaign(), { runId: "r" });
+    expect(sendCall()).toBeUndefined();
+  });
+
+  it("does NOT send when no daily budget is configured (campaign null + brand null)", async () => {
+    routeFetch({ brandBudgetCents: null });
+    await maybeSendExtendAudienceEmail(makeCampaign({ dailyBudgetCents: null }), { runId: "r" });
+    expect(sendCall()).toBeUndefined();
+  });
+
+  it("sends on brand-budget fallback when the campaign has no own budget but the brand does", async () => {
+    routeFetch({ brandBudgetCents: "800" });
+    await maybeSendExtendAudienceEmail(makeCampaign({ dailyBudgetCents: null }), { runId: "r" });
+    expect(sendCall()).toBeTruthy();
+  });
+
+  it("does NOT send when auto-topup is OFF", async () => {
+    routeFetch({ autoTopup: false });
+    await maybeSendExtendAudienceEmail(makeCampaign(), { runId: "r" });
+    expect(sendCall()).toBeUndefined();
+  });
+
+  it("does NOT send (fail-safe) when the auto-topup read fails", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/internal/accounts/by-org/")) return Promise.reject(new Error("billing down"));
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ dailyBudgetCents: "1000" }) });
+    });
+    await maybeSendExtendAudienceEmail(makeCampaign(), { runId: "r" });
+    expect(sendCall()).toBeUndefined();
+  });
+
+  it("never throws when the send itself fails (fire-and-forget)", async () => {
+    routeFetch({ sendOk: false });
+    await expect(maybeSendExtendAudienceEmail(makeCampaign(), { runId: "r" })).resolves.toBeUndefined();
+  });
+
+  it("does NOT send when the campaign has no brands", async () => {
+    await maybeSendExtendAudienceEmail(makeCampaign({ brandIds: [] }), { runId: "r" });
+    expect(sendCall()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What
When a brand's cold-outreach loop has contacted everyone in its active audiences (all targeted audiences exhausted, the campaign auto-stopping in `/end-run`), email the brand's user to nudge them to extend an audience so outreach keeps running. Closes the gap where an active, paying brand silently stops producing outcomes and the user is never told.

## Where
Hooked into `POST /end-run`, in the all-audiences-exhausted branch (right before the campaign is auto-stopped) — the exact moment "the brand is fully contacted". Fire-and-forget after the response is already sent.

## Conditions (ALL must hold to send)
- **Exhausted** — every targeted audience is exhausted (`!serveable`), campaign auto-stopping
- **Sales feature** — `sales-cold-email-outreach` (the audience/extend concept)
- **Has an owning user** — `createdByUserId` present (recipient anchor)
- **Brand active** — not paused (`anyBrandPaused` false)
- **Budget configured** — campaign `dailyBudgetCents > 0`, else any targeted brand's billing daily budget `> 0`
- **Auto-topup ON** — billing `GET /internal/accounts/by-org/{orgId}/balance` → `has_auto_topup === true` (user-less internal read)

## 1×/month per brand
Enforced by transactional-email-service dedup on the new `audience_fully_contacted` eventType (monthly-per-brand cadence) — no campaign-service state. **Depends on transactional-email-service PR (branch `KevinLourd/monthly-brand-dedup`) adding that cadence.**

## Ownership / safety
- Send + templating + recipient resolution + dedup owned by transactional-email-service. campaign-service registers the template at boot (`PUT /platform-templates`, API-key only) and fires `POST /send`.
- **Fire-and-forget**: the outreach loop / run finalization is never blocked or failed — every path logs and swallows errors.
- Auto-topup / budget reads are **fail-safe** (any error/absent field → treat as OFF → no email), so an unset billing field never spams.
- No metered cost declared (campaign-service spends nothing here).
- Copy is user-facing, no em-dash.

## Env (set on campaign-service staging)
- `TRANSACTIONAL_EMAIL_SERVICE_URL`, `TRANSACTIONAL_EMAIL_SERVICE_API_KEY` (copied from billing-service)

## Tests
`tests/unit/transactional-email.test.ts` (10 cases): happy path + each guard (non-sales, no user, paused, no budget, brand-budget fallback, auto-topup OFF, fail-safe billing error, send failure never throws, no brands). Full suite 197/197 green, `tsc` clean, build + openapi regen OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
