### PR TITLE
feat(goal): the goal is an opaque string, not this service's enum

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,22 @@ A gate block caused by a **normal, expected** business state — out of credits,
 ## Two distinct "goal" concepts — `activeGoalId` (attribution) vs `campaigns.goal` (pacing). Do NOT conflate.
 
 - **`activeGoalId`** (text, nullable) is an OPAQUE attribution id, threaded downstream as the `x-active-goal-id` header and returned on reads. It **never drives pacing** — no gate-check, workflow pick, or audience selection reads it.
-- **`campaigns.goal`** (RuntimeGoal `signup|meetingBooked|purchase`, nullable — added Campaign v2, migration 0039) is the campaign's OWN optimization goal and IS the pacing lever. At `/start-run` and in the scheduler's workflow greedy pick, the runtime goal is `campaign.goal ?? brandRuntimeContext.currentGoal` — the campaign's own goal overrides the brand's `currentGoal` when set, else inherits it (NULL). It's also renderable (3 known values → human labels) and exposed on reads + `/start-run`, so display and runtime agree.
+- **`campaigns.goal`** (nullable — added Campaign v2, migration 0039) is the campaign's OWN optimization goal and IS the pacing lever. At `/start-run` and in the scheduler's workflow greedy pick, the runtime goal is `campaign.goal ?? brandRuntimeContext.currentGoal` — the campaign's own goal overrides the brand's `currentGoal` when set, else inherits it (NULL). Exposed on reads + `/start-run`, so display and runtime agree.
 - The brief for Campaign v2 asserted "per-campaign goal runtime is already implemented" — it was NOT. Before 0039, ALL pacing used the brand `currentGoal`; there was no per-campaign goal override. If a future task claims per-campaign goal already paces, verify against `runtimeGoal` resolution in `src/routes/internal.ts` /start-run, not the presence of `activeGoalId`. (Set 2026-07-17, Campaign v2 PR #276.)
+
+## The goal is an OPAQUE STRING — this service does NOT own the goal vocabulary, and must never re-introduce an enum for it
+
+`RuntimeGoal` is `string` (`src/lib/brand-runtime-client.ts`) and `RuntimeGoalSchema` is `z.string().min(1)` (`src/schemas.ts`). Not an oversight — a deliberate removal of `z.enum(["signup","meetingBooked","purchase"])`.
+
+Two services own this concept and neither is this one: **brand-service** owns which goals a brand authorizes (its `brands.current_goal` check constraint already permits `websiteVisit`, `positiveReply`, `whatsappConversation`, `combinedSales` on top of the three we had names for), and **features-service** owns the spelling — it normalises every fleet spelling and returns **400 on a goal it cannot resolve**, which is the fail-loud boundary. campaign-service only carries the value from one to the other.
+
+The enum was never a real constraint, and that is the point: **the brand-goal path never passed through it.** `fetchBrandRuntimeContext` returns `await res.json() as BrandRuntimeContext` — a bare cast, no Zod — so a brand set to `combinedSales` already flowed end-to-end untouched. The enum only capped what a CALLER could ask for on `campaign.goal`, i.e. it made the brand's own goal unrepresentable per-campaign while the brand-level path carried it fine.
+
+**Non-empty is the one rule that stays, and it is fail-loud, not taste**: features-service reads an ABSENT goal as "default to meeting-booked", so `""` would forward as a silent default instead of an error. Never relax `.min(1)`.
+
+Forward the value VERBATIM. Do not map, alias, collapse or "normalise" a goal on the way through — features-service ranks workflows and audiences on the goal it is given, so rewriting one silently returns a different outcome's winner. (Related trap, dashboard side: `runtimeGoalForOptimizationGoal` in distribute.you squashes 8 brand goals into the old 3 — lossy, and currently uncalled. Do not mirror that mapping here.)
+
+(Set 2026-07-31, T1 of the per-run goal arbitration. Next: features-service returns the best goal among the brand's authorized set, and campaign-service greedy-picks goal + workflow and Thompson-picks the audience.)
 
 The per-campaign audience SUBSET (`campaigns.audience_ids`, Campaign v2) is a HARD filter on the audience bandit (`requiredAudienceIds` in `selectAudienceFromProjection`): a campaign never contacts an audience outside its targeted subset (no fallback). NULL/empty → inherit the brand's full active audience set. (The old workflow-conditioning `eligibleAudienceIds` soft-filter was REMOVED in v0.44.1 — see the single-endpoint note below.) Distinct from the singular `audienceId` column (per-campaign attribution; the per-RUN chosen audience is re-selected fresh at /start-run).
 

--- a/openapi.json
+++ b/openapi.json
@@ -191,12 +191,7 @@
       "RuntimeGoal": {
         "type": "string",
         "nullable": true,
-        "enum": [
-          "signup",
-          "meetingBooked",
-          "purchase",
-          null
-        ]
+        "minLength": 1
       },
       "ErrorResponse": {
         "type": "object",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -38,12 +38,20 @@ export const campaigns = pgTable(
     // nothing keeps the pre-v2 behavior (brand-level goal / audiences / services /
     // destination), so no existing or running campaign is disrupted.
 
-    // The campaign's OWN optimization goal — a RuntimeGoal value
-    // ('signup' | 'meetingBooked' | 'purchase'). Drives THIS campaign's runtime pacing /
-    // candidate-selection (workflow greedy pick at the trigger + audience Thompson at
-    // /start-run): when set it overrides the brand's currentGoal for this campaign only.
-    // NULL → pace on the brand goal. Distinct from activeGoalId (an opaque attribution id
-    // threaded as x-active-goal-id and never consumed for pacing).
+    // The campaign's OWN optimization goal — an OPAQUE string, no enum. Drives THIS
+    // campaign's runtime pacing / candidate-selection (workflow greedy pick at the trigger +
+    // audience Thompson at /start-run): when set it overrides the brand's currentGoal for
+    // this campaign only. NULL → pace on the brand goal.
+    //
+    // Deliberately unconstrained here: brand-service owns which goals a brand authorizes and
+    // features-service owns the spelling (and fails loud on one it cannot resolve). The
+    // previous three-value enum on the API schema capped a campaign to a subset of the goals
+    // the fleet supports while the brand-goal path — which never passes through this column —
+    // already carried the wider set. Non-empty is enforced at the API boundary: an absent
+    // goal means "default" downstream, so an empty string would be a silent default.
+    //
+    // Distinct from activeGoalId (an opaque attribution id threaded as x-active-goal-id and
+    // never consumed for pacing).
     goal: text("goal"),
 
     // The SUBSET (one OR more) of the brand's audiences this campaign targets

--- a/src/lib/brand-runtime-client.ts
+++ b/src/lib/brand-runtime-client.ts
@@ -1,6 +1,18 @@
 import { buildServiceHeaders, type DownstreamIdentity } from "./downstream-headers.js";
 
-export type RuntimeGoal = "signup" | "meetingBooked" | "purchase";
+/**
+ * The brand's runtime optimization goal, as brand-service reports it.
+ *
+ * Deliberately a bare string, not a union. brand-service owns this vocabulary and its own
+ * column already permits values this service has no name for; features-service owns the
+ * spelling and fails loud on a goal it cannot resolve. campaign-service only carries the
+ * value from one to the other, so narrowing it here bought nothing and silently capped what
+ * a campaign could pace on.
+ *
+ * Kept as a named alias rather than inlining `string` so every call site still reads as "this
+ * string is a goal" — the name is documentation, not a constraint.
+ */
+export type RuntimeGoal = string;
 
 export interface BrandProfile {
   id: string;

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -3,7 +3,6 @@ import { campaigns } from "../db/schema.js";
 import { eq, and, lte, isNotNull, isNull } from "drizzle-orm";
 import { executeCampaignWorkflow } from "./workflows.js";
 import { resolveWorkflowSlugForTrigger } from "./features-workflow-projection-client.js";
-import type { RuntimeGoal } from "./brand-runtime-client.js";
 import { listRuns } from "@distribute/runs-client";
 import { notPausedBrandClause } from "./brand-pause.js";
 
@@ -164,7 +163,7 @@ export async function reRunDueCampaigns(): Promise<number> {
           },
           fallbackSlug: campaign.workflowSlug,
           // Campaign v2: pace the workflow pick on the campaign's own goal when set.
-          goalOverride: campaign.goal as RuntimeGoal | null,
+          goalOverride: campaign.goal,
         });
         await executeCampaignWorkflow(workflowSlug, {
           campaignId: campaign.id,

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -218,8 +218,9 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
     // overriding the brand's currentGoal for both the workflow projection and the audience
     // bandit. NULL → pace on the brand goal (inherit), unchanged behavior. This is the
     // single place the runtime goal is resolved, so display (campaign reads expose the same
-    // raw campaign.goal) and runtime agree.
-    const runtimeGoal: RuntimeGoal = (campaign.goal as RuntimeGoal | null) ?? brandRuntimeContext.currentGoal;
+    // raw campaign.goal) and runtime agree. Whatever the value is, it is forwarded verbatim —
+    // this service does not own the goal vocabulary and never rewrites it.
+    const runtimeGoal: RuntimeGoal = campaign.goal ?? brandRuntimeContext.currentGoal;
     // Cost-aware Thompson sampling over the chosen workflow's audiences, straight from
     // features-service /workflow-projection — which enumerates EVERY active audience of the
     // brand per dynasty (floored to brand/crossOrg when an audience never ran the workflow),
@@ -308,7 +309,7 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       audienceId,
       // Campaign v2 own config — the campaign's raw own goal (null = paced on brand goal),
       // its targeted audience subset, its services, its click-destination.
-      goal: (campaign.goal as RuntimeGoal | null) ?? null,
+      goal: campaign.goal ?? null,
       audienceIds: campaign.audienceIds ?? null,
       servicesOffered: campaign.servicesOffered ?? null,
       clickDestinationUrl: campaign.clickDestinationUrl ?? null,
@@ -353,7 +354,7 @@ async function hasServeableAudience(
     featureSlug,
   };
   const brandRuntimeContext = await fetchBrandRuntimeContext(primaryBrandId, identity);
-  const runtimeGoal: RuntimeGoal = (campaign.goal as RuntimeGoal | null) ?? brandRuntimeContext.currentGoal;
+  const runtimeGoal: RuntimeGoal = campaign.goal ?? brandRuntimeContext.currentGoal;
   const excludedAudienceIds = await getFreshExhaustedAudienceIds(campaign.id);
   const rows = await fetchWorkflowProjectionRows({
     featureSlug,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -9,11 +9,22 @@ export const ErrorResponse = z.object({
   error: z.string(),
 }).openapi("ErrorResponse");
 
-// The runtime optimization goal a campaign paces against. Byte-equal to
-// brand-service's RuntimeGoal (the brand's currentGoal) — a campaign's own goal, when
-// set, overrides the brand goal for that campaign's pacing/candidate-selection. Renderable:
-// the dashboard maps each value to a human label.
-export const RuntimeGoalEnum = z.enum(["signup", "meetingBooked", "purchase"]).openapi("RuntimeGoal");
+// The runtime optimization goal a campaign paces against — an OPAQUE string, deliberately
+// not an enum. campaign-service does NOT own this vocabulary: brand-service owns which goals
+// a brand authorizes (its own column already permits values this service never had a name
+// for), and features-service owns the spelling and fails loud on a goal it cannot resolve.
+// A campaign's own goal, when set, overrides the brand goal for that campaign's
+// pacing/candidate-selection; NULL inherits the brand.
+//
+// This used to be z.enum(["signup", "meetingBooked", "purchase"]), which capped a campaign to
+// three of the goals the fleet supports and made the brand's own goal unrepresentable per
+// campaign. The brand-goal path never went through this schema (it is read straight off
+// brand-service), so the enum constrained nothing except what a caller could ASK for.
+//
+// Non-empty is the one constraint we keep, and it is a fail-loud rule rather than a taste:
+// features-service reads an ABSENT goal as "default to meeting-booked", so an empty string
+// would forward as a silent default instead of an error.
+export const RuntimeGoalSchema = z.string().min(1).openapi("RuntimeGoal");
 
 export const CampaignSchema = z.object({
   id: z.string().uuid(),
@@ -30,7 +41,7 @@ export const CampaignSchema = z.object({
   audienceId: z.string().nullable(),
   // Per-campaign OWN config (Campaign v2). Null = inherit the brand. `goal` is renderable
   // and drives this campaign's runtime pacing; audienceIds is the targeted subset.
-  goal: RuntimeGoalEnum.nullable(),
+  goal: RuntimeGoalSchema.nullable(),
   audienceIds: z.array(z.string()).nullable(),
   servicesOffered: z.array(z.string()).nullable(),
   clickDestinationUrl: z.string().nullable(),
@@ -67,7 +78,7 @@ export const CreateCampaignBody = z.object({
   // Per-campaign OWN config (Campaign v2). Omit / null = inherit the brand. audienceIds is the
   // targeted SUBSET (one or more) of the brand's audiences; an empty array is rejected — use
   // null to clear back to inherit.
-  goal: RuntimeGoalEnum.nullable().optional(),
+  goal: RuntimeGoalSchema.nullable().optional(),
   audienceIds: z.array(z.string().min(1)).min(1, "audienceIds must contain at least one audience (use null to inherit the brand)").nullable().optional(),
   servicesOffered: z.array(z.string().min(1)).nullable().optional(),
   clickDestinationUrl: z.string().min(1).nullable().optional(),
@@ -102,7 +113,7 @@ export const UpdateCampaignBody = z.object({
   // Set / clear this campaign's OWN config (Campaign v2). null clears a field → inherit the
   // brand. Updating these never touches the brand or any sibling campaign. audienceIds must be
   // non-empty when present; use null to clear back to inherit.
-  goal: RuntimeGoalEnum.nullable().optional(),
+  goal: RuntimeGoalSchema.nullable().optional(),
   audienceIds: z.array(z.string().min(1)).min(1, "audienceIds must contain at least one audience (use null to inherit the brand)").nullable().optional(),
   servicesOffered: z.array(z.string().min(1)).nullable().optional(),
   clickDestinationUrl: z.string().min(1).nullable().optional(),
@@ -234,7 +245,7 @@ export const StartRunResponse = z.object({
   // optimization goal (null = paced on the brand goal); the sending runtime reads
   // servicesOffered / clickDestinationUrl as authoritative per-campaign config (null =
   // inherit the brand). audienceIds is the campaign's targeted subset.
-  goal: RuntimeGoalEnum.nullable(),
+  goal: RuntimeGoalSchema.nullable(),
   audienceIds: z.array(z.string()).nullable(),
   servicesOffered: z.array(z.string()).nullable(),
   clickDestinationUrl: z.string().nullable(),

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -327,8 +327,35 @@ describe("Campaign CRUD", () => {
       await createCampaign({ ...validBody, name: "Empty Aud", audienceIds: [] }).expect(400);
     });
 
-    it("rejects an unknown goal value", async () => {
-      await createCampaign({ ...validBody, name: "Bad Goal", goal: "worldPeace" }).expect(400);
+    // campaign-service does NOT own the goal vocabulary. brand-service owns which goals a
+    // brand authorizes; features-service owns the spelling and fails loud (400) on a goal it
+    // cannot resolve. So any non-empty goal is accepted here and forwarded verbatim —
+    // including the goals the old three-value enum made unreachable per campaign.
+    it.each(["positiveReply", "combinedSales", "formSubmission", "websiteVisit"])(
+      "accepts the goal %s, which the previous three-value enum rejected",
+      async (goal) => {
+        const res = await createCampaign({ ...validBody, name: `Goal ${goal}`, goal }).expect(201);
+        expect(res.body.campaign.goal).toBe(goal);
+
+        const read = await get(res.body.campaign.id).expect(200);
+        expect(read.body.campaign.goal).toBe(goal);
+      },
+    );
+
+    it("still accepts the legacy goal values", async () => {
+      const res = await createCampaign({ ...validBody, name: "Legacy Goal", goal: "meetingBooked" }).expect(201);
+      expect(res.body.campaign.goal).toBe("meetingBooked");
+    });
+
+    it("rejects an EMPTY goal — an absent goal is a default downstream, so '' would become a silent default", async () => {
+      await createCampaign({ ...validBody, name: "Empty Goal", goal: "" }).expect(400);
+    });
+
+    it("sets a non-legacy goal via update", async () => {
+      const created = await createCampaign({ ...validBody, name: "Update Goal" }).expect(201);
+
+      const res = await patch(created.body.campaign.id, { goal: "formSubmission" }).expect(200);
+      expect(res.body.campaign.goal).toBe("formSubmission");
     });
 
     it("does NOT clobber a sibling campaign under the same brand", async () => {

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -505,6 +505,41 @@ describe("Pipeline routes", () => {
       );
     });
 
+    // The goal vocabulary is brand-service's, not ours. brand-service's own check constraint
+    // already allows values this service never had a name for; a campaign paces on whatever
+    // the brand says, forwarded verbatim, and features-service is the one that fails loud on
+    // a goal it cannot resolve.
+    it("should forward a brand goal this service has no enum for, verbatim", async () => {
+      mockFetchBrandRuntimeContext.mockResolvedValueOnce({
+        brand: { id: brandIds[0] },
+        currentGoal: "combinedSales",
+        brandProfile: null,
+      });
+      const campaign = await insertTestCampaign(orgId, { brandIds });
+
+      await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      expect(mockFetchCandidates).toHaveBeenCalledWith(
+        expect.objectContaining({ goal: "combinedSales" }),
+      );
+    });
+
+    it("should pace on a campaign goal outside the legacy three values", async () => {
+      const campaign = await insertTestCampaign(orgId, { brandIds, goal: "positiveReply" });
+
+      await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      expect(mockFetchCandidates).toHaveBeenCalledWith(
+        expect.objectContaining({ goal: "positiveReply" }),
+      );
+    });
+
     it("should HARD-restrict the audience bandit to the campaign's targeted subset", async () => {
       // Rows contain a targeted (aud-a) and an untargeted (aud-z) audience under the workflow.
       mockFetchCandidates.mockResolvedValueOnce([


### PR DESCRIPTION
## Problem

`campaign.goal` was validated against `z.enum(["signup", "meetingBooked", "purchase"])`, which capped a campaign to three of the goals the fleet supports.

**The enum was never a real constraint on the value that paces a run.** The brand-goal path does not pass through it — `fetchBrandRuntimeContext` returns `await res.json() as BrandRuntimeContext`, a bare cast with no Zod — so a brand set to `combinedSales` already flowed end to end untouched. The enum only capped what a *caller* could ask for on `campaign.goal`, i.e. it made the brand's own goal unrepresentable per campaign while the brand-level path carried it fine.

## Why this service should not own the vocabulary

Two services own this concept and neither is this one:

- **brand-service** owns which goals a brand authorizes. Its `brands.current_goal` check constraint already permits `websiteVisit`, `positiveReply`, `whatsappConversation` and `combinedSales` on top of the three we had names for.
- **features-service** owns the spelling. It normalises every fleet spelling and returns **400 on a goal it cannot resolve** — that is the fail-loud boundary.

campaign-service only carries the value from one to the other.

## Change

- `RuntimeGoal` becomes `string`; `RuntimeGoalEnum` becomes `RuntimeGoalSchema` = `z.string().min(1)`.
- The three `campaign.goal as RuntimeGoal | null` casts are now no-ops, so they are dropped, along with scheduler's type-only import.
- `openapi.json` regenerated: the `RuntimeGoal` component goes from `enum` to `minLength: 1`.
- CLAUDE.md pins the invariant so a future task does not re-introduce the enum.

**Non-empty is the one rule kept, and it is fail-loud rather than taste**: features-service reads an ABSENT goal as "default to meeting-booked", so an empty string would forward as a silent default instead of an error.

The value is forwarded **verbatim** at every hop. features-service ranks workflows and audiences on the goal it is given, so rewriting one silently returns a different outcome's winner.

## Tests

The `rejects an unknown goal value` case asserted the opposite invariant and had to change. Replaced by:

| Test | Expects |
|---|---|
| create with `positiveReply` / `combinedSales` / `formSubmission` / `websiteVisit` | 201, round-trips through create + read |
| create with `meetingBooked` | 201 (no regression on the legacy three) |
| create with an empty goal | 400 |
| update to `formSubmission` | 200, round-trips |
| brand goal `combinedSales`, campaign goal null | projection fetched with `goal: "combinedSales"` — brand pass-through proven |
| campaign goal `positiveReply` | projection fetched with `goal: "positiveReply"` |

375 tests pass (26 files), `tsc` clean, build clean.

## Deployment

No new env vars. No migration — `campaigns.goal` is already `text`, unconstrained at the DB level; only the API schema narrowed it.

**Not breaking for the dashboard**: it hand-writes its own `RuntimeGoal` union rather than generating from `openapi.json`, so widening the producer does not break its build. Offering the wider set in its goal picker is a separate change that belongs with the Sales Funnels work.

## Context

Groundwork for per-run goal arbitration. features-service will return the best goal among the brand's authorized set; campaign-service will greedy-pick goal and workflow, then Thompson-pick the audience. Feature requests are in flight on brand-service (own the authorized set and per-funnel economics) and features-service (arbitrate the goal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
