### PR TITLE
feat(brand-reads): name the org whose per-brand configuration we want

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,30 @@ Forward the value VERBATIM. Do not map, alias, collapse or "normalise" a goal on
 
 (Set 2026-07-31, T1 of the per-run goal arbitration.)
 
+## Per-brand configuration is per (org, brand) — every brand-service read NAMES the org
+
+A `brands` row is a shared global identity: any org claiming the same domain gets the same
+brand id. Everything a customer configures on top of it — the goal, the confirmed profile
+fields, the sales economics, the funnels, the click destination — belongs to the **(org,
+brand)** pair, not to the brand. So "the runtime context of brand X" has no single answer.
+
+brand-service resolves the org from **`x-org-id`**: that header when sent, else the single
+claiming org when exactly one exists, else `400 ORG_REQUIRED`. 21 production brands are
+claimed by more than one org.
+
+`fetchBrandRuntimeContext` (`src/lib/brand-runtime-client.ts`) — this service's ONLY
+brand-service read — therefore treats `identity.orgId` as **load-bearing, not tracking**,
+and throws before the call when it is missing rather than let brand-service pick an org for
+us. The org is always the CAMPAIGN's org (`req.orgId` / `campaign.orgId`) on all three legs:
+`/start-run`, the `/end-run` stop-guard, and the scheduler's trigger. A stand-in org would be
+the cross-org read this scoping closes. Pinned by `tests/unit/brand-runtime-client.test.ts`
+(header on the wire) plus per-leg identity assertions in the scheduler + internal-routes
+tests, so the header cannot be dropped silently by a refactor of the shared header builder.
+
+Billing's `/internal/brands/:id/daily-budget` reads (`gate-check.ts`,
+`transactional-email.ts`) are a different service and already carry `x-org-id` too.
+(Set 2026-08-01.)
+
 ## The GOAL is arbitrated by features-service — three levers, and we deduce none of them
 
 `GET /features/:slug/goal-arbitration?brandId=` answers, in ONE call: which of the goals the brand AUTHORIZES returns the most per dollar, that goal's best workflow, and the pairing's audience rows. `fetchGoalArbitration` consumes it and the two decision points take their share:

--- a/src/lib/brand-runtime-client.ts
+++ b/src/lib/brand-runtime-client.ts
@@ -28,6 +28,21 @@ export interface BrandRuntimeContext {
   brandProfile: BrandProfile | null;
 }
 
+/**
+ * Read the runtime context brand-service holds for ONE org's view of a brand.
+ *
+ * The brand row is a shared global identity — several orgs legitimately claim the same
+ * domain — but everything a customer configures on top of it (the goal, the confirmed
+ * profile fields) belongs to the (org, brand) pair. So "the runtime context of brand X"
+ * has no single answer, and brand-service resolves the org from `x-org-id`: it will only
+ * fall back to the sole claiming org when exactly one exists, and 400s (`ORG_REQUIRED`)
+ * rather than guess for a brand several orgs claim.
+ *
+ * `identity.orgId` is therefore load-bearing on this call, not merely tracking: it names
+ * WHOSE configuration we want. It is asserted below rather than left to
+ * `buildServiceHeaders`, so dropping it can never silently degrade into brand-service
+ * picking an org for us.
+ */
 export async function fetchBrandRuntimeContext(
   brandId: string,
   identity: DownstreamIdentity,
@@ -36,6 +51,15 @@ export async function fetchBrandRuntimeContext(
   const apiKey = process.env.BRAND_SERVICE_API_KEY;
   if (!baseUrl || !apiKey) {
     throw new Error("[campaign-service] BRAND_SERVICE_URL or BRAND_SERVICE_API_KEY not configured");
+  }
+  // Fail loud rather than let the call go out org-less. A stand-in org would be the very
+  // cross-org read brand-service is closing, and an org-less call is only answerable for a
+  // brand exactly one org claims — which is a silent, data-dependent behaviour change.
+  if (!identity.orgId || identity.orgId.trim() === "") {
+    throw new Error(
+      `[campaign-service] BrandService runtime-context for brand ${brandId} requires an org: ` +
+      "per-brand configuration belongs to an (org, brand) pair and this service must name the org.",
+    );
   }
 
   const url = `${baseUrl.replace(/\/$/, "")}/internal/brands/${encodeURIComponent(brandId)}/runtime-context`;

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -1196,6 +1196,13 @@ describe("Pipeline routes", () => {
       });
       expect(updated!.status).toBe("ongoing");
       expect(updated!.nextRunAt).not.toBeNull();
+
+      // The stop-guard's brand read names the campaign's org: per-brand configuration is
+      // per (org, brand), so a brand several orgs claim is only answerable with an org.
+      expect(mockFetchBrandRuntimeContext).toHaveBeenCalledWith(
+        brandIds[0],
+        expect.objectContaining({ orgId }),
+      );
     });
 
     it("stopCampaign=true auto-stops the campaign ONLY when no serveable audience remains (all exhausted)", async () => {

--- a/tests/unit/brand-runtime-client.test.ts
+++ b/tests/unit/brand-runtime-client.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchBrandRuntimeContext } from "../../src/lib/brand-runtime-client.js";
+import type { DownstreamIdentity } from "../../src/lib/downstream-headers.js";
+
+const BRAND_ID = "11111111-1111-1111-1111-111111111111";
+
+function identity(overrides: Partial<DownstreamIdentity> = {}): DownstreamIdentity {
+  return {
+    orgId: "org-1",
+    userId: "user-1",
+    runId: "run-1",
+    campaignId: "camp-1",
+    brandId: BRAND_ID,
+    workflowSlug: "sales-email-cold-outreach",
+    featureSlug: "sales-cold-email-outreach",
+    ...overrides,
+  };
+}
+
+const runtimeContext = {
+  brand: { id: BRAND_ID },
+  currentGoal: "meetingBooked",
+  brandProfile: null,
+};
+
+/**
+ * brand-service resolves per-brand configuration per (org, brand): several orgs claim the
+ * same domain and each configures it independently. `x-org-id` is what names whose
+ * configuration this read wants — without it brand-service either guesses (the leak it is
+ * closing) or 400s. These tests pin that the header is on the wire so it cannot be dropped
+ * silently by a future refactor of the shared header builder.
+ */
+describe("fetchBrandRuntimeContext org scoping", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.BRAND_SERVICE_URL = "https://brand.test.local";
+    process.env.BRAND_SERVICE_API_KEY = "test-brand-key";
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => runtimeContext,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("sends the org whose configuration is wanted as x-org-id", async () => {
+    await fetchBrandRuntimeContext(BRAND_ID, identity({ orgId: "org-abc" }));
+
+    const [url, opts] = (globalThis.fetch as any).mock.calls[0];
+    expect(url).toBe(`https://brand.test.local/internal/brands/${BRAND_ID}/runtime-context`);
+    expect(opts.headers["x-org-id"]).toBe("org-abc");
+    expect(opts.headers["x-brand-id"]).toBe(BRAND_ID);
+    expect(opts.headers["x-api-key"]).toBe("test-brand-key");
+  });
+
+  it("resolves a brand claimed by several orgs to the org it named", async () => {
+    // Same brand, two campaigns owned by different orgs: each read must carry its own org
+    // so brand-service answers with that org's configuration rather than refusing.
+    await fetchBrandRuntimeContext(BRAND_ID, identity({ orgId: "org-one" }));
+    await fetchBrandRuntimeContext(BRAND_ID, identity({ orgId: "org-two" }));
+
+    const calls = (globalThis.fetch as any).mock.calls;
+    expect(calls[0][1].headers["x-org-id"]).toBe("org-one");
+    expect(calls[1][1].headers["x-org-id"]).toBe("org-two");
+  });
+
+  it.each([["", "empty"], ["   ", "blank"], [undefined, "absent"]])(
+    "refuses to read org-less rather than let brand-service pick an org (%s org)",
+    async (orgId) => {
+      await expect(
+        fetchBrandRuntimeContext(BRAND_ID, identity({ orgId: orgId as string })),
+      ).rejects.toThrow(/requires an org/);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it("surfaces brand-service's ORG_REQUIRED refusal instead of swallowing it", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ code: "ORG_REQUIRED", error: "claimed by more than one org" }),
+    });
+
+    await expect(fetchBrandRuntimeContext(BRAND_ID, identity())).rejects.toThrow(/ORG_REQUIRED/);
+  });
+});

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -130,6 +130,14 @@ describe("Scheduler - reRunDueCampaigns", () => {
         featureSlug: "sales-cold-email-v1",
       }),
     );
+    // The trigger leg reads brand-service (goal arbitration / runtime context) through this
+    // identity. Per-brand configuration is per (org, brand), so the campaign's org must ride
+    // along — a brand several orgs claim has no single answer without it.
+    expect(mockResolveWorkflowSlug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identity: expect.objectContaining({ orgId: "org-ext-1" }),
+      }),
+    );
   });
 
   it("should NOT create a run — let the workflow's start-run do it", async () => {


### PR DESCRIPTION
## Why

A `brands` row is a shared global identity — any org claiming the same domain gets the same brand id. Everything a customer configures on top of it (the goal, the confirmed profile fields, sales economics, funnels, click destination) belongs to the **(org, brand)** pair, not to the brand. brand-service is closing the cross-org read/write path that created ([brand-service#423](https://github.com/shamanic-technologies/brand-service/pull/423)): internal reads resolve the org from `x-org-id`, fall back to the single claiming org only when exactly one claims the brand, and return `400 ORG_REQUIRED` rather than guess for a brand several orgs claim. **21 production brands are claimed by more than one org**, 8 of them carrying ongoing campaigns.

## What was actually true here

campaign-service has exactly one brand-service read — `fetchBrandRuntimeContext` → `GET /internal/brands/:id/runtime-context`. It **already sent `x-org-id`**, implicitly, because it goes through the shared tracking-header builder (`buildServiceHeaders`), and the org it sends is the campaign's own on all three legs that reach it: `/start-run`, the `/end-run` stop-guard, and the scheduler's trigger. So brand-service's ship does not break those 8 campaigns.

That is not enough to close the ticket. Nothing said the header was **load-bearing on that call** rather than tracking, nothing pinned it, and dropping it would not have failed loudly — it would have degraded into brand-service picking an org for us on single-claim brands and 400ing on multi-claim ones. A data-dependent behaviour change, invisible to every test in the repo.

## Change

- `fetchBrandRuntimeContext` asserts the org **before** the call and throws when it is absent or blank, instead of letting the read go out org-less. A stand-in org would be the very cross-org read this scoping closes, so the no-go is enforced in code, not by convention.
- The doc comment states why the org names *whose* configuration is wanted, and what brand-service does without it.
- `CLAUDE.md` records the (org, brand) grain, the resolution rule, and the three legs.

Billing's `/internal/brands/:id/daily-budget` reads (`gate-check.ts`, `transactional-email.ts`) are a different service and already carry `x-org-id`; they are unaffected.

## Regression coverage

New `tests/unit/brand-runtime-client.test.ts`:
- `x-org-id` is on the wire, equal to the org the caller named
- two orgs reading the **same** brand each carry their own org (the multi-claim case brand-service now answers instead of refusing)
- absent / empty / blank org throws and **no fetch is made**
- brand-service's `ORG_REQUIRED` refusal surfaces instead of being swallowed

Plus per-leg identity assertions: the scheduler's trigger (`tests/unit/scheduler.test.ts`) and the `/end-run` stop-guard (`tests/integration/internal-routes.test.ts`) each assert the campaign's org rides the identity. `/start-run` already had one.

## Verification

- 401/401 tests green (218 unit, 183 integration against a local `campaign_test`)
- `tsc --noEmit` clean, `pnpm run build` clean, `openapi.json` unchanged (no route surface change)

No behaviour change for a brand exactly one org claims. No ordering constraint against brand-service: the deployed brand-service ignores this header on these reads, so this is a no-op until #423 lands and a fix afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
