### PR TITLE
feat(goal-arbitration): consume the elected goal, stop supplying it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,32 @@ The enum was never a real constraint, and that is the point: **the brand-goal pa
 
 Forward the value VERBATIM. Do not map, alias, collapse or "normalise" a goal on the way through — features-service ranks workflows and audiences on the goal it is given, so rewriting one silently returns a different outcome's winner. (Related trap, dashboard side: `runtimeGoalForOptimizationGoal` in distribute.you squashes 8 brand goals into the old 3 — lossy, and currently uncalled. Do not mirror that mapping here.)
 
-(Set 2026-07-31, T1 of the per-run goal arbitration. Next: features-service returns the best goal among the brand's authorized set, and campaign-service greedy-picks goal + workflow and Thompson-picks the audience.)
+(Set 2026-07-31, T1 of the per-run goal arbitration.)
+
+## The GOAL is arbitrated by features-service — three levers, and we deduce none of them
+
+`GET /features/:slug/goal-arbitration?brandId=` answers, in ONE call: which of the goals the brand AUTHORIZES returns the most per dollar, that goal's best workflow, and the pairing's audience rows. `fetchGoalArbitration` consumes it and the two decision points take their share:
+
+```
+TRIGGER   (scheduler)  : elected goal → its elected workflow           ← greedy, features-owned
+START-RUN (internal.ts): elected goal → Thompson over the pairing rows ← explore, ours
+```
+
+**Why the ranking is not ours to do.** A cost-per-outcome is denominated in each goal's OWN outcome — a click, a reply, a booked meeting — so comparing two goals' cost-per-outcome compares two different things. Only features-service can normalise each goal through its own funnel to the same terminal unit (a paying client's lifetime revenue). Ranking goals here would mean re-deriving their economics. Do NOT add a consumer-side argmin over per-goal calls.
+
+**Both legs elect the SAME goal without threading anything through the DAG.** features-service's election is deterministic (argmax return-per-dollar, canonical tie-break) and both calls hit the same shared evidence snapshot, so the trigger and `/start-run` converge on their own. The elected goal is NOT persisted on the campaign row — it is a per-run decision, not config.
+
+**The rows come back in the SAME `ProjectionRow` shape as `/workflow-projection`** (features-service serves them that way on purpose), so the audience bandit parses them unchanged — `normalizeProjectionRows` is shared by both fetchers precisely so the bandit cannot behave differently depending on which endpoint fed it.
+
+**A campaign that states its OWN `campaign.goal` is NEVER arbitrated.** That is a manual override the customer set on purpose; arbitration only fills the inherit (NULL) case.
+
+**Snapshot drift at `/start-run`**: if the elected workflow is not the DAG actually running (the shared snapshot rolled between trigger and start-run), keep the elected GOAL but re-read the rows for the workflow that IS running. Never Thompson-pick an audience from another workflow's rows.
+
+**Fail-soft, and SILENT on the expected path.** Any arbitration failure → fall back to `campaign.goal ?? brand.currentGoal` and the existing workflow greedy, i.e. exactly the pre-arbitration behaviour: a selection optimization must never block a run. features-service 502s with `reason: "authorized_goals_unavailable"` for as long as brand-service has not declared the brand's authorized set — that is THEIR fail-loud, but for US it is an expected business state that fires on every tick for every campaign of every client, so it is **not logged at all** (per the log-discipline section above). Any OTHER failure still warns. Do not "fix" that silence into a warn.
+
+`hasServeableAudience` (the `/end-run` stop-guard) deliberately does NOT arbitrate: audience membership is goal-independent (every active audience is enumerated per dynasty whatever the goal), so it returns the same set, and if that ever stopped holding the guard would see a SUPERSET — the safe direction for a fail-safe stop.
+
+STILL TO DO (T4b, gated on brand-service declaring the authorized set): `findOrCreate` a campaign per `(org, brand, feature, goal)` so the elected goal selects WHICH campaign runs, which moves the scheduler's claim grain from campaign to brand. Three known snags: `brandIds` is a `text[]` (no unique index can span it), `uniq_campaigns_org_name` forces a deterministic generated name, and the lazy create must be `INSERT ... ON CONFLICT DO NOTHING` then `SELECT`. (Set 2026-07-31, T4a.)
 
 The per-campaign audience SUBSET (`campaigns.audience_ids`, Campaign v2) is a HARD filter on the audience bandit (`requiredAudienceIds` in `selectAudienceFromProjection`): a campaign never contacts an audience outside its targeted subset (no fallback). NULL/empty → inherit the brand's full active audience set. (The old workflow-conditioning `eligibleAudienceIds` soft-filter was REMOVED in v0.44.1 — see the single-endpoint note below.) Distinct from the singular `audienceId` column (per-campaign attribution; the per-RUN chosen audience is re-selected fresh at /start-run).
 

--- a/src/lib/features-workflow-projection-client.ts
+++ b/src/lib/features-workflow-projection-client.ts
@@ -105,9 +105,15 @@ export async function fetchWorkflowProjectionRows({
   if (!Array.isArray(body.rows)) {
     throw new Error("[campaign-service] FeatureService workflow-projection returned an invalid rows payload");
   }
-  // Normalize: fold the audience-grain raw evidence into `audienceEvidence` so the selection
-  // code reads a flat shape and never depends on the estimatesByGrain nesting.
-  return body.rows.map((r): ProjectionRow => {
+  return normalizeProjectionRows(body.rows);
+}
+
+// Fold the audience-grain raw evidence into `audienceEvidence` so the selection code reads a
+// flat shape and never depends on the estimatesByGrain nesting. Shared by /workflow-projection
+// and /goal-arbitration — both serve the SAME row shape, so both normalize identically and the
+// audience bandit cannot behave differently depending on which endpoint fed it.
+function normalizeProjectionRows(rows: RawProjectionRow[]): ProjectionRow[] {
+  return rows.map((r): ProjectionRow => {
     const ev = r.estimatesByGrain?.audience?.evidence;
     return {
       audienceId: r.audienceId,
@@ -124,6 +130,91 @@ export async function fetchWorkflowProjectionRows({
       resolved: r.resolved,
     };
   });
+}
+
+// ── Goal arbitration (features-service GET /features/:slug/goal-arbitration) ────────────────
+//
+// The GOAL is the third selection lever, and it is arbitrated by features-service, not here.
+// It answers, in ONE call: which of the goals the brand AUTHORIZES returns the most per dollar,
+// that goal's best workflow, and the pairing's audience rows (same `ProjectionRow` shape the
+// audience bandit already parses). campaign-service greedily takes the first two and
+// Thompson-samples the third — it decides none of them and never issues one request per goal.
+//
+// Why features-service and not us: a cost-per-outcome is denominated in each goal's OWN outcome
+// (a click, a reply, a booked meeting), so comparing two goals' cost-per-outcome compares two
+// different things. Only features-service can normalise each goal through its own funnel to the
+// same terminal unit. Ranking goals here would be re-deriving their economics.
+export interface GoalArbitration {
+  /** The elected goal, canonical camel spelling — forwarded verbatim, never rewritten. */
+  goal: RuntimeGoal;
+  /** The elected goal's best workflow dynasty slug. */
+  workflowSlug: string;
+  /** The winning (goal × workflow) pairing's rows, for the audience Thompson. */
+  rows: ProjectionRow[];
+}
+
+interface RawGoalArbitrationResponse {
+  arbitration?: { status?: string; goal?: string | null };
+  workflow?: { workflowDynastySlug?: string } | null;
+  rows?: RawProjectionRow[];
+}
+
+// features-service 502s with this reason for as long as brand-service has not declared the
+// brand's authorized goal set. That is their fail-loud (they refuse to substitute a default
+// set), but for US it is an EXPECTED business state, not a fault: it means "this brand has no
+// arbitration yet", and it fires on EVERY tick for EVERY campaign of EVERY client until
+// brand-service ships. Per the log discipline in CLAUDE.md that is exactly the routine
+// high-frequency event that must not be logged at all — a warn here would bury real signal
+// fleet-wide. Any OTHER failure is a genuine anomaly and still warns.
+const EXPECTED_NO_ARBITRATION_REASON = "authorized_goals_unavailable";
+
+/**
+ * Ask features-service to elect the goal (and its best workflow) for this brand.
+ *
+ * Returns null when nothing could be elected — the brand authorizes no set yet, every
+ * authorized goal is unrankable, or features-service is unreachable. The caller then paces on
+ * the campaign's own goal or the brand's goal, i.e. exactly the pre-arbitration behaviour: a
+ * selection optimization must never block a campaign from running.
+ */
+export async function fetchGoalArbitration({
+  featureSlug,
+  brandId,
+  identity,
+}: {
+  featureSlug: string;
+  brandId: string;
+  identity: DownstreamIdentity;
+}): Promise<GoalArbitration | null> {
+  const baseUrl = process.env.FEATURES_SERVICE_URL;
+  const apiKey = process.env.FEATURES_SERVICE_API_KEY;
+  if (!baseUrl || !apiKey) {
+    throw new Error("[campaign-service] FEATURES_SERVICE_URL or FEATURES_SERVICE_API_KEY not configured");
+  }
+
+  const url = new URL(`${baseUrl.replace(/\/$/, "")}/features/${encodeURIComponent(featureSlug)}/goal-arbitration`);
+  url.searchParams.set("brandId", brandId);
+
+  const res = await fetch(url, { method: "GET", headers: buildServiceHeaders(apiKey, identity) });
+  if (!res.ok) {
+    const body = await res.text();
+    if (body.includes(EXPECTED_NO_ARBITRATION_REASON)) return null;
+    throw new Error(`[campaign-service] FeatureService goal-arbitration failed (${res.status}): ${body}`);
+  }
+
+  const body = await res.json() as RawGoalArbitrationResponse;
+  // "unrankable" is a real 200 answer, not an error: the brand authorizes an empty set, or every
+  // goal it authorizes has no defined return. Nothing to elect → the caller keeps its own goal.
+  if (body.arbitration?.status !== "resolved") return null;
+
+  const goal = body.arbitration.goal;
+  const workflowSlug = body.workflow?.workflowDynastySlug;
+  if (!goal || !workflowSlug) {
+    throw new Error(
+      "[campaign-service] FeatureService goal-arbitration returned status=resolved without a goal or workflow",
+    );
+  }
+
+  return { goal, workflowSlug, rows: normalizeProjectionRows(body.rows ?? []) };
 }
 
 // Per-run WORKFLOW selection: GREEDY — pick the workflow with the cheapest
@@ -311,6 +402,15 @@ export async function resolveWorkflowSlugForTrigger(args: {
   // Rotation is feature-scoped: non-rotating features keep their configured workflow.
   if (!isWorkflowRotationEnabled(featureSlug)) return fallbackSlug;
   try {
+    // A campaign that states its OWN goal is a manual override and is NOT arbitrated — the
+    // customer picked that goal on purpose. Arbitration only fills the inherit case.
+    if (!goalOverride) {
+      const arbitration = await fetchGoalArbitration({ featureSlug, brandId: primaryBrandId, identity });
+      // The elected goal already determined this workflow (features-service ranks the goal's
+      // workflows on the same cost-per-outcome our greedy uses), so there is nothing left to
+      // pick here. Null → no arbitration for this brand yet, fall through to the brand goal.
+      if (arbitration) return arbitration.workflowSlug;
+    }
     const ctx = await fetchBrandRuntimeContext(primaryBrandId, identity);
     const goal: RuntimeGoal = goalOverride ?? ctx.currentGoal;
     const rows = await fetchWorkflowProjectionRows({

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -14,8 +14,10 @@ import { markAudienceExhausted, getFreshExhaustedAudienceIds } from "../lib/audi
 import { maybeSendExtendAudienceEmail } from "../lib/transactional-email.js";
 import {
   fetchWorkflowProjectionRows,
+  fetchGoalArbitration,
   selectAudienceFromProjection,
   hasServeableAudienceInProjection,
+  type ProjectionRow,
 } from "../lib/features-workflow-projection-client.js";
 import type { DownstreamIdentity } from "../lib/downstream-headers.js";
 
@@ -220,7 +222,8 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
     // single place the runtime goal is resolved, so display (campaign reads expose the same
     // raw campaign.goal) and runtime agree. Whatever the value is, it is forwarded verbatim —
     // this service does not own the goal vocabulary and never rewrites it.
-    const runtimeGoal: RuntimeGoal = campaign.goal ?? brandRuntimeContext.currentGoal;
+    // Arbitration may replace this below when the campaign states no own goal.
+    let runtimeGoal: RuntimeGoal = campaign.goal ?? brandRuntimeContext.currentGoal;
     // Cost-aware Thompson sampling over the chosen workflow's audiences, straight from
     // features-service /workflow-projection — which enumerates EVERY active audience of the
     // brand per dynasty (floored to brand/crossOrg when an audience never ran the workflow),
@@ -235,7 +238,27 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
     const excludedAudienceIds = await getFreshExhaustedAudienceIds(campaignId);
     let audienceId: string | null = null;
     try {
-      const projectionRows = await fetchWorkflowProjectionRows({
+      // The GOAL is arbitrated by features-service, on the same evidence the trigger used and
+      // by the same deterministic rule, so both legs land on the same goal without threading
+      // anything through the DAG. Only when the campaign states no own goal — an explicit
+      // per-campaign goal is a manual override and is never arbitrated away.
+      let projectionRows: ProjectionRow[] | null = null;
+      if (!campaign.goal) {
+        const arbitration = await fetchGoalArbitration({
+          featureSlug: featureSlug!,
+          brandId: primaryBrandId,
+          identity: preRunIdentity,
+        });
+        if (arbitration) {
+          runtimeGoal = arbitration.goal;
+          // Normally the elected workflow IS the one now running (the trigger elected it from
+          // the same shared snapshot). If that snapshot rolled in between, the rows we were
+          // handed describe a workflow that is NOT executing — re-read the rows for the one
+          // that is, on the elected goal, rather than picking an audience for the wrong DAG.
+          if (arbitration.workflowSlug === workflowSlug) projectionRows = arbitration.rows;
+        }
+      }
+      projectionRows ??= await fetchWorkflowProjectionRows({
         featureSlug: featureSlug!,
         brandId: primaryBrandId,
         goal: runtimeGoal,
@@ -332,6 +355,13 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
  *
  * Throws on a features/brand-service error so the caller can fail SAFE (never stop on an
  * infra hiccup — a false stop is the bug this whole change fixes).
+ *
+ * Deliberately does NOT arbitrate the goal, unlike /start-run. Audience MEMBERSHIP is
+ * goal-independent — features-service enumerates every active audience of the brand per dynasty
+ * whatever the goal, and the goal only changes the cost metric attached to each row — so asking
+ * on the brand goal returns the same audience set. If that ever stopped holding, this guard
+ * would see a SUPERSET of what the picker considers, which is the safe direction for a
+ * fail-safe stop condition: it can only keep a campaign alive, never stop one wrongly.
  */
 async function hasServeableAudience(
   campaign: typeof campaigns.$inferSelect,

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -9,6 +9,7 @@ const {
   mockGateChecks,
   mockFetchBrandRuntimeContext,
   mockFetchCandidates,
+  mockFetchArbitration,
 } = vi.hoisted(() => ({
   mockCreateRun: vi.fn(),
   mockUpdateRun: vi.fn(),
@@ -17,6 +18,7 @@ const {
   mockGateChecks: vi.fn(),
   mockFetchBrandRuntimeContext: vi.fn(),
   mockFetchCandidates: vi.fn(),
+  mockFetchArbitration: vi.fn(),
 }));
 
 vi.mock("@distribute/runs-client", () => ({
@@ -47,6 +49,7 @@ vi.mock("../../src/lib/features-workflow-projection-client.js", async (importOri
   return {
     ...original, // keep the real pure selectAudienceFromProjection / hasServeableAudienceInProjection
     fetchWorkflowProjectionRows: mockFetchCandidates,
+    fetchGoalArbitration: mockFetchArbitration,
   };
 });
 
@@ -125,6 +128,9 @@ describe("Pipeline routes", () => {
       brandProfile: { ...defaultBrandProfile, brandId: brandIds[0] },
     });
     mockFetchCandidates.mockResolvedValue(defaultRows);
+    // No arbitration by default: brand-service has not declared an authorized goal set, so every
+    // existing expectation keeps the pre-arbitration behaviour (campaign goal, else brand goal).
+    mockFetchArbitration.mockResolvedValue(null);
   });
 
   afterAll(async () => {
@@ -538,6 +544,89 @@ describe("Pipeline routes", () => {
       expect(mockFetchCandidates).toHaveBeenCalledWith(
         expect.objectContaining({ goal: "positiveReply" }),
       );
+    });
+
+    // === Goal arbitration: features-service elects the goal, we do not deduce it ===
+
+    it("should use the ARBITRATED goal's rows when its workflow is the one running", async () => {
+      mockFetchArbitration.mockResolvedValueOnce({
+        goal: "formSubmission",
+        workflowSlug: DEFAULT_WORKFLOW_SLUG,
+        rows: [projectionRow("aud-arbitrated")],
+      });
+      const campaign = await insertTestCampaign(orgId, { brandIds });
+
+      const res = await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      // One answer carried both the goal and the rows → no second projection call.
+      expect(mockFetchCandidates).not.toHaveBeenCalled();
+      expect(res.body.audienceId).toBe("aud-arbitrated");
+    });
+
+    it("should keep the arbitrated GOAL but re-read rows when the elected workflow is not the one running", async () => {
+      // The shared evidence snapshot rolled between the trigger and now, so the elected workflow
+      // is no longer the DAG that is executing. Picking an audience from those rows would pick
+      // for the wrong workflow.
+      mockFetchArbitration.mockResolvedValueOnce({
+        goal: "formSubmission",
+        workflowSlug: "some-other-dynasty",
+        rows: [projectionRow("aud-stale", "some-other-dynasty")],
+      });
+      const campaign = await insertTestCampaign(orgId, { brandIds });
+
+      const res = await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      expect(mockFetchCandidates).toHaveBeenCalledWith(
+        expect.objectContaining({ goal: "formSubmission" }),
+      );
+      expect(res.body.audienceId).toBe(DEFAULT_AUDIENCE_ID);
+    });
+
+    it("should NOT arbitrate a campaign that states its own goal", async () => {
+      const campaign = await insertTestCampaign(orgId, { brandIds, goal: "websiteVisit" });
+
+      await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      expect(mockFetchArbitration).not.toHaveBeenCalled();
+      expect(mockFetchCandidates).toHaveBeenCalledWith(
+        expect.objectContaining({ goal: "websiteVisit" }),
+      );
+    });
+
+    it("should fall back to the brand goal when nothing is arbitrated", async () => {
+      const campaign = await insertTestCampaign(orgId, { brandIds });
+
+      await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      expect(mockFetchArbitration).toHaveBeenCalled();
+      expect(mockFetchCandidates).toHaveBeenCalledWith(
+        expect.objectContaining({ goal: "signup" }),
+      );
+    });
+
+    it("should still start the run when arbitration throws", async () => {
+      mockFetchArbitration.mockRejectedValueOnce(new Error("features-service unavailable"));
+      const campaign = await insertTestCampaign(orgId, { brandIds });
+
+      const res = await request(app)
+        .post("/start-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .expect(200);
+
+      // Fail-soft: a selection optimization never hard-fails a run.
+      expect(res.body.audienceId).toBeNull();
     });
 
     it("should HARD-restrict the audience bandit to the campaign's targeted subset", async () => {

--- a/tests/unit/goal-arbitration-client.test.ts
+++ b/tests/unit/goal-arbitration-client.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockFetchBrandRuntimeContext = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/lib/brand-runtime-client.js", () => ({
+  fetchBrandRuntimeContext: mockFetchBrandRuntimeContext,
+}));
+
+import {
+  fetchGoalArbitration,
+  resolveWorkflowSlugForTrigger,
+} from "../../src/lib/features-workflow-projection-client.js";
+import type { DownstreamIdentity } from "../../src/lib/downstream-headers.js";
+
+const ROTATING_FEATURE = "sales-cold-email-outreach";
+const BRAND_ID = "brand-1";
+const identity: DownstreamIdentity = {
+  orgId: "org-1",
+  userId: "user-1",
+  runId: "11111111-1111-4111-8111-111111111111",
+  campaignId: "camp-1",
+  brandId: BRAND_ID,
+  workflowSlug: "wf-configured",
+  featureSlug: ROTATING_FEATURE,
+};
+
+/** A features-service row in the raw (estimatesByGrain) wire shape both endpoints serve. */
+function rawRow(audienceId: string | null, slug: string, costPerOutcomeUsd: number | null = 10) {
+  return {
+    audienceId,
+    workflow: { workflowDynastySlug: slug, workflowDynastyName: slug },
+    estimatesByGrain: audienceId
+      ? {
+          audience: {
+            evidence: { spentUsd: 10, observedContacted: 100, observedClicks: 20, observedPositiveReplies: 5 },
+            resolvedOutcomeCount: 5,
+          },
+        }
+      : undefined,
+    resolved: { grain: audienceId ? "audience" : "brand", costPerOutcomeUsd },
+  };
+}
+
+function jsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+function errorResponse(status: number, body: unknown) {
+  return { ok: false, status, json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+/** Route the mocked fetch by path so one test can serve both endpoints. */
+function routeFetch(handlers: { arbitration?: unknown; projection?: unknown }) {
+  return vi.fn(async (url: URL | string) => {
+    const href = url.toString();
+    if (href.includes("/goal-arbitration")) {
+      if (!handlers.arbitration) throw new Error("unexpected goal-arbitration call");
+      return handlers.arbitration;
+    }
+    if (href.includes("/workflow-projection")) {
+      if (!handlers.projection) throw new Error("unexpected workflow-projection call");
+      return handlers.projection;
+    }
+    throw new Error(`unexpected fetch: ${href}`);
+  });
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  process.env.FEATURES_SERVICE_URL = "http://features-service";
+  process.env.FEATURES_SERVICE_API_KEY = "test-key";
+  mockFetchBrandRuntimeContext.mockResolvedValue({ brand: {}, currentGoal: "signup", brandProfile: null });
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describe("fetchGoalArbitration", () => {
+  it("returns the elected goal, its workflow and the pairing's rows", async () => {
+    vi.stubGlobal(
+      "fetch",
+      routeFetch({
+        arbitration: jsonResponse({
+          arbitration: { status: "resolved", goal: "positiveReply" },
+          workflow: { workflowDynastySlug: "wf-elected" },
+          rows: [rawRow(null, "wf-elected"), rawRow("aud-1", "wf-elected")],
+        }),
+      }),
+    );
+
+    const result = await fetchGoalArbitration({ featureSlug: ROTATING_FEATURE, brandId: BRAND_ID, identity });
+
+    expect(result).not.toBeNull();
+    expect(result!.goal).toBe("positiveReply");
+    expect(result!.workflowSlug).toBe("wf-elected");
+    // Rows arrive normalised exactly like /workflow-projection's, so the audience bandit
+    // cannot behave differently depending on which endpoint fed it.
+    expect(result!.rows).toHaveLength(2);
+    expect(result!.rows[1].audienceEvidence).toMatchObject({ observedContacted: 100, resolvedOutcomeCount: 5 });
+    expect(result!.rows[0].audienceEvidence).toBeNull();
+  });
+
+  it("returns null when nothing could be ranked (a real 200 answer, not an error)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      routeFetch({
+        arbitration: jsonResponse({
+          arbitration: { status: "unrankable", goal: null, reason: "no_rankable_goal" },
+          workflow: null,
+          rows: [],
+        }),
+      }),
+    );
+
+    await expect(
+      fetchGoalArbitration({ featureSlug: ROTATING_FEATURE, brandId: BRAND_ID, identity }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null WITHOUT throwing when the brand has no authorized goal set yet", async () => {
+    vi.stubGlobal(
+      "fetch",
+      routeFetch({
+        arbitration: errorResponse(502, {
+          error: "brand-service states no authorized goal set for this brand",
+          reason: "authorized_goals_unavailable",
+        }),
+      }),
+    );
+
+    await expect(
+      fetchGoalArbitration({ featureSlug: ROTATING_FEATURE, brandId: BRAND_ID, identity }),
+    ).resolves.toBeNull();
+  });
+
+  it("throws on any OTHER failure — that is a real anomaly, not an expected business state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      routeFetch({ arbitration: errorResponse(502, { error: "Failed to arbitrate goals" }) }),
+    );
+
+    await expect(
+      fetchGoalArbitration({ featureSlug: ROTATING_FEATURE, brandId: BRAND_ID, identity }),
+    ).rejects.toThrow(/goal-arbitration failed/);
+  });
+
+  it("throws when the producer says resolved but names no goal or workflow", async () => {
+    vi.stubGlobal(
+      "fetch",
+      routeFetch({
+        arbitration: jsonResponse({ arbitration: { status: "resolved", goal: "signup" }, workflow: null, rows: [] }),
+      }),
+    );
+
+    await expect(
+      fetchGoalArbitration({ featureSlug: ROTATING_FEATURE, brandId: BRAND_ID, identity }),
+    ).rejects.toThrow(/without a goal or workflow/);
+  });
+});
+
+describe("resolveWorkflowSlugForTrigger — goal arbitration", () => {
+  const baseArgs = {
+    featureSlug: ROTATING_FEATURE,
+    primaryBrandId: BRAND_ID,
+    identity,
+    fallbackSlug: "wf-configured",
+  };
+
+  it("launches the elected goal's workflow", async () => {
+    vi.stubGlobal(
+      "fetch",
+      routeFetch({
+        arbitration: jsonResponse({
+          arbitration: { status: "resolved", goal: "positiveReply" },
+          workflow: { workflowDynastySlug: "wf-elected" },
+          rows: [rawRow(null, "wf-elected")],
+        }),
+      }),
+    );
+
+    await expect(resolveWorkflowSlugForTrigger(baseArgs)).resolves.toBe("wf-elected");
+    // The elected goal already ranked its own workflows — no second projection call.
+    expect(mockFetchBrandRuntimeContext).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the brand goal's greedy pick when nothing is arbitrated", async () => {
+    vi.stubGlobal(
+      "fetch",
+      routeFetch({
+        arbitration: errorResponse(502, { reason: "authorized_goals_unavailable" }),
+        projection: jsonResponse({ rows: [rawRow(null, "wf-greedy", 3), rawRow(null, "wf-pricey", 30)] }),
+      }),
+    );
+
+    await expect(resolveWorkflowSlugForTrigger(baseArgs)).resolves.toBe("wf-greedy");
+    expect(mockFetchBrandRuntimeContext).toHaveBeenCalled();
+  });
+
+  it("does NOT warn on the no-authorized-set path — it fires every tick for every campaign", async () => {
+    vi.stubGlobal(
+      "fetch",
+      routeFetch({
+        arbitration: errorResponse(502, { reason: "authorized_goals_unavailable" }),
+        projection: jsonResponse({ rows: [rawRow(null, "wf-greedy", 3)] }),
+      }),
+    );
+
+    await resolveWorkflowSlugForTrigger(baseArgs);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("DOES warn when arbitration fails for any other reason", async () => {
+    vi.stubGlobal("fetch", routeFetch({ arbitration: errorResponse(500, { error: "boom" }) }));
+
+    await expect(resolveWorkflowSlugForTrigger(baseArgs)).resolves.toBe("wf-configured");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("never arbitrates a campaign that states its OWN goal — that is a manual override", async () => {
+    vi.stubGlobal(
+      "fetch",
+      routeFetch({ projection: jsonResponse({ rows: [rawRow(null, "wf-own-goal", 3)] }) }),
+    );
+
+    await expect(
+      resolveWorkflowSlugForTrigger({ ...baseArgs, goalOverride: "websiteVisit" }),
+    ).resolves.toBe("wf-own-goal");
+    // routeFetch throws on an unexpected goal-arbitration call, so reaching here proves none was made.
+  });
+
+  it("does not call features-service at all for a non-rotating feature", async () => {
+    const fetchMock = routeFetch({});
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      resolveWorkflowSlugForTrigger({ ...baseArgs, featureSlug: "pr-expert-quote-outreach" }),
+    ).resolves.toBe("wf-configured");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

campaign-service used to **tell** features-service which goal to rank under — it forwarded the brand's single configured goal — so the goal leg of the selection chain was the one lever nobody arbitrated.

features-service [#703](https://github.com/shamanic-technologies/features-service/pull/703) now elects it. `GET /features/:slug/goal-arbitration?brandId=` answers, in one call: which of the goals the brand **authorizes** returns the most per dollar, that goal's best workflow, and the pairing's audience rows.

## Change

Three levers, and we deduce none of them:

```
TRIGGER   (scheduler)  : elected goal → its elected workflow           ← greedy, features-owned
START-RUN (internal.ts): elected goal → Thompson over the pairing rows ← explore, ours
```

**Why the ranking is not ours.** A cost-per-outcome is denominated in each goal's OWN outcome — a click, a reply, a booked meeting — so comparing two goals' cost-per-outcome compares two different things. Only features-service can normalise each goal through its own funnel to the same terminal unit. Doing it here would mean re-deriving their economics, and it would cost one request per goal.

**Both legs elect the same goal with nothing threaded through the DAG.** The election is deterministic (argmax return-per-dollar, canonical tie-break) and both calls hit the same shared evidence snapshot, so the trigger and `/start-run` converge on their own. The elected goal is **not persisted** on the campaign row — it is a per-run decision, not config.

**Rows are consumed unchanged.** features-service serves them in the same `ProjectionRow` shape as `/workflow-projection` on purpose, so the audience bandit parses them as-is. `normalizeProjectionRows` is now shared by both fetchers so the bandit cannot behave differently depending on which endpoint fed it.

**Snapshot drift.** If the elected workflow is not the DAG actually running, keep the elected **goal** but re-read the rows for the workflow that **is**. Never Thompson-pick an audience from another workflow's rows.

**A campaign that states its own `campaign.goal` is never arbitrated** — that is a manual override the customer set on purpose. Arbitration only fills the inherit (NULL) case.

## Fail-soft, and silent on the expected path

Any arbitration failure falls back to `campaign.goal ?? brand.currentGoal` plus the existing workflow greedy — exactly the pre-arbitration behaviour. A selection optimization must never block a run.

features-service 502s with `reason: "authorized_goals_unavailable"` for as long as brand-service has not declared the brand's authorized set. That is **their** fail-loud (they refuse to substitute a default set), but for **us** it is an expected business state that fires on **every tick for every campaign of every client** — so per the repo's log discipline it is **not logged at all**. A warn there would bury real signal fleet-wide. Any *other* failure still warns.

## Deployment

**Dormant until brand-service ships.** Every brand currently takes the fallback path, which is byte-for-byte today's behaviour. No env vars, no migration, no API surface change (`openapi.json` unchanged).

⚠️ **Deployment ordering** — this is additive and dormant, not blocked: nothing calls the new path with a resolved answer until brand-service declares an authorized goal set ([brand-service #393](https://github.com/shamanic-technologies/brand-service/pull/393), in flight). Merging early is safe and lets the consumer be live the moment the producer chain completes.

## Tests

391 pass (27 files), `tsc` clean, build clean.

**New unit suite** (`tests/unit/goal-arbitration-client.test.ts`, 11 tests): elected goal + workflow + normalised rows; `unrankable` is a real 200 answer not an error; the no-authorized-set 502 returns null **without throwing**; any other failure throws; `resolved` without a goal/workflow throws; the trigger launches the elected workflow and makes no second projection call; the fallback path; **no warn** on the no-authorized-set path; **warn** on a real anomaly; own-goal is never arbitrated; non-rotating features never call features-service.

**New integration tests** (5): arbitrated rows used when the elected workflow is the one running (and no second projection call); goal kept but rows re-read on drift; own-goal campaigns skip arbitration; fallback to the brand goal when nothing is arbitrated; the run still starts when arbitration throws.

## Still to do (T4b)

Gated on brand-service declaring the authorized set: `findOrCreate` a campaign per `(org, brand, feature, goal)` so the elected goal selects **which** campaign runs — which moves the scheduler's claim grain from campaign to brand. Three known snags, documented in CLAUDE.md: `brandIds` is a `text[]` (no unique index can span it), `uniq_campaigns_org_name` forces a deterministic generated name, and the lazy create must be `INSERT ... ON CONFLICT DO NOTHING` then `SELECT`.

Follows #299 (the goal became an opaque string, which is what let a campaign pace on the goals this arbitration can elect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
