### PR TITLE
feat(funnel-budgets): work every funded funnel, each paced on its own ceiling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,43 @@ START-RUN (internal.ts): elected goal → Thompson over the pairing rows ← exp
 
 `hasServeableAudience` (the `/end-run` stop-guard) deliberately does NOT arbitrate: audience membership is goal-independent (every active audience is enumerated per dynasty whatever the goal), so it returns the same set, and if that ever stopped holding the guard would see a SUPERSET — the safe direction for a fail-safe stop.
 
-STILL TO DO (T4b, gated on brand-service declaring the authorized set): `findOrCreate` a campaign per `(org, brand, feature, goal)` so the elected goal selects WHICH campaign runs, which moves the scheduler's claim grain from campaign to brand. Three known snags: `brandIds` is a `text[]` (no unique index can span it), `uniq_campaigns_org_name` forces a deterministic generated name, and the lazy create must be `INSERT ... ON CONFLICT DO NOTHING` then `SELECT`. (Set 2026-07-31, T4a.)
+**Arbitration now only decides for a brand with ONE pot.** A customer who funds each sales funnel separately has decided which funnels run — see the per-funnel section below. A funnel campaign carries the funnel's own goal, so it is a stated-goal campaign and is never arbitrated. (Set 2026-07-31, T4a; scoped 2026-08-02.)
+
+## Per-funnel funding: every funded funnel runs, each paced on its OWN ceiling
+
+billing-service lets a customer fund each of a brand's SALES FUNNELS separately. Its brand-level
+`GET /internal/brands/:id/daily-budget` still answers the SUM, so nothing reading the brand total
+changes — but "which funnel is best by ROI, run that one" is no longer the right question. Both
+funded funnels get worked, each spending up to its own ceiling and stopping there.
+
+- **One campaign per funded funnel** (`campaigns.funnel_key`, migration 0041). The cost ledger is
+  already keyed on campaignId, so a funnel's spend today IS its campaign's spend today — no new
+  attribution dimension. Provisioned by the scheduler (`src/lib/funnel-campaigns.ts`) from
+  billing's `GET /internal/brands/:id/funnel-budgets` ∩ brand-service's
+  `GET /internal/brands/:id/sales-funnels` (which carries the goal each funnel optimizes for,
+  forwarded verbatim onto `campaigns.goal`). A funnel billing funds but brand-service does not
+  declare ACTIVE is never provisioned.
+- **The gate paces on that funnel's own ceiling** (`gate-check.ts`, block a2), fail-CLOSED like
+  the brand ceiling. Precedence: campaign's own `dailyBudgetCents` → `funnelKey` ceiling → brand
+  daily budget. A funnel funded at ZERO, or absent from billing, blocks (`Funnel not funded`) —
+  it NEVER falls back to the brand total, which would let it spend another funnel's money.
+- **Serial, for now: one run in flight per BRAND** (`hasLiveRunForBrand` in funnel-campaigns.ts).
+  Running funnels concurrently needs an audit of lead de-duplication and of sending-account load
+  that nobody has done. Deleting that one block is what unlocks parallelism; nothing else has to
+  be undone.
+- **The turn goes to the lowest spent-today ÷ own-ceiling ratio** (`selectLowestFillRatio`),
+  never a fixed order and never "the primary first". A fixed order starves whatever sits last —
+  if the first funnel can absorb the whole day the others never run, and that shows up in no log
+  at all. A funnel at its ceiling yields with no special case (ratio ≥ 1 → not a candidate); all
+  funnels full → parked until the day rollover.
+- **Fail-SOFT in the scheduler, fail-CLOSED in the gate.** An unreadable budget/funnel set leaves
+  the brand on today's behaviour (turn-taking is an optimization); the gate is what refuses to
+  spend past a cap it cannot read.
+- A brand that never set per-funnel ceilings grows no funnel campaigns and behaves exactly as
+  before. The pre-funnel (`funnel_key` NULL) campaign is SUPERSEDED — not stopped — while funded
+  funnels exist, and resumes if the customer clears them.
+- The brand-level PAUSE is untouched: the dashboard still reads and renders it.
+(Set 2026-08-02.)
 
 The per-campaign audience SUBSET (`campaigns.audience_ids`, Campaign v2) is a HARD filter on the audience bandit (`requiredAudienceIds` in `selectAudienceFromProjection`): a campaign never contacts an audience outside its targeted subset (no fallback). NULL/empty → inherit the brand's full active audience set. (The old workflow-conditioning `eligibleAudienceIds` soft-filter was REMOVED in v0.44.1 — see the single-endpoint note below.) Distinct from the singular `audienceId` column (per-campaign attribution; the per-RUN chosen audience is re-selected fresh at /start-run).
 

--- a/drizzle/0041_campaign_funnel_key.sql
+++ b/drizzle/0041_campaign_funnel_key.sql
@@ -1,0 +1,25 @@
+-- The sales funnel this campaign works, in brand-service's funnel vocabulary
+-- (reply_meeting | visit_meeting | visit_signup | visit_form).
+--
+-- A customer can now fund each of a brand's sales funnels separately (billing-service
+-- brand_funnel_budgets), so a brand's spend is no longer one pot to be won by whichever
+-- funnel features-service judged best. One campaign per funded funnel makes "how much did
+-- this funnel spend today" answerable from the cost ledger already keyed on campaignId —
+-- no new attribution dimension.
+--
+-- NULL means the campaign is not funnel-scoped: every campaign that predates per-funnel
+-- funding keeps NULL and paces exactly as it does today (its own dailyBudgetCents, else the
+-- brand-level daily budget, which billing still answers as the SUM of the per-funnel
+-- ceilings). Nothing is backfilled: a brand that never declares per-funnel ceilings never
+-- grows funnel campaigns.
+--
+-- Idempotent (IF NOT EXISTS) so a partial-apply replay is safe.
+ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "funnel_key" text;
+
+-- One campaign per (org, brand, feature, funnel) is the invariant the scheduler provisions
+-- against. brand_ids is a text[] so no unique index can span it; this partial index makes the
+-- lookup the provisioner runs every due-tick cheap without pretending to enforce uniqueness
+-- (the provisioner uses a SELECT-then-INSERT guarded by the campaigns' unique name index).
+CREATE INDEX IF NOT EXISTS "idx_campaigns_org_feature_funnel"
+  ON "campaigns" USING btree ("org_id", "feature_slug", "funnel_key")
+  WHERE "funnel_key" IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1776500000000,
       "tag": "0040_campaign_audience_exhaustion",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1776600000000,
+      "tag": "0041_campaign_funnel_key",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -116,6 +116,10 @@
             "type": "integer",
             "nullable": true
           },
+          "funnelKey": {
+            "type": "string",
+            "nullable": true
+          },
           "maxLeads": {
             "type": "integer",
             "nullable": true
@@ -176,6 +180,7 @@
           "maxBudgetMonthlyUsd",
           "maxBudgetTotalUsd",
           "dailyBudgetCents",
+          "funnelKey",
           "maxLeads",
           "startDate",
           "endDate",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -84,6 +84,22 @@ export const campaigns = pgTable(
     // against runs-service *CostInUsdCents and billing's brand dailyBudgetCents — no ×100.
     dailyBudgetCents: integer("daily_budget_cents"),
 
+    // The sales funnel this campaign works, in brand-service's funnel vocabulary
+    // (reply_meeting | visit_meeting | visit_signup | visit_form). A customer funds each of a
+    // brand's funnels separately (billing-service brand_funnel_budgets), so a funded funnel gets
+    // its OWN campaign: the cost ledger is already keyed on campaignId, which makes "how much did
+    // this funnel spend today" answerable without a new attribution dimension.
+    //
+    // NULL = not funnel-scoped. Every campaign that predates per-funnel funding keeps NULL and
+    // paces exactly as before (own dailyBudgetCents, else the brand-level daily budget — which
+    // billing still answers as the SUM of the per-funnel ceilings). A brand that never declares
+    // per-funnel ceilings never grows funnel campaigns.
+    //
+    // A funnel campaign carries the funnel's OWN goal in `goal`, which is why it is never
+    // goal-arbitrated: the customer's funding decided which funnel runs, so features-service is
+    // asked only for the best workflow and the audience evidence FOR THAT funnel's goal.
+    funnelKey: text("funnel_key"),
+
     // Volume limit (optional, total leads across all runs)
     maxLeads: integer("max_leads"),
 
@@ -106,6 +122,7 @@ export const campaigns = pgTable(
   (table) => [
     index("idx_campaigns_org").on(table.orgId),
     uniqueIndex("uniq_campaigns_org_name").on(table.orgId, table.name),
+    index("idx_campaigns_org_feature_funnel").on(table.orgId, table.featureSlug, table.funnelKey),
   ]
 );
 

--- a/src/lib/brand-sales-funnels-client.ts
+++ b/src/lib/brand-sales-funnels-client.ts
@@ -1,0 +1,80 @@
+import type { IdentityHeaders } from "@distribute/runs-client";
+import type { RuntimeGoal } from "./brand-runtime-client.js";
+
+/**
+ * One sales funnel a brand has declared it sells through, as brand-service reports it.
+ *
+ * A funnel is one chain from the first signal outreach can buy (a positive reply, or a click
+ * onto the site) down to a paid client, and it carries the GOAL that chain optimizes for. That
+ * goal is the only field this service needs: it is what a funnel campaign paces on, so
+ * features-service is asked for the best workflow and the audience evidence FOR THAT goal.
+ *
+ * The goal is forwarded verbatim, exactly like the brand's currentGoal — brand-service owns the
+ * vocabulary and features-service owns the spelling. This service never maps or narrows it.
+ */
+export interface DeclaredSalesFunnel {
+  /** reply_meeting | visit_meeting | visit_signup | visit_form. */
+  funnelKey: string;
+  active: boolean;
+  goal: RuntimeGoal;
+}
+
+/**
+ * Read the funnels a brand has declared it sells through.
+ *
+ * Contract (brand-service): GET /internal/brands/{brandId}/sales-funnels (x-api-key [+ x-org-id])
+ *   -> { funnels: [{ funnelKey, active, goal, currentGoal, ... }], declared }
+ *
+ * Returns null when the set could not be read (missing config, network error, non-2xx,
+ * unparseable payload). Callers treat that as "no funnel information this tick" and leave the
+ * brand exactly as it is — provisioning a campaign is not worth guessing a goal for.
+ *
+ * An EMPTY list is a real answer, not a failure: the org has declared nothing yet. Per
+ * brand-service's own contract we never substitute a plausible set for it.
+ *
+ * Only ACTIVE funnels are returned to the caller — a funnel the org switched off must never be
+ * worked, whatever billing still holds a ceiling for.
+ */
+export async function fetchDeclaredSalesFunnels(
+  brandId: string,
+  identity: IdentityHeaders,
+): Promise<DeclaredSalesFunnel[] | null> {
+  const url = process.env.BRAND_SERVICE_URL;
+  const apiKey = process.env.BRAND_SERVICE_API_KEY;
+  if (!url || !apiKey) return null;
+
+  const headers: Record<string, string> = {
+    "x-api-key": apiKey,
+    // Per-brand configuration belongs to the (org, brand) pair — name the org rather than let
+    // brand-service pick one for a brand several orgs claim.
+    "x-org-id": identity.orgId,
+    "x-brand-id": brandId,
+  };
+  if (identity.userId) headers["x-user-id"] = identity.userId;
+  if (identity.runId) headers["x-run-id"] = identity.runId;
+  if (identity.campaignId) headers["x-campaign-id"] = identity.campaignId;
+  if (identity.workflowSlug) headers["x-workflow-slug"] = identity.workflowSlug;
+
+  try {
+    const res = await fetch(
+      `${url.replace(/\/$/, "")}/internal/brands/${encodeURIComponent(brandId)}/sales-funnels`,
+      { headers },
+    );
+    if (!res.ok) return null;
+
+    const data = await res.json() as {
+      funnels?: Array<{ funnelKey?: string; active?: boolean; goal?: string | null }>;
+    };
+    if (!Array.isArray(data.funnels)) return null;
+
+    const funnels: DeclaredSalesFunnel[] = [];
+    for (const raw of data.funnels) {
+      if (!raw?.funnelKey || !raw.goal) continue;
+      if (raw.active === false) continue;
+      funnels.push({ funnelKey: raw.funnelKey, active: true, goal: raw.goal });
+    }
+    return funnels;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/funnel-budget-client.ts
+++ b/src/lib/funnel-budget-client.ts
@@ -1,0 +1,100 @@
+import type { IdentityHeaders } from "@distribute/runs-client";
+
+/**
+ * Per-funnel daily spend ceilings, as billing-service holds them for ONE org's view of a brand.
+ *
+ * A customer funds each sales funnel of a brand separately, so "the brand's daily budget" is no
+ * longer a single pot: it is the SUM of these ceilings, and billing keeps serving that sum on
+ * GET /internal/brands/{brandId}/daily-budget. Nothing that reads the brand total changes.
+ *
+ * Contract (billing-service): GET /internal/brands/{brandId}/funnel-budgets (x-api-key + x-org-id)
+ *   -> { brandId, dailyBudgetCents: string|null, funnels: [{ funnelKey, dailyBudgetCents, updatedAt }] }
+ *
+ * A brand that has never set per-funnel ceilings returns `funnels: []` plus its brand-level
+ * value — billing never fabricates a split, and neither do we.
+ */
+export interface FunnelBudget {
+  /** brand-service's funnel vocabulary: reply_meeting | visit_meeting | visit_signup | visit_form. */
+  funnelKey: string;
+  /** This funnel's own daily ceiling, in CENTS (directly comparable to runs *CostInUsdCents). */
+  dailyBudgetCents: number;
+}
+
+export type FunnelBudgetsRead =
+  | { ok: true; brandDailyBudgetCents: number | null; funnels: FunnelBudget[] }
+  | { ok: false };
+
+/**
+ * Read this org's per-funnel daily ceilings for a brand.
+ *
+ * Returns ok:false on missing config, network error, non-2xx or an unparseable payload. The
+ * caller decides what that means: the gate treats it as fail-CLOSED (spend control must never
+ * read an unreadable cap as "unbounded"), while the scheduler's turn-taking treats it as
+ * fail-SOFT (a selection optimization must never block a run — the gate still holds the line).
+ *
+ * `x-org-id` is load-bearing, not tracking: per-funnel funding belongs to the (org, brand) pair
+ * and billing 400s rather than guess an org for a brand several orgs claim.
+ */
+export async function fetchFunnelBudgets(
+  brandId: string,
+  identity: IdentityHeaders,
+): Promise<FunnelBudgetsRead> {
+  const url = process.env.BILLING_SERVICE_URL;
+  const apiKey = process.env.BILLING_SERVICE_API_KEY;
+  if (!url || !apiKey) return { ok: false };
+
+  const headers: Record<string, string> = {
+    "x-api-key": apiKey,
+    "x-org-id": identity.orgId,
+    "x-brand-id": brandId,
+  };
+  if (identity.userId) headers["x-user-id"] = identity.userId;
+  if (identity.runId) headers["x-run-id"] = identity.runId;
+  if (identity.campaignId) headers["x-campaign-id"] = identity.campaignId;
+  if (identity.workflowSlug) headers["x-workflow-slug"] = identity.workflowSlug;
+
+  try {
+    const res = await fetch(
+      `${url.replace(/\/$/, "")}/internal/brands/${encodeURIComponent(brandId)}/funnel-budgets`,
+      { headers },
+    );
+    if (!res.ok) return { ok: false };
+
+    const data = await res.json() as {
+      dailyBudgetCents?: string | null;
+      funnels?: Array<{ funnelKey?: string; dailyBudgetCents?: string }>;
+    };
+
+    let brandDailyBudgetCents: number | null = null;
+    if (data.dailyBudgetCents !== null && data.dailyBudgetCents !== undefined) {
+      const total = parseFloat(data.dailyBudgetCents);
+      if (!Number.isFinite(total)) return { ok: false };
+      brandDailyBudgetCents = total;
+    }
+
+    if (!Array.isArray(data.funnels)) return { ok: false };
+
+    const funnels: FunnelBudget[] = [];
+    for (const raw of data.funnels) {
+      if (!raw?.funnelKey) return { ok: false };
+      const cents = parseFloat(raw.dailyBudgetCents ?? "");
+      // An unparseable ceiling is not "no ceiling" — refuse the whole read rather than let one
+      // funnel silently pace on nothing.
+      if (!Number.isFinite(cents)) return { ok: false };
+      funnels.push({ funnelKey: raw.funnelKey, dailyBudgetCents: cents });
+    }
+
+    return { ok: true, brandDailyBudgetCents, funnels };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/**
+ * The funnels this org has actually FUNDED for the brand: a ceiling of zero is a deliberate
+ * "do not work this funnel", not a missing value, so it is filtered out here once rather than
+ * re-tested at every call site.
+ */
+export function fundedFunnels(read: Extract<FunnelBudgetsRead, { ok: true }>): FunnelBudget[] {
+  return read.funnels.filter((f) => f.dailyBudgetCents > 0);
+}

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -1,0 +1,348 @@
+import { and, arrayContains, desc, eq } from "drizzle-orm";
+import { getStatsBudget, listRuns, type IdentityHeaders } from "@distribute/runs-client";
+import { db } from "../db/index.js";
+import { campaigns } from "../db/schema.js";
+import { fetchFunnelBudgets, fundedFunnels, type FunnelBudget } from "./funnel-budget-client.js";
+import { fetchDeclaredSalesFunnels, type DeclaredSalesFunnel } from "./brand-sales-funnels-client.js";
+import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
+
+// A campaign that did not get this brand's turn re-checks on the next active tick. The turn is
+// re-ranked from scratch every tick, so this is a "wait your turn", not a backoff.
+export const FUNNEL_TURN_DEFER_MS = 60_000; // 1 min
+
+// A campaign superseded by the brand's funnel campaigns (the pre-funnel, funnelKey=NULL one) is
+// not deleted or stopped — the customer may clear their per-funnel ceilings at any moment and
+// fall back to one brand-level pot. It just re-checks lazily instead of every minute.
+export const SUPERSEDED_DEFER_MS = 15 * 60_000; // 15 min
+
+/**
+ * The campaign columns the turn planner reads. Structurally a subset of what the scheduler's
+ * claim already returns, so the planner never needs its own query.
+ */
+export interface ClaimedFunnelCampaign {
+  id: string;
+  orgId: string;
+  createdByUserId: string | null;
+  workflowSlug: string;
+  brandIds: string[] | null;
+  featureSlug: string | null;
+  funnelKey: string | null;
+}
+
+/** One funnel campaign in the running to take the brand's next turn. */
+export interface FunnelTurnCandidate {
+  campaignId: string;
+  funnelKey: string;
+  /** Committed spend today for THIS campaign — i.e. for this funnel — in cents. */
+  spentCents: number;
+  /** This funnel's own daily ceiling, in cents. Always > 0 (a zero ceiling is not funded). */
+  ceilingCents: number;
+}
+
+/**
+ * Which funded funnel goes next: the one with the lowest ratio of what it has already spent
+ * today to what it is allowed to spend today.
+ *
+ * NOT a fixed order and NOT "the primary funnel first". A fixed order starves whatever sits
+ * last — if the first funnel can absorb the whole day, the others never run, and that shows up
+ * in no log at all, only in a funnel that mysteriously never spends. Ranking on the ratio fills
+ * every funnel at the same pace RELATIVE to what it can absorb, and a funnel at its ceiling
+ * yields its turn with no special case: its ratio is >= 1, so it is simply not a candidate.
+ *
+ * Returns null when every funded funnel is at its ceiling — nothing runs until they reset.
+ * Ties break on funnelKey so the choice is deterministic rather than insertion-ordered.
+ */
+export function selectLowestFillRatio(candidates: FunnelTurnCandidate[]): string | null {
+  let bestId: string | null = null;
+  let bestRatio = Infinity;
+  let bestKey = "";
+
+  for (const c of candidates) {
+    if (!(c.ceilingCents > 0)) continue; // not funded — never run
+    const ratio = c.spentCents / c.ceilingCents;
+    if (ratio >= 1) continue; // at its ceiling: stops and yields to another funded funnel
+    if (ratio < bestRatio || (ratio === bestRatio && c.funnelKey < bestKey)) {
+      bestRatio = ratio;
+      bestKey = c.funnelKey;
+      bestId = c.campaignId;
+    }
+  }
+
+  return bestId;
+}
+
+/**
+ * Plan which of the claimed campaigns may fire this tick.
+ *
+ * Returns the campaigns that must NOT fire, each with the time it should be re-checked. A
+ * campaign absent from the map fires — so every non-sales campaign, and every brand with no
+ * per-funnel funding, is untouched and behaves exactly as it does today.
+ *
+ * Three things happen per brand, in this order:
+ *   1. Provision — every funded funnel of the brand gets its own campaign (created on the spot,
+ *      due immediately, so the next tick can claim it).
+ *   2. Serialize — at most ONE run in flight per BRAND. This is the deliberate constraint that
+ *      keeps funnels from running concurrently; removing it is what unlocks parallelism later,
+ *      and nothing else has to be undone for that. It is not a lock: the same runs-service
+ *      liveness read the per-campaign guard already uses, widened to the brand.
+ *   3. Rank — the funded funnel with the lowest spent/ceiling ratio takes the turn.
+ *
+ * Fail-SOFT throughout: any unreadable budget, funnel set or spend leaves the brand on today's
+ * behaviour rather than blocking it. The per-funnel CEILING is enforced fail-CLOSED in
+ * gate-check, which is where spend control belongs — this is turn-taking, an optimization.
+ */
+export async function planFunnelTurns(
+  claimed: ClaimedFunnelCampaign[],
+  now: Date = new Date(),
+): Promise<Map<string, Date>> {
+  const deferred = new Map<string, Date>();
+
+  // Only the sales-outreach family funds per funnel. Everything else keeps its own pacing and
+  // its own per-campaign serialization, untouched.
+  const groups = new Map<string, ClaimedFunnelCampaign[]>();
+  for (const c of claimed) {
+    if (!isSalesOutreachFeature(c.featureSlug)) continue;
+    const brandId = c.brandIds?.[0];
+    if (!brandId) continue;
+    const key = `${c.orgId}::${brandId}`;
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(c);
+    else groups.set(key, [c]);
+  }
+
+  for (const group of groups.values()) {
+    try {
+      await planOneBrand(group, now, deferred);
+    } catch (err) {
+      // A planning failure must never strand a brand: leave the group to fire on today's
+      // behaviour (per-campaign serialization + the gate's own ceiling enforcement).
+      console.warn(`[campaign-service] funnel turn planning failed for campaign ${group[0]?.id}:`, err);
+    }
+  }
+
+  return deferred;
+}
+
+async function planOneBrand(
+  group: ClaimedFunnelCampaign[],
+  now: Date,
+  deferred: Map<string, Date>,
+): Promise<void> {
+  const seed = group[0];
+  const orgId = seed.orgId;
+  const brandId = seed.brandIds![0];
+  const featureSlug = seed.featureSlug!;
+
+  const identity: IdentityHeaders = {
+    orgId,
+    userId: seed.createdByUserId ?? undefined,
+    campaignId: seed.id,
+    brandId,
+    workflowSlug: seed.workflowSlug,
+  };
+
+  const budgets = await fetchFunnelBudgets(brandId, identity);
+  // Unreadable ceilings → today's behaviour. gate-check fail-closes on the same read, so an
+  // outage cannot turn into overspend; it just cannot improve turn-taking either.
+  if (!budgets.ok) return;
+
+  const funded = fundedFunnels(budgets);
+  // A brand that has never set per-funnel ceilings behaves EXACTLY as it does today: billing
+  // still answers its brand-level budget and the pre-funnel campaign paces on it.
+  if (funded.length === 0) return;
+
+  const declared = await fetchDeclaredSalesFunnels(brandId, identity);
+  await ensureFundedFunnelCampaigns({ seed, brandId, featureSlug, funded, declared, now });
+
+  // Serial, for now: at most one run in flight per brand. Running funnels concurrently needs an
+  // audit of lead de-duplication and of sending-account load that nobody has done, so it is
+  // deliberately out of scope — delete this block and the funnels run in parallel.
+  if (await hasLiveRunForBrand(orgId, brandId, now)) {
+    for (const c of group) deferred.set(c.id, new Date(now.getTime() + FUNNEL_TURN_DEFER_MS));
+    return;
+  }
+
+  const ceilingByFunnel = new Map(funded.map((f) => [f.funnelKey, f.dailyBudgetCents]));
+
+  // The pre-funnel campaign is superseded while funded funnels exist: its money has been
+  // allocated per funnel, so letting it run on the brand-level sum would let one campaign spend
+  // the whole day's allowance across every funnel at once.
+  const contenders: ClaimedFunnelCampaign[] = [];
+  for (const c of group) {
+    if (c.funnelKey && ceilingByFunnel.has(c.funnelKey)) contenders.push(c);
+    else deferred.set(c.id, new Date(now.getTime() + SUPERSEDED_DEFER_MS));
+  }
+  if (contenders.length === 0) return;
+
+  const candidates: FunnelTurnCandidate[] = [];
+  for (const c of contenders) {
+    candidates.push({
+      campaignId: c.id,
+      funnelKey: c.funnelKey!,
+      spentCents: await spentTodayCents(orgId, c.id, featureSlug),
+      ceilingCents: ceilingByFunnel.get(c.funnelKey!)!,
+    });
+  }
+
+  const winner = selectLowestFillRatio(candidates);
+
+  if (winner === null) {
+    // Every funded funnel is at its ceiling — nothing runs until the ceilings reset.
+    const reset = nextDayStart(now);
+    for (const c of contenders) deferred.set(c.id, reset);
+    return;
+  }
+
+  for (const c of contenders) {
+    if (c.id !== winner) deferred.set(c.id, new Date(now.getTime() + FUNNEL_TURN_DEFER_MS));
+  }
+}
+
+/**
+ * Give every funded funnel of the brand its own campaign, so the money spent on a funnel is
+ * attributable to it. A campaign already carries a goal and already has costs attributed to it,
+ * which is why one campaign per funnel answers "how much did this funnel spend today" without
+ * inventing a new attribution dimension.
+ *
+ * The campaign carries the funnel's OWN goal, which is also what stops it being goal-arbitrated:
+ * a campaign that states its own goal is never arbitrated, so features-service keeps answering
+ * the best workflow and the per-audience evidence — scoped to the funnel being run — and stops
+ * being the thing that chooses which funnel runs. The customer's funding decides that.
+ *
+ * A funnel billing funds but brand-service does not declare (or declares inactive) is skipped:
+ * there is no goal to pace it on, and a switched-off funnel must never be worked.
+ */
+async function ensureFundedFunnelCampaigns({
+  seed,
+  brandId,
+  featureSlug,
+  funded,
+  declared,
+  now,
+}: {
+  seed: ClaimedFunnelCampaign;
+  brandId: string;
+  featureSlug: string;
+  funded: FunnelBudget[];
+  declared: DeclaredSalesFunnel[] | null;
+  now: Date;
+}): Promise<void> {
+  // No readable funnel declaration → no goal to pace a new campaign on. Provisioning waits;
+  // whatever campaigns already exist keep running.
+  if (!declared || declared.length === 0) return;
+  if (!seed.createdByUserId) return; // no recipient/owner to attribute a new campaign to
+
+  const goalByFunnel = new Map(declared.map((f) => [f.funnelKey, f.goal]));
+
+  for (const f of funded) {
+    const goal = goalByFunnel.get(f.funnelKey);
+    if (!goal) continue;
+
+    const existing = await db.query.campaigns.findFirst({
+      where: and(
+        eq(campaigns.orgId, seed.orgId),
+        eq(campaigns.featureSlug, featureSlug),
+        eq(campaigns.funnelKey, f.funnelKey),
+        arrayContains(campaigns.brandIds, [brandId]),
+      ),
+      orderBy: [desc(campaigns.createdAt)],
+    });
+    if (existing) {
+      // A funnel the customer re-funded after switching it off resumes rather than duplicating.
+      if (existing.status !== "ongoing") {
+        await db
+          .update(campaigns)
+          .set({ status: "ongoing", nextRunAt: now, updatedAt: now })
+          .where(and(eq(campaigns.id, existing.id), eq(campaigns.orgId, seed.orgId)));
+      }
+      continue;
+    }
+
+    // Deterministic name: uniq_campaigns_org_name is the only uniqueness Postgres can enforce
+    // here (brand_ids is a text[], so no unique index can span it), which makes a duplicate
+    // provision a constraint violation rather than a second campaign for the same funnel.
+    const name = funnelCampaignName(featureSlug, brandId, f.funnelKey);
+
+    try {
+      await db.insert(campaigns).values({
+        orgId: seed.orgId,
+        createdByUserId: seed.createdByUserId,
+        name,
+        workflowSlug: seed.workflowSlug,
+        brandIds: [brandId],
+        featureSlug,
+        funnelKey: f.funnelKey,
+        // The funnel's own goal — forwarded verbatim from brand-service, never mapped.
+        goal,
+        featureInputs: null,
+        status: "ongoing",
+        nextRunAt: now,
+        updatedAt: now,
+      });
+    } catch (err) {
+      // Two ticks (or two instances) racing the same funnel both SELECT nothing and both
+      // INSERT; the unique name index rejects the loser. That is the intended outcome, not a
+      // fault — the winner's campaign is the one campaign for this funnel.
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes("uniq_campaigns_org_name")) throw err;
+    }
+  }
+}
+
+export function funnelCampaignName(featureSlug: string, brandId: string, funnelKey: string): string {
+  return `${featureSlug} - ${brandId} - ${funnelKey}`;
+}
+
+/**
+ * Committed spend today for ONE campaign — which, for a funnel campaign, IS that funnel's spend
+ * today. The cost ledger is already keyed on campaignId, so no per-funnel spend figure is
+ * invented here.
+ *
+ * Same net-committed basis the gate paces on: actual + provisioned, post-usage-discount. A
+ * failed read reports 0 so an unreadable spend never silently parks a funnel; the gate is what
+ * refuses to spend past an unreadable ceiling.
+ */
+async function spentTodayCents(orgId: string, campaignId: string, featureSlug: string): Promise<number> {
+  try {
+    const budget = await getStatsBudget({
+      orgId,
+      campaignId,
+      featureSlug,
+      windows: [{ label: "today", since: startOfToday().toISOString() }],
+    });
+    const today = budget.windows.find((w) => w.label === "today");
+    if (!today) return 0;
+    return parseFloat(today.netTotalCostInUsdCents ?? today.totalCostInUsdCents) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Same "alive" definition the per-campaign guard uses (any running run within the freshness
+// window, whichever service owns it), widened from the campaign to the BRAND. Runs are tagged
+// with the campaign's brandId CSV, which for a funnel campaign is the single brand.
+const LIVE_RUN_FRESHNESS_MS = 15 * 60_000;
+
+async function hasLiveRunForBrand(orgId: string, brandId: string, now: Date): Promise<boolean> {
+  const { runs } = await listRuns({
+    orgId,
+    brandId,
+    status: "running",
+    startedAfter: new Date(now.getTime() - LIVE_RUN_FRESHNESS_MS).toISOString(),
+    limit: 1,
+  });
+  return runs.length > 0;
+}
+
+function startOfToday(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function nextDayStart(now: Date): Date {
+  const d = new Date(now.getTime());
+  d.setDate(d.getDate() + 1);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -4,6 +4,7 @@ import { campaigns } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 import { anyBrandPaused } from "./brand-pause.js";
 import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
+import { fetchFunnelBudgets } from "./funnel-budget-client.js";
 
 const STALE_THRESHOLD_MS = 3 * 60 * 60 * 1000; // 3 hours
 
@@ -33,6 +34,11 @@ export interface GateCheckInput {
   // THIS campaign on its OWN committed spend today vs this ceiling (two campaigns under one
   // brand pace independently). NULL = no own budget → fall back to the brand daily budget.
   dailyBudgetCents: number | null;
+  // The sales funnel this campaign works (brand-service vocabulary), or null when the campaign
+  // is not funnel-scoped. When set, the sales gate paces THIS campaign on THAT funnel's own
+  // daily ceiling read from billing — so a brand funding two funnels has each worked up to its
+  // own ceiling, and the brand's total for the day cannot exceed the sum.
+  funnelKey: string | null;
   maxLeads: number | null;
 }
 
@@ -214,6 +220,44 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
         : 0;
       if (spentCents >= campaign.dailyBudgetCents) {
         return { allowed: false, reason: "Campaign daily budget reached" };
+      }
+    } else if (campaign.funnelKey) {
+      // (a2) The campaign works ONE sales funnel: pace it on THAT funnel's own daily ceiling
+      // (billing-service brand_funnel_budgets), not on the brand-level total. The brand total
+      // is still exactly the SUM of those ceilings, so a brand funding two funnels has both
+      // worked, neither exceeds its own ceiling, and the day's total cannot exceed the sum.
+      //
+      // The funnel's spend today IS this campaign's spend today: one campaign per funnel, and
+      // the cost ledger is already keyed on campaignId — no per-funnel spend figure is invented
+      // here. Read once (campaign-scoped), then compared against each in-scope brand's ceiling.
+      const campaignSpend = await getStatsBudget({
+        orgId: campaign.orgId,
+        campaignId: campaign.campaignId,
+        featureSlug: campaign.featureSlug,
+        windows: [{ label: "today", since: startOfToday().toISOString() }],
+      });
+      const today = campaignSpend.windows.find(w => w.label === "today");
+      const spentCents = today
+        ? parseFloat(today.netTotalCostInUsdCents ?? today.totalCostInUsdCents) || 0
+        : 0;
+
+      for (const brandId of campaign.brandIds) {
+        const budgets = await fetchFunnelBudgets(brandId, identity);
+        // Fail-CLOSED, same stance as the brand ceiling below: an unreadable cap must never be
+        // read as "unbounded".
+        if (!budgets.ok) {
+          return { allowed: false, reason: "Funnel daily budget unavailable" };
+        }
+        const ceilingCents = budgets.funnels.find(f => f.funnelKey === campaign.funnelKey)?.dailyBudgetCents ?? null;
+        // A funnel funded at zero — or no longer funded at all — is never run. That is a
+        // deliberate customer decision, not a missing value, so it is not a fallback to the
+        // brand total: falling back would let an unfunded funnel spend another funnel's money.
+        if (ceilingCents === null || ceilingCents <= 0) {
+          return { allowed: false, reason: "Funnel not funded" };
+        }
+        if (spentCents >= ceilingCents) {
+          return { allowed: false, reason: "Funnel daily budget reached" };
+        }
       }
     } else {
     // (b) Fall back to the per-brand daily budget. Multi-brand tick: blocked if ANY in-scope

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -5,6 +5,7 @@ import { executeCampaignWorkflow } from "./workflows.js";
 import { resolveWorkflowSlugForTrigger } from "./features-workflow-projection-client.js";
 import { listRuns } from "@distribute/runs-client";
 import { notPausedBrandClause } from "./brand-pause.js";
+import { planFunnelTurns } from "./funnel-campaigns.js";
 
 // Cadence while a campaign is actively running (a run is in-flight). At this
 // rate the scheduler catches /end-run reschedules and stuck-run detection.
@@ -102,12 +103,30 @@ export async function reRunDueCampaigns(): Promise<number> {
       brandProfileId: campaigns.brandProfileId,
       audienceId: campaigns.audienceId,
       goal: campaigns.goal,
+      funnelKey: campaigns.funnelKey,
     });
 
   if (dueCampaigns.length === 0) return 0;
 
+  // Per-funnel turn-taking. Provisions a campaign for every funded funnel of each brand,
+  // holds the brand to ONE run in flight, and hands the turn to the funded funnel with the
+  // lowest spent-today/ceiling ratio. Campaigns absent from the map fire as they always have —
+  // every non-sales campaign, and every brand with no per-funnel funding, is untouched.
+  const funnelDefers = await planFunnelTurns(dueCampaigns, now);
+
   for (const campaign of dueCampaigns) {
     try {
+      const funnelDefer = funnelDefers.get(campaign.id);
+      if (funnelDefer) {
+        await db
+          .update(campaigns)
+          .set({ nextRunAt: funnelDefer, updatedAt: new Date() })
+          .where(eq(campaigns.id, campaign.id));
+        // Not logged: this fires every tick for every funnel that did not take its brand's
+        // turn, across every client. The decision is observable in the persisted nextRunAt.
+        continue;
+      }
+
       const missingFields: string[] = [];
       if (!campaign.brandIds || campaign.brandIds.length === 0) missingFields.push("brandIds");
       if (!campaign.createdByUserId) missingFields.push("createdByUserId");

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -99,6 +99,7 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
       maxBudgetMonthlyUsd: campaign.maxBudgetMonthlyUsd,
       maxBudgetTotalUsd: campaign.maxBudgetTotalUsd,
       dailyBudgetCents: campaign.dailyBudgetCents,
+      funnelKey: campaign.funnelKey,
       maxLeads: campaign.maxLeads,
     });
 
@@ -113,6 +114,10 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
       const benignBlock = result.reason === "Insufficient credits" ||
                           result.reason === "Brand daily budget reached" ||
                           result.reason === "Campaign daily budget reached" ||
+                          // A funnel hitting its own ceiling — or the customer having funded it
+                          // at zero — is an expected pacing outcome, not a fault.
+                          result.reason === "Funnel daily budget reached" ||
+                          result.reason === "Funnel not funded" ||
                           result.reason === "Brand paused";
       traceEvent(req.runId, {
         service: "campaign-service",
@@ -333,6 +338,9 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
       // Campaign v2 own config — the campaign's raw own goal (null = paced on brand goal),
       // its targeted audience subset, its services, its click-destination.
       goal: campaign.goal ?? null,
+      // The sales funnel this campaign works (null = not funnel-scoped). Exposed so the run's
+      // downstream nodes and any reader can see which funnel's money this execution spends.
+      funnelKey: campaign.funnelKey ?? null,
       audienceIds: campaign.audienceIds ?? null,
       servicesOffered: campaign.servicesOffered ?? null,
       clickDestinationUrl: campaign.clickDestinationUrl ?? null,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -51,6 +51,12 @@ export const CampaignSchema = z.object({
   maxBudgetTotalUsd: z.string().nullable(),
   // Per-campaign daily budget for the sales feature (cents). Null = fall back to brand daily budget.
   dailyBudgetCents: z.number().int().nullable(),
+  // The sales funnel this campaign works, in brand-service's vocabulary (reply_meeting |
+  // visit_meeting | visit_signup | visit_form). Null = not funnel-scoped: the campaign paces on
+  // the brand-level daily budget as it always has. Set = the campaign is paced on THAT funnel's
+  // own daily ceiling in billing, which is what makes a funnel's spend attributable to it.
+  // Provisioned by this service from the funnels the customer funds — never set by a caller.
+  funnelKey: z.string().nullable(),
   maxLeads: z.number().int().nullable(),
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  mockListRuns,
+  mockGetStatsBudget,
+  mockFindFirst,
+  mockInsertValues,
+  mockUpdateWhere,
+} = vi.hoisted(() => ({
+  mockListRuns: vi.fn(),
+  mockGetStatsBudget: vi.fn(),
+  mockFindFirst: vi.fn(),
+  mockInsertValues: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  listRuns: mockListRuns,
+  getStatsBudget: mockGetStatsBudget,
+}));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    query: { campaigns: { findFirst: mockFindFirst } },
+    insert: vi.fn().mockReturnValue({ values: mockInsertValues }),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: mockUpdateWhere }),
+    }),
+  },
+}));
+
+vi.mock("../../src/db/schema.js", () => ({
+  campaigns: {
+    id: "id",
+    orgId: "org_id",
+    featureSlug: "feature_slug",
+    funnelKey: "funnel_key",
+    brandIds: "brand_ids",
+    createdAt: "created_at",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  desc: vi.fn(),
+  arrayContains: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import {
+  planFunnelTurns,
+  selectLowestFillRatio,
+  funnelCampaignName,
+  FUNNEL_TURN_DEFER_MS,
+  SUPERSEDED_DEFER_MS,
+  type ClaimedFunnelCampaign,
+} from "../../src/lib/funnel-campaigns.js";
+
+const SALES = "sales-cold-email-outreach";
+
+function claimed(overrides: Partial<ClaimedFunnelCampaign> = {}): ClaimedFunnelCampaign {
+  return {
+    id: "campaign-1",
+    orgId: "org-1",
+    createdByUserId: "user-1",
+    workflowSlug: "sales-email-cold-outreach",
+    brandIds: ["brand-1"],
+    featureSlug: SALES,
+    funnelKey: null,
+    ...overrides,
+  };
+}
+
+function mockFunnelBudgets(funnels: Array<{ funnelKey: string; dailyBudgetCents: string }>) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      brandId: "brand-1",
+      dailyBudgetCents: String(funnels.reduce((s, f) => s + Number(f.dailyBudgetCents), 0)),
+      funnels: funnels.map(f => ({ ...f, updatedAt: null })),
+    }),
+  });
+}
+
+function mockDeclaredFunnels(funnels: Array<{ funnelKey: string; goal: string; active?: boolean }>) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      declared: funnels.length > 0,
+      funnels: funnels.map(f => ({ ...f, active: f.active ?? true, currentGoal: f.goal })),
+    }),
+  });
+}
+
+function mockSpend(cents: string) {
+  mockGetStatsBudget.mockResolvedValueOnce({
+    windows: [{ label: "today", totalCostInUsdCents: cents, netTotalCostInUsdCents: cents }],
+  });
+}
+
+describe("selectLowestFillRatio", () => {
+  it("hands the turn to the funnel that has filled the least of its own ceiling", () => {
+    // The bigger absolute spend is the EMPTIER funnel relative to what it can absorb.
+    const winner = selectLowestFillRatio([
+      { campaignId: "a", funnelKey: "reply_meeting", spentCents: 800, ceilingCents: 1000 },
+      { campaignId: "b", funnelKey: "visit_signup", spentCents: 900, ceilingCents: 5000 },
+    ]);
+    expect(winner).toBe("b");
+  });
+
+  it("is not a fixed order — a funnel that can absorb the whole day never starves the others", () => {
+    // First in the list, huge ceiling, nothing spent: under a fixed order it would take every
+    // turn. It takes this one, and once it has filled 10% the smaller funnel wins the next.
+    const big = { campaignId: "big", funnelKey: "reply_meeting", spentCents: 0, ceilingCents: 100_000 };
+    const small = { campaignId: "small", funnelKey: "visit_signup", spentCents: 0, ceilingCents: 100 };
+    expect(selectLowestFillRatio([big, small])).toBe("big"); // tie at 0 → funnelKey order
+    expect(selectLowestFillRatio([{ ...big, spentCents: 10_000 }, small])).toBe("small");
+  });
+
+  it("a funnel at its ceiling yields to another funded one, with no special case", () => {
+    const winner = selectLowestFillRatio([
+      { campaignId: "full", funnelKey: "reply_meeting", spentCents: 1000, ceilingCents: 1000 },
+      { campaignId: "open", funnelKey: "visit_signup", spentCents: 990, ceilingCents: 1000 },
+    ]);
+    expect(winner).toBe("open");
+  });
+
+  it("returns null when every funded funnel is at its ceiling", () => {
+    expect(
+      selectLowestFillRatio([
+        { campaignId: "a", funnelKey: "reply_meeting", spentCents: 1000, ceilingCents: 1000 },
+        { campaignId: "b", funnelKey: "visit_signup", spentCents: 2500, ceilingCents: 2000 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("never runs a funnel funded at zero", () => {
+    expect(
+      selectLowestFillRatio([
+        { campaignId: "zero", funnelKey: "visit_signup", spentCents: 0, ceilingCents: 0 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("breaks ties deterministically on funnelKey, not insertion order", () => {
+    const rows = [
+      { campaignId: "v", funnelKey: "visit_signup", spentCents: 50, ceilingCents: 100 },
+      { campaignId: "r", funnelKey: "reply_meeting", spentCents: 50, ceilingCents: 100 },
+    ];
+    expect(selectLowestFillRatio(rows)).toBe("r");
+    expect(selectLowestFillRatio([...rows].reverse())).toBe("r");
+  });
+});
+
+describe("planFunnelTurns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+    process.env.BILLING_SERVICE_API_KEY = "billing-key";
+    process.env.BRAND_SERVICE_URL = "https://brand.test.local";
+    process.env.BRAND_SERVICE_API_KEY = "brand-key";
+    mockListRuns.mockResolvedValue({ runs: [] });
+    mockFindFirst.mockResolvedValue({ id: "existing", status: "ongoing" });
+    mockInsertValues.mockResolvedValue(undefined);
+    mockUpdateWhere.mockResolvedValue(undefined);
+  });
+
+  it("leaves non-sales campaigns entirely alone", async () => {
+    const deferred = await planFunnelTurns([claimed({ featureSlug: "pr-media-pitch-v1" })]);
+    expect(deferred.size).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("a brand that never set per-funnel ceilings behaves exactly as today", async () => {
+    mockFunnelBudgets([]);
+    const deferred = await planFunnelTurns([claimed()]);
+    expect(deferred.size).toBe(0);
+  });
+
+  it("falls through to today's behaviour when the ceilings cannot be read (fail-soft)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+    const deferred = await planFunnelTurns([claimed()]);
+    expect(deferred.size).toBe(0);
+  });
+
+  it("gives every funded funnel its own campaign", async () => {
+    mockFunnelBudgets([
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      { funnelKey: "reply_meeting", dailyBudgetCents: "2000" },
+    ]);
+    mockDeclaredFunnels([
+      { funnelKey: "visit_signup", goal: "signup" },
+      { funnelKey: "reply_meeting", goal: "meetingBooked" },
+    ]);
+    mockFindFirst.mockResolvedValue(undefined); // neither funnel has a campaign yet
+
+    await planFunnelTurns([claimed()]);
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(2);
+    const inserted = mockInsertValues.mock.calls.map(c => c[0]);
+    expect(inserted.map(v => v.funnelKey).sort()).toEqual(["reply_meeting", "visit_signup"]);
+    // The campaign carries the funnel's OWN goal, forwarded verbatim — that is what keeps it
+    // out of goal arbitration.
+    expect(inserted.find(v => v.funnelKey === "reply_meeting").goal).toBe("meetingBooked");
+    expect(inserted.find(v => v.funnelKey === "visit_signup").goal).toBe("signup");
+    expect(inserted[0].name).toBe(funnelCampaignName(SALES, "brand-1", inserted[0].funnelKey));
+  });
+
+  it("never provisions a funnel billing funds but brand-service does not declare active", async () => {
+    mockFunnelBudgets([
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      { funnelKey: "visit_form", dailyBudgetCents: "500" },
+    ]);
+    mockDeclaredFunnels([
+      { funnelKey: "visit_signup", goal: "signup" },
+      { funnelKey: "visit_form", goal: "formSubmission", active: false },
+    ]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed()]);
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(1);
+    expect(mockInsertValues.mock.calls[0][0].funnelKey).toBe("visit_signup");
+  });
+
+  it("holds the whole brand while a run is in flight — one run per brand", async () => {
+    mockFunnelBudgets([
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      { funnelKey: "reply_meeting", dailyBudgetCents: "2000" },
+    ]);
+    mockDeclaredFunnels([
+      { funnelKey: "visit_signup", goal: "signup" },
+      { funnelKey: "reply_meeting", goal: "meetingBooked" },
+    ]);
+    mockListRuns.mockResolvedValue({ runs: [{ id: "live" }] });
+
+    const now = new Date("2026-08-02T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
+        claimed({ id: "c-reply", funnelKey: "reply_meeting" }),
+      ],
+      now,
+    );
+
+    expect(deferred.get("c-visit")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
+    expect(deferred.get("c-reply")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
+    // The brand's liveness is what is checked, not one campaign's.
+    expect(mockListRuns).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: "org-1", brandId: "brand-1", status: "running" }),
+    );
+  });
+
+  it("fires exactly one funnel per tick — the emptiest relative to its ceiling", async () => {
+    mockFunnelBudgets([
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      { funnelKey: "reply_meeting", dailyBudgetCents: "1000" },
+    ]);
+    mockDeclaredFunnels([
+      { funnelKey: "visit_signup", goal: "signup" },
+      { funnelKey: "reply_meeting", goal: "meetingBooked" },
+    ]);
+    mockSpend("900"); // c-visit is 90% full
+    mockSpend("100"); // c-reply is 10% full
+
+    const now = new Date("2026-08-02T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
+        claimed({ id: "c-reply", funnelKey: "reply_meeting" }),
+      ],
+      now,
+    );
+
+    expect(deferred.has("c-reply")).toBe(false); // takes the turn
+    expect(deferred.get("c-visit")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
+  });
+
+  it("parks every funnel until the ceilings reset when all are full", async () => {
+    mockFunnelBudgets([
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      { funnelKey: "reply_meeting", dailyBudgetCents: "1000" },
+    ]);
+    mockDeclaredFunnels([
+      { funnelKey: "visit_signup", goal: "signup" },
+      { funnelKey: "reply_meeting", goal: "meetingBooked" },
+    ]);
+    mockSpend("1000");
+    mockSpend("1200");
+
+    const now = new Date("2026-08-02T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
+        claimed({ id: "c-reply", funnelKey: "reply_meeting" }),
+      ],
+      now,
+    );
+
+    expect(deferred.size).toBe(2);
+    for (const at of deferred.values()) expect(at.getTime()).toBeGreaterThan(now.getTime());
+  });
+
+  it("supersedes the pre-funnel campaign once funnels are funded", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+    mockDeclaredFunnels([{ funnelKey: "visit_signup", goal: "signup" }]);
+    mockSpend("0");
+
+    const now = new Date("2026-08-02T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-legacy", funnelKey: null }),
+        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
+      ],
+      now,
+    );
+
+    // The legacy campaign paces on the brand-level SUM — letting it run would spend every
+    // funnel's allowance at once.
+    expect(deferred.get("c-legacy")?.getTime()).toBe(now.getTime() + SUPERSEDED_DEFER_MS);
+    expect(deferred.has("c-visit")).toBe(false);
+  });
+});

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -70,6 +70,9 @@ function makeCampaign(overrides: Partial<GateCheckInput> = {}): GateCheckInput {
     // Null by default → the sales gate falls back to the brand daily budget, so the existing
     // brand-budget describe block exercises unchanged. The campaign-own-budget block sets it.
     dailyBudgetCents: null,
+    // Null by default → not funnel-scoped, so the sales gate keeps falling back to the brand
+    // daily budget and every block below exercises unchanged. The funnel block sets it.
+    funnelKey: null,
     maxLeads: null,
     ...overrides,
   };
@@ -542,6 +545,144 @@ describe("Gate Check", () => {
       expect(opts.headers["x-api-key"]).toBe("test-billing-key");
       expect(opts.headers["x-org-id"]).toBe("org-1");
       expect(opts.headers["x-campaign-id"]).toBe("campaign-1");
+    });
+  });
+
+  describe("Per-funnel daily budget pacing", () => {
+    const ORIG_URL = process.env.BILLING_SERVICE_URL;
+    const ORIG_KEY = process.env.BILLING_SERVICE_API_KEY;
+
+    beforeEach(() => {
+      process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+      process.env.BILLING_SERVICE_API_KEY = "test-billing-key";
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "0" }]),
+      );
+    });
+
+    afterEach(() => {
+      if (ORIG_URL === undefined) delete process.env.BILLING_SERVICE_URL;
+      else process.env.BILLING_SERVICE_URL = ORIG_URL;
+      if (ORIG_KEY === undefined) delete process.env.BILLING_SERVICE_API_KEY;
+      else process.env.BILLING_SERVICE_API_KEY = ORIG_KEY;
+    });
+
+    function mockFunnelBudgets(
+      funnels: Array<{ funnelKey: string; dailyBudgetCents: string }>,
+      dailyBudgetCents: string | null = "3000",
+    ) {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          brandId: "brand-1",
+          dailyBudgetCents,
+          funnels: funnels.map(f => ({ ...f, updatedAt: null })),
+        }),
+      });
+    }
+
+    function funnelCampaign(funnelKey = "visit_signup") {
+      return makeCampaign({ brandIds: ["brand-1"], funnelKey });
+    }
+
+    it("paces on THIS funnel's own ceiling, not the brand-level total", async () => {
+      mockFunnelBudgets([
+        { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+        { funnelKey: "reply_meeting", dailyBudgetCents: "2000" },
+      ]);
+      mockGetStatsBudget.mockResolvedValue(
+        // 1500 is under the 3000 brand-level SUM but at 150% of this funnel's own 1000.
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "1500" }]),
+      );
+
+      const result = await runGateChecks(funnelCampaign());
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Funnel daily budget reached");
+      // Paced, not terminal — the ceiling re-opens at the day rollover.
+      expect(result.autoStopped).toBeUndefined();
+      expect(result.nextRunAt).toBeUndefined();
+    });
+
+    it("allows while this funnel is under its own ceiling", async () => {
+      mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "999" }]),
+      );
+      // affordability + lead-stats fetches after the billing read
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ affordable: true }) });
+
+      const result = await runGateChecks(funnelCampaign());
+      expect(result.allowed).toBe(true);
+    });
+
+    it("never runs a funnel funded at zero", async () => {
+      mockFunnelBudgets([
+        { funnelKey: "visit_signup", dailyBudgetCents: "0" },
+        { funnelKey: "reply_meeting", dailyBudgetCents: "2000" },
+      ]);
+
+      const result = await runGateChecks(funnelCampaign());
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Funnel not funded");
+    });
+
+    it("never falls back to the brand total when this funnel has no ceiling at all", async () => {
+      // A funnel absent from billing must not spend another funnel's money.
+      mockFunnelBudgets([{ funnelKey: "reply_meeting", dailyBudgetCents: "2000" }]);
+
+      const result = await runGateChecks(funnelCampaign());
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Funnel not funded");
+    });
+
+    it("fails CLOSED when the per-funnel ceilings cannot be read", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+
+      const result = await runGateChecks(funnelCampaign());
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Funnel daily budget unavailable");
+    });
+
+    it("reads the funnel ceilings from billing's locked contract", async () => {
+      mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ affordable: true }) });
+
+      await runGateChecks(funnelCampaign());
+
+      const [calledUrl, calledInit] = mockFetch.mock.calls[0];
+      expect(calledUrl).toBe("https://billing.test.local/internal/brands/brand-1/funnel-budgets");
+      expect(calledInit.headers["x-api-key"]).toBe("test-billing-key");
+      expect(calledInit.headers["x-org-id"]).toBe("org-1");
+    });
+
+    it("a campaign's OWN daily budget still wins over its funnel ceiling", async () => {
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "500" }]),
+      );
+
+      const result = await runGateChecks(
+        makeCampaign({ brandIds: ["brand-1"], funnelKey: "visit_signup", dailyBudgetCents: 500 }),
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Campaign daily budget reached");
+      expect(mockFetch).not.toHaveBeenCalledWith(
+        expect.stringContaining("/funnel-budgets"),
+        expect.anything(),
+      );
+    });
+
+    it("a campaign with no funnel keeps reading the brand-level daily budget", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ brandId: "brand-1", dailyBudgetCents: "1000", updatedAt: null }),
+      });
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ affordable: true }) });
+
+      const result = await runGateChecks(makeCampaign({ brandIds: ["brand-1"] }));
+      expect(result.allowed).toBe(true);
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://billing.test.local/internal/brands/brand-1/daily-budget",
+      );
     });
   });
 

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -79,6 +79,13 @@ vi.mock("../../src/lib/brand-pause.js", () => ({
   notPausedBrandClause: vi.fn(() => undefined),
 }));
 
+// Per-funnel turn-taking has its own suite (tests/unit/funnel-campaigns.test.ts). Here it is a
+// no-op so these campaigns (a non-sales-outreach feature slug) keep the pre-funnel behaviour the
+// assertions below were written for.
+vi.mock("../../src/lib/funnel-campaigns.js", () => ({
+  planFunnelTurns: vi.fn(async () => new Map()),
+}));
+
 import {
   reRunDueCampaigns,
   claimStuckCampaigns,


### PR DESCRIPTION
## What

A customer can now fund each of a brand's **sales funnels** separately (billing-service PR #344, on staging). Its brand-level `GET /internal/brands/:id/daily-budget` still answers the SUM of those ceilings, so nothing reading the brand total changes.

This service used to ask features-service which single funnel was best by ROI and run that one. That made sense when a brand had one pot. Now **every funded funnel gets run, and each is paced against its own daily ceiling.**

## How

**One campaign per funded funnel** — `campaigns.funnel_key` (migration 0041). The cost ledger is already keyed on `campaignId`, so a funnel's spend today IS its campaign's spend today; no new attribution dimension. Provisioned by the scheduler from billing's `GET /internal/brands/:id/funnel-budgets` intersected with brand-service's `GET /internal/brands/:id/sales-funnels`, which carries the goal each funnel optimizes for. That goal is forwarded verbatim onto `campaigns.goal` — which is also what keeps a funnel campaign out of goal arbitration. features-service keeps answering what it is good at (best workflow + per-audience evidence), scoped to the funnel being run; it stops choosing which funnel runs.

**The gate paces on that funnel's own ceiling** (`gate-check.ts`), fail-CLOSED like the brand ceiling. Precedence: the campaign's own `dailyBudgetCents` → its `funnelKey` ceiling → the brand daily budget. A funnel funded at **zero**, or absent from billing, blocks (`Funnel not funded`) and never falls back to the brand total — falling back would let it spend another funnel's money.

**Serial, for now: at most one run in flight per brand.** Running funnels concurrently is deliberately out of scope: it needs an audit of lead de-duplication and of sending-account load that nobody has done. It is one `hasLiveRunForBrand` block; deleting it is what unlocks parallelism, and nothing else has to be undone.

**Which funnel goes next is the lowest spent-today ÷ own-ceiling ratio**, never a fixed order and never "the primary first". A fixed order starves whatever sits last: if the first funnel can absorb the whole day the others never run, and that shows up in no log at all, only in a funnel that mysteriously never spends. A funnel at its ceiling yields its turn with no special case (ratio ≥ 1 → not a candidate). Every funnel full → parked until the day rollover.

**Fail-SOFT in the scheduler, fail-CLOSED in the gate.** An unreadable budget or funnel set leaves the brand on today's behaviour — turn-taking is a selection optimization and must never block a run. The gate is what refuses to spend past a cap it cannot read.

## Conformance

Read from the API registry, not from any PR description:
- billing `GET /internal/brands/{brandId}/funnel-budgets` → `{ brandId, dailyBudgetCents: string|null, funnels: [{ funnelKey, dailyBudgetCents, updatedAt }] }`, `x-api-key` + `x-org-id`. Empty `funnels` for a brand that never set ceilings.
- brand `GET /internal/brands/{brandId}/sales-funnels` → funnels with `funnelKey`, `active`, `goal`.
- Funnel vocabulary: `reply_meeting | visit_meeting | visit_signup | visit_form`.

## Acceptance

- A brand funding two funnels has both worked; neither exceeds its own ceiling; the brand's day total cannot exceed the sum (each campaign is capped by its own funnel's ceiling).
- A funnel at its ceiling stops and yields; all funded funnels full → nothing runs until they reset.
- A funnel funded at zero is never run (filtered at provisioning, at ranking, and blocked at the gate).
- A brand that has never set per-funnel ceilings behaves exactly as today — no funnel campaigns, brand-level budget as before.
- No two runs of the same brand in flight at once.
- The brand-level pause is untouched; the dashboard still reads and renders it.

## Tests

241 unit (15 new in `funnel-campaigns.test.ts`, 8 new gate-check cases) + 183 integration, all green. `tsc --noEmit` clean, build + OpenAPI regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
