### PR TITLE
fix(unpause): seed the resumed feature's campaign, not a hardcoded cold one

### DIFF
--- a/src/lib/sales-outreach-campaign.ts
+++ b/src/lib/sales-outreach-campaign.ts
@@ -27,8 +27,19 @@ export type EnsureSalesOutreachCampaignResult =
   | { action: "resumed"; campaign: Campaign }
   | { action: "created"; campaign: Campaign };
 
-function defaultSalesOutreachCampaignName(brandId: string): string {
-  return `Sales cold email outreach - ${brandId}`;
+function defaultSalesOutreachCampaignName(featureSlug: string, brandId: string): string {
+  const label = featureSlug === SALES_CRM_FEATURE_SLUG ? "Sales CRM email outreach" : "Sales cold email outreach";
+  return `${label} - ${brandId}`;
+}
+
+// The workflow slug stamped on a freshly-seeded campaign. It is ONLY a fallback: the scheduler
+// re-resolves the workflow via features-service (greedy /workflow-projection) on the campaign's
+// FIRST tick (rotation is enabled for every sales-outreach feature), so this literal is
+// overridden before it is ever executed. We therefore do NOT hardcode cold's workflow for every
+// feature — cold keeps its historical seed slug; any other sales-outreach feature stamps its own
+// feature slug as a harmless nominal (features-service picks the real dynasty at trigger).
+function seedWorkflowSlugForFeature(featureSlug: string): string {
+  return featureSlug === SALES_OUTREACH_FEATURE_SLUG ? SALES_OUTREACH_WORKFLOW_SLUG : featureSlug;
 }
 
 export async function ensureRunnableSalesOutreachCampaign(
@@ -38,20 +49,30 @@ export async function ensureRunnableSalesOutreachCampaign(
     brandId,
     userId,
     runId,
+    featureSlug,
     now = new Date(),
   }: {
     orgId: string;
     brandId: string;
     userId?: string;
     runId?: string;
+    // The sales-outreach feature to (re)seed for this brand. On un-pause the caller forwards the
+    // resumed product's x-feature-slug; campaign-service must NOT hardcode cold. Defaults to
+    // sales-cold-email-outreach when absent (brand-level dashboard un-pause carries no feature) or
+    // when a non-sales slug is passed (pause is a sales-outreach switch).
+    featureSlug?: string;
     now?: Date;
   },
 ): Promise<EnsureSalesOutreachCampaignResult> {
+  const resolvedFeatureSlug = isSalesOutreachFeature(featureSlug)
+    ? (featureSlug as string)
+    : SALES_OUTREACH_FEATURE_SLUG;
+
   const existing = await store.query.campaigns.findFirst({
     where: and(
       eq(campaigns.orgId, orgId),
       eq(campaigns.status, "ongoing"),
-      eq(campaigns.featureSlug, SALES_OUTREACH_FEATURE_SLUG),
+      eq(campaigns.featureSlug, resolvedFeatureSlug),
       arrayContains(campaigns.brandIds, [brandId]),
     ),
     orderBy: [desc(campaigns.createdAt)],
@@ -65,7 +86,7 @@ export async function ensureRunnableSalesOutreachCampaign(
     where: and(
       eq(campaigns.orgId, orgId),
       eq(campaigns.status, "stopped"),
-      eq(campaigns.featureSlug, SALES_OUTREACH_FEATURE_SLUG),
+      eq(campaigns.featureSlug, resolvedFeatureSlug),
       arrayContains(campaigns.brandIds, [brandId]),
     ),
     orderBy: [desc(campaigns.updatedAt), desc(campaigns.createdAt)],
@@ -91,7 +112,7 @@ export async function ensureRunnableSalesOutreachCampaign(
         where: and(
           eq(campaigns.orgId, orgId),
           eq(campaigns.status, "ongoing"),
-          eq(campaigns.featureSlug, SALES_OUTREACH_FEATURE_SLUG),
+          eq(campaigns.featureSlug, resolvedFeatureSlug),
           arrayContains(campaigns.brandIds, [brandId]),
         ),
         orderBy: [desc(campaigns.createdAt)],
@@ -117,10 +138,10 @@ export async function ensureRunnableSalesOutreachCampaign(
       orgId,
       createdByUserId: userId,
       parentRunId: runId ?? null,
-      name: defaultSalesOutreachCampaignName(brandId),
-      workflowSlug: SALES_OUTREACH_WORKFLOW_SLUG,
+      name: defaultSalesOutreachCampaignName(resolvedFeatureSlug, brandId),
+      workflowSlug: seedWorkflowSlugForFeature(resolvedFeatureSlug),
       brandIds: [brandId],
-      featureSlug: SALES_OUTREACH_FEATURE_SLUG,
+      featureSlug: resolvedFeatureSlug,
       featureInputs: null,
       status: "ongoing",
       nextRunAt: now,

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -47,7 +47,8 @@ router.get("/brands/:brandId/pause", requireApiKey, serviceAuth, async (req: Aut
  * PATCH /brands/:brandId/pause — set a brand's pause state (upsert in place).
  *
  * ONE mutable row per brand. Un-pausing also ensures the brand has a runnable sales outreach
- * campaign behind it, then wakes the scheduler so work resumes promptly.
+ * campaign behind it (for the resumed feature — forwarded as x-feature-slug, defaulting to
+ * sales-cold-email-outreach when absent), then wakes the scheduler so work resumes promptly.
  */
 router.patch("/brands/:brandId/pause", requireApiKey, serviceAuth, validateBody(UpdateBrandPauseBody), async (req: AuthenticatedRequest, res) => {
   try {
@@ -69,6 +70,10 @@ router.patch("/brands/:brandId/pause", requireApiKey, serviceAuth, validateBody(
           brandId,
           userId: req.userId,
           runId: req.runId,
+          // Feature-agnostic un-pause: seed the feature the caller is resuming (forwarded as
+          // x-feature-slug), NOT a hardcoded cold. Absent (brand-level dashboard un-pause carries
+          // no feature) → defaults to sales-cold-email-outreach inside ensureRunnable.
+          featureSlug: req.featureSlug,
           now,
         });
       }

--- a/tests/unit/sales-outreach-campaign.test.ts
+++ b/tests/unit/sales-outreach-campaign.test.ts
@@ -168,6 +168,58 @@ describe("ensureRunnableSalesOutreachCampaign", () => {
     }));
   });
 
+  it("creates a CRM campaign (feature-agnostic) when featureSlug is sales-crm-email-outreach", async () => {
+    const now = new Date("2026-06-18T12:00:00.000Z");
+    const created = campaign({ id: "campaign-crm", featureSlug: SALES_CRM_FEATURE_SLUG, nextRunAt: now, updatedAt: now });
+    const mut = mutation([created]);
+    const store = {
+      query: { campaigns: { findFirst: vi.fn().mockResolvedValue(undefined) } },
+      update: mut.update,
+      insert: mut.insert,
+    };
+
+    await expect(ensureRunnableSalesOutreachCampaign(store as never, {
+      orgId: "org-1",
+      brandId: "brand-1",
+      userId: "user-1",
+      featureSlug: SALES_CRM_FEATURE_SLUG,
+      now,
+    })).resolves.toEqual({ action: "created", campaign: created });
+
+    // The seeded row carries the CRM feature + its own slug as the (scheduler-overridden) nominal
+    // workflow — NOT the hardcoded cold feature/workflow.
+    expect(mut.fns.values).toHaveBeenCalledWith(expect.objectContaining({
+      featureSlug: SALES_CRM_FEATURE_SLUG,
+      workflowSlug: SALES_CRM_FEATURE_SLUG,
+      brandIds: ["brand-1"],
+      status: "ongoing",
+    }));
+  });
+
+  it("defaults to cold when a non-sales feature slug is passed", async () => {
+    const now = new Date("2026-06-18T12:00:00.000Z");
+    const created = campaign({ id: "campaign-created", nextRunAt: now, updatedAt: now });
+    const mut = mutation([created]);
+    const store = {
+      query: { campaigns: { findFirst: vi.fn().mockResolvedValue(undefined) } },
+      update: mut.update,
+      insert: mut.insert,
+    };
+
+    await ensureRunnableSalesOutreachCampaign(store as never, {
+      orgId: "org-1",
+      brandId: "brand-1",
+      userId: "user-1",
+      featureSlug: "pr-expert-quote-outreach",
+      now,
+    });
+
+    expect(mut.fns.values).toHaveBeenCalledWith(expect.objectContaining({
+      featureSlug: SALES_OUTREACH_FEATURE_SLUG,
+      workflowSlug: SALES_OUTREACH_WORKFLOW_SLUG,
+    }));
+  });
+
   it("fails loud when the stopped campaign is missing its user id", async () => {
     const stopped = campaign({ id: "campaign-stopped", status: "stopped", createdByUserId: null });
     const mut = mutation([]);


### PR DESCRIPTION
## Bug
On brand un-pause, campaign-service auto-seeds a runnable campaign but **hardcoded** `sales-cold-email-outreach` (feature + workflow). It's not our job to pick the feature — the workflow×audience must come from features-service, and the feature identity from the caller.

## Fix
`ensureRunnableSalesOutreachCampaign` now takes an optional `featureSlug`:
- Scopes find-existing / find-stopped / create to that feature.
- `PATCH /brands/:id/pause` forwards `req.featureSlug` (already extracted from `x-feature-slug`; api-service already forwards it via `buildInternalHeaders`).
- **Defaults to cold** when absent (brand-level dashboard un-pause carries no feature) or when a non-sales slug is passed (pause is a sales-outreach switch).
- Seed workflow slug is per-feature (cold keeps its historical literal; other sales features stamp their own slug) and is **overridden by the scheduler's greedy features-service pick on the first tick** — so workflow×audience is chosen by features-service, never hardcoded.

## Safety
- Cold path **byte-identical** (default feature + same seed workflow slug + same name).
- No new HTTP call on the un-pause path.
- Builds on #295 (sales-outreach feature family helper).

## Tests
371 pass (added: CRM-featured seed creates a CRM campaign; non-sales slug defaults cold). `tsc --noEmit` clean, build + openapi no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)