### PR TITLE
feat(sales-crm): full sales-outreach parity for sales-crm-email-outreach

### DIFF
--- a/src/lib/brand-pause.ts
+++ b/src/lib/brand-pause.ts
@@ -1,7 +1,7 @@
 import { sql, and, eq, inArray, type SQL } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { brandPause, campaigns } from "../db/schema.js";
-import { SALES_OUTREACH_FEATURE_SLUG } from "./sales-outreach-campaign.js";
+import { SALES_OUTREACH_FEATURE_SLUGS } from "./sales-outreach-campaign.js";
 
 /**
  * SQL predicate: the campaign is NOT held by a brand pause.
@@ -10,8 +10,9 @@ import { SALES_OUTREACH_FEATURE_SLUG } from "./sales-outreach-campaign.js";
  * `brand_ids` array belongs to a paused brand (brand_pause.paused = true) in the SAME org.
  * This clause is the negation — true for campaigns that should still run.
  *
- * FEATURE-SCOPED: a brand pause is a sales-cold-email-outreach switch (the pause toggle re-seeds
- * a sales campaign on un-pause), so it holds ONLY that feature's campaigns. Every other feature
+ * FEATURE-SCOPED: a brand pause is a sales-outreach switch (the pause toggle re-seeds a sales
+ * campaign on un-pause), so it holds ONLY the sales-outreach feature family's campaigns
+ * (sales-cold-email-outreach + sales-crm-email-outreach). Every other feature
  * (pr-expert-quote-outreach, pr-expert-quote-opportunities, ai-visibility-scoring, …) keeps
  * running for a paused brand — pausing sales must not freeze the brand's other features.
  *
@@ -30,7 +31,10 @@ export function notPausedBrandClause(): SQL {
       ON bp.org_id = c.org_id
       AND bp.paused = true
       AND bp.brand_id = ANY(c.brand_ids)
-    WHERE c.feature_slug = ${SALES_OUTREACH_FEATURE_SLUG}
+    WHERE c.feature_slug IN (${sql.join(
+      [...SALES_OUTREACH_FEATURE_SLUGS].map((slug) => sql`${slug}`),
+      sql`, `,
+    )})
   )`;
 }
 

--- a/src/lib/features-workflow-projection-client.ts
+++ b/src/lib/features-workflow-projection-client.ts
@@ -1,6 +1,7 @@
 import { buildServiceHeaders, type DownstreamIdentity } from "./downstream-headers.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "./brand-runtime-client.js";
 import { thompsonArgminCost, type Arm, type Rng } from "./bandit.js";
+import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
 
 // Audience-grain, send-tagged evidence for one (audience × workflow dynasty) couple.
 // Present ONLY on audienceId != null rows whose audience actually spent under this couple
@@ -268,18 +269,18 @@ export function hasServeableAudienceInProjection(
   return ids.size > 0;
 }
 
-// Per-run workflow rotation (the greedy bandit) is enabled ONLY for these features.
-// Every other feature always runs its campaign's configured workflowSlug, run after run,
-// with no features-service call and no rotation. Product decision (2026-07-07): only
-// sales-cold-email-outreach should vary its workflow across runs.
-const WORKFLOW_ROTATION_FEATURE_SLUGS = new Set<string>(["sales-cold-email-outreach"]);
-
 /**
  * Whether the greedy workflow rotation applies to a given feature. When false, the
  * trigger keeps the campaign's configured workflowSlug (no features-service call).
+ *
+ * Scoped to the sales-outreach feature family (sales-cold-email-outreach +
+ * sales-crm-email-outreach) — those vary their workflow across runs. Every other feature
+ * always runs its campaign's configured workflowSlug, run after run, with no
+ * features-service call and no rotation. (Product decision 2026-07-07: rotation is a
+ * sales-outreach lever; extended to sales-crm-email-outreach 2026-07-24 for full parity.)
  */
 export function isWorkflowRotationEnabled(featureSlug: string): boolean {
-  return WORKFLOW_ROTATION_FEATURE_SLUGS.has(featureSlug);
+  return isSalesOutreachFeature(featureSlug);
 }
 
 /**

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -3,13 +3,14 @@ import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 import { anyBrandPaused } from "./brand-pause.js";
+import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
 
 const STALE_THRESHOLD_MS = 3 * 60 * 60 * 1000; // 3 hours
 
-// The ONE feature paced by the brand daily budget (billing-service brand_daily_budgets).
-// Every other feature is paced by the campaign's own budget windows instead. Keep this byte-equal
-// to the feature_slug.
-const SALES_FEATURE_SLUG = "sales-cold-email-outreach";
+// The sales-outreach feature family (sales-cold-email-outreach + sales-crm-email-outreach) is
+// paced by the brand daily budget (billing-service brand_daily_budgets) and held on brand pause.
+// Every other feature is paced by the campaign's own budget windows and runs through a pause.
+// See isSalesOutreachFeature (sales-outreach-campaign.ts) for membership.
 
 export interface GateCheckInput {
   campaignId: string;
@@ -57,10 +58,10 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   // flight when the brand was paused still reaches this gate. NOT a terminal stop — the
   // campaign stays 'ongoing'; internal.ts backs it off and the next un-pause resumes it.
   //
-  // FEATURE-SCOPED: a brand pause is a sales-cold-email-outreach switch, so it only holds that
-  // feature's runs. Non-sales features (pr-expert-quote-outreach, …) run through even when the
-  // brand is paused — mirrors notPausedBrandClause() on the scheduler side.
-  if (campaign.featureSlug === SALES_FEATURE_SLUG && (await anyBrandPaused(campaign.orgId, campaign.brandIds))) {
+  // FEATURE-SCOPED: a brand pause is a sales-outreach switch, so it only holds that feature
+  // family's runs (cold + CRM). Non-sales features (pr-expert-quote-outreach, …) run through even
+  // when the brand is paused — mirrors notPausedBrandClause() on the scheduler side.
+  if (isSalesOutreachFeature(campaign.featureSlug) && (await anyBrandPaused(campaign.orgId, campaign.brandIds))) {
     return { allowed: false, reason: "Brand paused" };
   }
 
@@ -102,7 +103,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   // paced by the brand daily budget (block 3c below) instead. For non-sales campaigns the
   // campaign's own configured caps govern at their cadence: daily (today's spend, resets at day
   // rollover), weekly, monthly, and total (one-off — auto-stops the campaign when hit).
-  const isSalesFeature = campaign.featureSlug === SALES_FEATURE_SLUG;
+  const isSalesFeature = isSalesOutreachFeature(campaign.featureSlug);
 
   if (!isSalesFeature) {
     const budgetLimits: Array<{ limit: string; label: string; autoStop: boolean; nextRunAt?: Date }> = [];

--- a/src/lib/sales-outreach-campaign.ts
+++ b/src/lib/sales-outreach-campaign.ts
@@ -3,7 +3,22 @@ import { db } from "../db/index.js";
 import { campaigns, type Campaign } from "../db/schema.js";
 
 export const SALES_OUTREACH_FEATURE_SLUG = "sales-cold-email-outreach";
+export const SALES_CRM_FEATURE_SLUG = "sales-crm-email-outreach";
 export const SALES_OUTREACH_WORKFLOW_SLUG = "sales-email-cold-outreach";
+
+// The sales-outreach feature family. Both features share the SAME runtime behaviour in this
+// service — brand-pause hold, brand-daily-budget pacing, greedy workflow rotation + Thompson
+// audience selection, and the extend-audience lifecycle email. Any per-feature gate keyed on
+// "is this a sales-outreach campaign?" MUST test membership here, not a single slug, so the two
+// features stay byte-identical. (Adding a third sales feature = one line here.)
+export const SALES_OUTREACH_FEATURE_SLUGS: ReadonlySet<string> = new Set([
+  SALES_OUTREACH_FEATURE_SLUG,
+  SALES_CRM_FEATURE_SLUG,
+]);
+
+export function isSalesOutreachFeature(slug?: string | null): boolean {
+  return !!slug && SALES_OUTREACH_FEATURE_SLUGS.has(slug);
+}
 
 type CampaignStore = Pick<typeof db, "query" | "insert" | "update">;
 

--- a/src/lib/transactional-email.ts
+++ b/src/lib/transactional-email.ts
@@ -8,7 +8,7 @@
 // loop / run finalization. Every path swallows its error (logged, not thrown).
 import type { Campaign } from "../db/schema.js";
 import { anyBrandPaused } from "./brand-pause.js";
-import { SALES_OUTREACH_FEATURE_SLUG } from "./sales-outreach-campaign.js";
+import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
 
 // eventType == template name. transactional-email-service maps a send's eventType to the
 // template of the same name and applies its monthly-per-brand dedup to this eventType.
@@ -179,7 +179,7 @@ async function sendExtendAudienceEmail(campaign: Campaign, userId: string, runId
  * exhausted, the campaign is being auto-stopped), email the user to extend an audience.
  *
  * Sends ONLY when EVERY condition holds:
- *   - sales-cold-email-outreach feature (the audience/extend concept applies)
+ *   - a sales-outreach feature (cold or CRM — the audience/extend concept applies)
  *   - the campaign has an owning user (createdByUserId) to resolve as recipient
  *   - the brand is ACTIVE (not paused)
  *   - a daily budget is configured (> 0)
@@ -190,7 +190,7 @@ async function sendExtendAudienceEmail(campaign: Campaign, userId: string, runId
  */
 export async function maybeSendExtendAudienceEmail(campaign: Campaign, opts: { runId?: string }): Promise<void> {
   try {
-    if (campaign.featureSlug !== SALES_OUTREACH_FEATURE_SLUG) return;
+    if (!isSalesOutreachFeature(campaign.featureSlug)) return;
 
     const userId = campaign.createdByUserId;
     if (!userId) return;

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 import { arrayContains } from "drizzle-orm/sql/expressions/conditions";
 import { db } from "../db/index.js";
 import { brandPause, brandPauseTransitions, campaigns } from "../db/schema.js";
@@ -7,11 +7,12 @@ import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/
 import { validateBody } from "../middleware/validate.js";
 import { UpdateBrandPauseBody, SetBrandCampaignsDailyBudgetBody } from "../schemas.js";
 import { wakeScheduler } from "../lib/scheduler.js";
-import { ensureRunnableSalesOutreachCampaign } from "../lib/sales-outreach-campaign.js";
+import { ensureRunnableSalesOutreachCampaign, SALES_OUTREACH_FEATURE_SLUGS } from "../lib/sales-outreach-campaign.js";
 
-// The daily budget is a sales-cold-email-outreach pacing lever (the ONLY feature the sales
-// gate enforces it for), so the brand-page propagation targets that feature's campaigns.
-const SALES_FEATURE_SLUG = "sales-cold-email-outreach";
+// The daily budget is a sales-outreach pacing lever (the ONLY feature family the sales gate
+// enforces it for), so the brand-page propagation targets that family's campaigns
+// (sales-cold-email-outreach + sales-crm-email-outreach).
+const SALES_FEATURE_SLUGS = [...SALES_OUTREACH_FEATURE_SLUGS];
 
 const router = Router();
 
@@ -125,8 +126,8 @@ router.patch("/brands/:brandId/pause", requireApiKey, serviceAuth, validateBody(
  * on the brand page, that number must flow down to the brand's campaign(s) so per-campaign
  * pacing enforces it immediately. Org-scoped (only this org's campaigns for the brand are
  * touched). dailyBudgetCents:null clears each campaign's own budget → they fall back to the
- * brand daily budget again. Scoped to sales-cold-email-outreach — the only feature the daily
- * budget paces.
+ * brand daily budget again. Scoped to the sales-outreach feature family
+ * (sales-cold-email-outreach + sales-crm-email-outreach) — the only features the daily budget paces.
  */
 router.patch("/brands/:brandId/daily-budget", requireApiKey, serviceAuth, validateBody(SetBrandCampaignsDailyBudgetBody), async (req: AuthenticatedRequest, res) => {
   try {
@@ -140,7 +141,7 @@ router.patch("/brands/:brandId/daily-budget", requireApiKey, serviceAuth, valida
       .where(and(
         eq(campaigns.orgId, orgId),
         arrayContains(campaigns.brandIds, [brandId]),
-        eq(campaigns.featureSlug, SALES_FEATURE_SLUG),
+        inArray(campaigns.featureSlug, SALES_FEATURE_SLUGS),
       ))
       .returning({ id: campaigns.id });
 

--- a/tests/unit/bandit.test.ts
+++ b/tests/unit/bandit.test.ts
@@ -203,8 +203,9 @@ describe("selectWorkflowGreedy", () => {
 });
 
 describe("isWorkflowRotationEnabled", () => {
-  it("enables rotation for sales-cold-email-outreach", () => {
+  it("enables rotation for the sales-outreach feature family (cold + CRM)", () => {
     expect(isWorkflowRotationEnabled("sales-cold-email-outreach")).toBe(true);
+    expect(isWorkflowRotationEnabled("sales-crm-email-outreach")).toBe(true);
   });
 
   it("disables rotation for pr-expert features", () => {

--- a/tests/unit/sales-outreach-campaign.test.ts
+++ b/tests/unit/sales-outreach-campaign.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   ensureRunnableSalesOutreachCampaign,
+  isSalesOutreachFeature,
+  SALES_CRM_FEATURE_SLUG,
   SALES_OUTREACH_FEATURE_SLUG,
   SALES_OUTREACH_WORKFLOW_SLUG,
 } from "../../src/lib/sales-outreach-campaign.js";
@@ -50,6 +52,23 @@ function mutation(returned: Campaign[]) {
     fns: { set, where, values, returning },
   };
 }
+
+describe("isSalesOutreachFeature", () => {
+  it("includes both cold and CRM sales-outreach features (full parity)", () => {
+    expect(isSalesOutreachFeature(SALES_OUTREACH_FEATURE_SLUG)).toBe(true);
+    expect(isSalesOutreachFeature(SALES_CRM_FEATURE_SLUG)).toBe(true);
+    expect(isSalesOutreachFeature("sales-cold-email-outreach")).toBe(true);
+    expect(isSalesOutreachFeature("sales-crm-email-outreach")).toBe(true);
+  });
+
+  it("excludes non-sales features and empty/nullish slugs", () => {
+    expect(isSalesOutreachFeature("pr-expert-quote-outreach")).toBe(false);
+    expect(isSalesOutreachFeature("hiring-cold-email-outreach")).toBe(false);
+    expect(isSalesOutreachFeature("")).toBe(false);
+    expect(isSalesOutreachFeature(null)).toBe(false);
+    expect(isSalesOutreachFeature(undefined)).toBe(false);
+  });
+});
 
 describe("ensureRunnableSalesOutreachCampaign", () => {
   it("reuses an existing ongoing sales campaign", async () => {

--- a/tests/unit/transactional-email.test.ts
+++ b/tests/unit/transactional-email.test.ts
@@ -10,6 +10,9 @@ vi.mock("../../src/lib/brand-pause.js", () => ({
 
 vi.mock("../../src/lib/sales-outreach-campaign.js", () => ({
   SALES_OUTREACH_FEATURE_SLUG: "sales-cold-email-outreach",
+  SALES_CRM_FEATURE_SLUG: "sales-crm-email-outreach",
+  isSalesOutreachFeature: (s?: string | null) =>
+    s === "sales-cold-email-outreach" || s === "sales-crm-email-outreach",
 }));
 
 const mockFetch = vi.fn();


### PR DESCRIPTION
## What
Extends every feature-scoped sales behaviour from `sales-cold-email-outreach` to `sales-crm-email-outreach` so the two run byte-identically.

| # | Surface | File |
|---|---------|------|
| 1 | greedy workflow rotation + Thompson audience selection | `features-workflow-projection-client.ts` |
| 2 | brand-pause scheduler claim clause | `brand-pause.ts` |
| 3 | brand-pause in-flight gate hold | `gate-check.ts` |
| 4 | brand-daily-budget pacing | `gate-check.ts` |
| 5 | brand-daily-budget propagation (`PATCH /daily-budget`) | `brands.ts` |
| 6 | extend-audience lifecycle email (all-exhausted stop) | `transactional-email.ts` |

Single `SALES_OUTREACH_FEATURE_SLUGS` set + `isSalesOutreachFeature()` helper replaces the scattered `=== "sales-cold-email-outreach"` literals. Third sales feature = one line.

## Safety
- Cold path byte-identical (helper returns same result for cold).
- **0 CRM campaigns in prod** → zero live blast radius; new behaviour only activates once CRM campaigns exist.
- Scheduler pause clause uses `sql.join` to expand the family into `IN (...)` (a bare JS array interpolates as a composite record → `operator does not exist: text = record`; caught by integration tests).

## NOT included (blocked upstream)
Surface #7 — auto-seeding a CRM campaign on brand un-pause. `sales-crm-email-outreach` has **no workflow dynasty** in workflow-service yet, so an auto-created campaign would stamp a non-existent `workflowSlug` and 404 on `/execute`. Needs a CRM workflow dynasty upstream first.

## Tests
369 pass (unit + integration), `tsc --noEmit` clean, build + openapi no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)