### PR TITLE
hotfix: Adopt the campaign already doing a funnel's work; delete the superseded state; every campaign states its funnel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,15 +92,39 @@ funded funnels get worked, each spending up to its own ceiling and stopping ther
 
 - **One campaign per funded funnel** (`campaigns.funnel_key`, migration 0041). The cost ledger is
   already keyed on campaignId, so a funnel's spend today IS its campaign's spend today — no new
-  attribution dimension. Provisioned by the scheduler (`src/lib/funnel-campaigns.ts`) from
+  attribution dimension. Reconciled by the scheduler (`src/lib/funnel-campaigns.ts`) from
   billing's `GET /internal/brands/:id/funnel-budgets` ∩ brand-service's
   `GET /internal/brands/:id/sales-funnels` (which carries the goal each funnel optimizes for,
   forwarded verbatim onto `campaigns.goal`). A funnel billing funds but brand-service does not
   declare ACTIVE is never provisioned.
+- **The campaign ALREADY doing a funnel's work becomes that funnel's campaign — a second one is
+  never stood up beside it.** `findIncumbentForFunnel` looks for the OLDEST `ongoing` campaign of
+  the same (org, brand, feature) that states no funnel and whose goal (its own, else the brand's)
+  names this funnel, and adopts it: same id, same months of runs, same attributed costs, now
+  stating the funnel + its goal. Standing up an empty twin left the working campaign reading as
+  dead and the live one as having produced nothing (prod, brand `6e21bb6c`, 2026-08-02). An empty
+  campaign THIS service provisioned for a funnel its incumbent was already working is dropped in
+  the same step — and only then: `isRemovableStandIn` requires the provisioned name, zero runs in
+  runs-service AND zero lifetime cost, and fails CLOSED on any unreadable read. Nothing that ever
+  ran is ever removed.
+- **Every campaign STATES its funnel, persisted — no consumer infers it from a goal.** Migration
+  0042 rewrites the goal vocabulary of every campaign that states a goal; `src/lib/funnel-backfill.ts`
+  (boot, after `listen`, fire-and-forget, idempotent) does the rest by reading each (org, brand)
+  pair's goal from brand-service once. The goal→funnel map lives in ONE place,
+  `src/lib/sales-funnel-vocabulary.ts`: form submissions → `visit_form`, booked meeting →
+  `reply_meeting` (these campaigns are cold email, so the chain that ran is reply→meeting, never
+  the website one — owner-decided 2026-08-02), website purchase / signup → `visit_signup`. A goal
+  naming no single funnel (`combinedSales`, `websiteVisit`, `positiveReply`,
+  `whatsappConversation`) keeps a NULL funnel: a funnel is a stored fact, never a guess.
 - **The gate paces on that funnel's own ceiling** (`gate-check.ts`, block a2), fail-CLOSED like
   the brand ceiling. Precedence: campaign's own `dailyBudgetCents` → `funnelKey` ceiling → brand
-  daily budget. A funnel funded at ZERO, or absent from billing, blocks (`Funnel not funded`) —
-  it NEVER falls back to the brand total, which would let it spend another funnel's money.
+  daily budget. A funnel funded at ZERO, or absent from billing while the brand funds OTHER
+  funnels, blocks (`Funnel not funded`) — it NEVER falls back to the brand total, which would let
+  it spend another funnel's money. The ONE case that reads the funnel as a label rather than a
+  ceiling: a brand billing reports NO per-funnel ceilings for at all (`funnels: []`) still has one
+  pot, so the campaign paces on the brand daily budget exactly as it did before every campaign
+  stated a funnel. Without that, stamping the funnel fleet-wide would have blocked every brand
+  that never split its budget.
 - **Serial, for now: one run in flight per BRAND** (`hasLiveRunForBrand` in funnel-campaigns.ts).
   Running funnels concurrently needs an audit of lead de-duplication and of sending-account load
   that nobody has done. Deleting that one block is what unlocks parallelism; nothing else has to
@@ -109,15 +133,18 @@ funded funnels get worked, each spending up to its own ceiling and stopping ther
   never a fixed order and never "the primary first". A fixed order starves whatever sits last —
   if the first funnel can absorb the whole day the others never run, and that shows up in no log
   at all. A funnel at its ceiling yields with no special case (ratio ≥ 1 → not a candidate); all
-  funnels full → parked until the day rollover.
+  funnels full → parked until the day rollover. EVERY alive campaign of the brand is a candidate
+  every tick — one that states no funnel is ranked on the brand daily budget, the ceiling the gate
+  actually binds it to. No campaign is ever held out of the running because another one covers its
+  funnel; there is no superseded state, and `tests/unit/no-legacy.test.ts` fails if the concept
+  returns.
 - **Fail-SOFT in the scheduler, fail-CLOSED in the gate.** An unreadable budget/funnel set leaves
   the brand on today's behaviour (turn-taking is an optimization); the gate is what refuses to
   spend past a cap it cannot read.
 - A brand that never set per-funnel ceilings grows no funnel campaigns and behaves exactly as
-  before. The pre-funnel (`funnel_key` NULL) campaign is SUPERSEDED — not stopped — while funded
-  funnels exist, and resumes if the customer clears them.
+  before: its campaigns state their funnel (a label) and keep pacing on the brand-level pot.
 - The brand-level PAUSE is untouched: the dashboard still reads and renders it.
-(Set 2026-08-02.)
+(Set 2026-08-02; adoption + fleet-wide funnel statement, same day.)
 
 The per-campaign audience SUBSET (`campaigns.audience_ids`, Campaign v2) is a HARD filter on the audience bandit (`requiredAudienceIds` in `selectAudienceFromProjection`): a campaign never contacts an audience outside its targeted subset (no fallback). NULL/empty → inherit the brand's full active audience set. (The old workflow-conditioning `eligibleAudienceIds` soft-filter was REMOVED in v0.44.1 — see the single-endpoint note below.) Distinct from the singular `audienceId` column (per-campaign attribution; the per-RUN chosen audience is re-selected fresh at /start-run).
 

--- a/drizzle/0042_campaign_funnel_from_goal.sql
+++ b/drizzle/0042_campaign_funnel_from_goal.sql
@@ -1,0 +1,44 @@
+-- Rewrite the goal a campaign STATES into the funnel it runs.
+--
+-- A campaign used to say what it was for in the goal vocabulary; brand-service now speaks
+-- funnels, and consumers must read the funnel off the campaign row rather than infer it from a
+-- goal. This is the stored-data half of that move: every campaign that states a goal naming one
+-- funnel gets that funnel written onto it.
+--
+--   form submissions  -> visit_form     (Form Magnet)
+--   booked meeting    -> reply_meeting  (Sales Meeting from Conversation — these campaigns are
+--                                        cold email, so the chain that ran is reply then
+--                                        meeting, never the website one; owner-decided
+--                                        2026-08-02)
+--   website purchase  -> visit_signup   (Website Purchase)
+--
+-- Every legacy spelling brand-service still accepts on write is listed, because a stored row may
+-- carry any of them. A goal that names no single funnel is deliberately absent and keeps a NULL
+-- funnel: `combinedSales` spans several funnels, and `websiteVisit` / `positiveReply` /
+-- `whatsappConversation` stop short of a paid client. A funnel is a fact, never a guess.
+--
+-- The campaigns that state NO goal at all (they run on their brand's goal) are stamped by the
+-- boot pass in `src/lib/funnel-backfill.ts`, which can read brand-service; SQL cannot.
+--
+-- Only touches rows whose funnel is still NULL, so it is idempotent and re-runnable, and it
+-- neither deletes, stops nor reschedules anything.
+UPDATE "campaigns"
+SET "funnel_key" = CASE "goal"
+    WHEN 'formSubmission'       THEN 'visit_form'
+    WHEN 'form_submissions'     THEN 'visit_form'
+    WHEN 'meetingBooked'        THEN 'reply_meeting'
+    WHEN 'booked_meetings'      THEN 'reply_meeting'
+    WHEN 'sales_meetings'       THEN 'reply_meeting'
+    WHEN 'signup'               THEN 'visit_signup'
+    WHEN 'signups'              THEN 'visit_signup'
+    WHEN 'websitePurchase'      THEN 'visit_signup'
+    WHEN 'website_purchase'     THEN 'visit_signup'
+    WHEN 'purchase'             THEN 'visit_signup'
+    WHEN 'sales'                THEN 'visit_signup'
+  END
+WHERE "funnel_key" IS NULL
+  AND "goal" IN (
+    'formSubmission', 'form_submissions',
+    'meetingBooked', 'booked_meetings', 'sales_meetings',
+    'signup', 'signups', 'websitePurchase', 'website_purchase', 'purchase', 'sales'
+  );

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1776600000000,
       "tag": "0041_campaign_funnel_key",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1776700000000,
+      "tag": "0042_campaign_funnel_from_goal",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -58,7 +58,7 @@ export const campaigns = pgTable(
     // (human-service saved-filter-set UUIDs == audience.id). NULL/absent → target the
     // brand's full active audience set (inherit). When set, the per-run audience bandit is
     // HARD-restricted to this subset — the campaign never contacts an audience outside it,
-    // regardless of workflow-conditioning. Supersedes the singular audienceId for targeting.
+    // regardless of workflow-conditioning. Replaces the singular audienceId for targeting.
     audienceIds: text("audience_ids").array(),
 
     // The services this campaign offers. NULL → inherit the brand's services. Exposed to the

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import statsRoutes from "./routes/stats.js";
 import internalRoutes from "./routes/internal.js";
 import { startScheduler } from "./lib/scheduler.js";
 import { registerExtendAudienceTemplate } from "./lib/transactional-email.js";
+import { runFunnelBackfill } from "./lib/funnel-backfill.js";
 const app = express();
 const PORT = process.env.PORT || 3003;
 
@@ -74,6 +75,10 @@ if (process.env.NODE_ENV !== "test") {
         // Register lifecycle email templates AFTER port-bind, fire-and-forget: a slow or
         // down transactional-email-service must never delay boot or fail the deploy.
         void registerExtendAudienceTemplate();
+        // Write the funnel every existing campaign runs onto its own row, once. Idempotent and
+        // fire-and-forget for the same reason: it reads brand-service per (org, brand) pair and
+        // must never delay the port bind or fail a deploy.
+        void runFunnelBackfill();
       });
     })
     .catch((err) => {

--- a/src/lib/funnel-adoption.ts
+++ b/src/lib/funnel-adoption.ts
@@ -1,0 +1,58 @@
+import { fetchBrandRuntimeContext } from "./brand-runtime-client.js";
+import type { DownstreamIdentity } from "./downstream-headers.js";
+import { funnelForGoal } from "./sales-funnel-vocabulary.js";
+
+/**
+ * Which funnel a campaign that states none is already running.
+ *
+ * A campaign's goal is its own when it states one, and the brand's otherwise — the same
+ * resolution the runtime uses at /start-run. Read once here so the funnel can be WRITTEN onto
+ * the campaign row; nothing downstream re-derives it.
+ *
+ * Returns null when the goal names no single funnel. A campaign whose funnel cannot be
+ * determined keeps a NULL funnel: a stated funnel is a fact, never a guess.
+ */
+export function resolveCampaignFunnelKey(
+  campaignGoal: string | null | undefined,
+  brandGoal: string | null | undefined,
+): string | null {
+  return funnelForGoal(campaignGoal ?? brandGoal);
+}
+
+/**
+ * This org's current goal for the brand, or null when it cannot be read.
+ *
+ * Fail-SOFT on purpose: both callers (the boot backfill and the scheduler's adoption step) use
+ * it to decide whether an existing campaign can be labelled with its funnel. An unreadable
+ * brand leaves the campaign exactly as it is and the next pass tries again — it never blocks a
+ * run and never invents a goal.
+ */
+export async function readBrandGoal(
+  brandId: string,
+  caller: {
+    orgId: string;
+    userId?: string | null;
+    campaignId?: string | null;
+    workflowSlug?: string | null;
+    featureSlug?: string | null;
+  },
+): Promise<string | null> {
+  // `orgId` is load-bearing on this read — the goal belongs to the (org, brand) pair, and
+  // brand-service refuses to pick an org for a brand several orgs claim. Everything else is
+  // tracking.
+  const identity: DownstreamIdentity = {
+    orgId: caller.orgId,
+    userId: caller.userId ?? "",
+    runId: "",
+    campaignId: caller.campaignId ?? "",
+    brandId,
+    workflowSlug: caller.workflowSlug ?? "",
+    featureSlug: caller.featureSlug ?? "",
+  };
+  try {
+    const ctx = await fetchBrandRuntimeContext(brandId, identity);
+    return ctx.currentGoal ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/funnel-backfill.ts
+++ b/src/lib/funnel-backfill.ts
@@ -1,0 +1,111 @@
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { campaigns } from "../db/schema.js";
+import { readBrandGoal, resolveCampaignFunnelKey } from "./funnel-adoption.js";
+import { SALES_OUTREACH_FEATURE_SLUGS } from "./sales-outreach-campaign.js";
+
+/**
+ * Write the funnel every existing campaign runs onto its own row, once, for the whole fleet.
+ *
+ * A campaign used to say what it was for only through its goal — its own when it stated one,
+ * its brand's otherwise — so every consumer had to infer the funnel from that goal. The funnel
+ * is now a stored fact: this pass reads each campaign's goal ONE last time and writes the funnel
+ * it means. Nothing reads the goal to find the funnel afterwards, and there is no read-time
+ * fallback anywhere.
+ *
+ * Idempotent: it only ever touches rows whose `funnel_key` is still NULL, so a re-boot (or a
+ * second replica booting at the same moment) re-runs it for free and converges on the same rows.
+ * Nothing is deleted, stopped or archived — a campaign's status, schedule and history are
+ * untouched; the pass adds the funnel and nothing else.
+ *
+ * What it deliberately leaves NULL, and why:
+ *   - every non-sales feature (PR, hiring, VC, AI-visibility …): a sales funnel is not a thing
+ *     those campaigns run,
+ *   - a goal that names no single funnel (`combinedSales` spans several; `websiteVisit`,
+ *     `positiveReply`, `whatsappConversation` stop short of a paid client),
+ *   - a brand whose goal cannot be read this boot: the next boot tries again rather than guess.
+ *
+ * Runs AFTER the port is bound, fire-and-forget: it makes N brand-service reads (one per
+ * distinct org+brand pair), and a slow or sleeping sibling must never delay a deploy.
+ */
+export async function backfillCampaignFunnelKeys(): Promise<{
+  scanned: number;
+  stamped: number;
+  undetermined: number;
+}> {
+  const rows = await db
+    .select({
+      id: campaigns.id,
+      orgId: campaigns.orgId,
+      brandIds: campaigns.brandIds,
+      goal: campaigns.goal,
+      createdByUserId: campaigns.createdByUserId,
+      workflowSlug: campaigns.workflowSlug,
+      featureSlug: campaigns.featureSlug,
+    })
+    .from(campaigns)
+    .where(
+      and(
+        isNull(campaigns.funnelKey),
+        inArray(campaigns.featureSlug, [...SALES_OUTREACH_FEATURE_SLUGS]),
+      ),
+    );
+
+  if (rows.length === 0) return { scanned: 0, stamped: 0, undetermined: 0 };
+
+  // One brand-service read per (org, brand) pair, not per campaign: the goal belongs to the
+  // pair, and a brand with 40 stopped campaigns must not cost 40 reads.
+  const brandGoals = new Map<string, string | null>();
+  let stamped = 0;
+  let undetermined = 0;
+
+  for (const row of rows) {
+    const brandId = row.brandIds?.[0];
+    if (!brandId) {
+      undetermined++;
+      continue;
+    }
+
+    const pair = `${row.orgId}::${brandId}`;
+    if (!brandGoals.has(pair)) {
+      brandGoals.set(
+        pair,
+        await readBrandGoal(brandId, {
+          orgId: row.orgId,
+          userId: row.createdByUserId,
+          campaignId: row.id,
+          workflowSlug: row.workflowSlug,
+          featureSlug: row.featureSlug,
+        }),
+      );
+    }
+
+    const funnelKey = resolveCampaignFunnelKey(row.goal, brandGoals.get(pair) ?? null);
+    if (!funnelKey) {
+      undetermined++;
+      continue;
+    }
+
+    await db
+      .update(campaigns)
+      .set({ funnelKey })
+      .where(and(eq(campaigns.id, row.id), isNull(campaigns.funnelKey)));
+    stamped++;
+  }
+
+  return { scanned: rows.length, stamped, undetermined };
+}
+
+/** Boot entry point: never throws, logs one summary line, never blocks the port. */
+export async function runFunnelBackfill(): Promise<void> {
+  try {
+    const { scanned, stamped, undetermined } = await backfillCampaignFunnelKeys();
+    if (scanned === 0) return; // already converged — say nothing
+    console.log(
+      `[campaign-service] funnel backfill: ${stamped}/${scanned} campaigns now state their funnel, ` +
+      `${undetermined} left null (their goal names no single funnel, or the brand could not be read)`,
+    );
+  } catch (err) {
+    console.error("[campaign-service] funnel backfill failed:", err);
+  }
+}

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -1,19 +1,17 @@
-import { and, arrayContains, desc, eq } from "drizzle-orm";
+import { and, arrayContains, asc, desc, eq, isNull } from "drizzle-orm";
 import { getStatsBudget, listRuns, type IdentityHeaders } from "@distribute/runs-client";
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { fetchFunnelBudgets, fundedFunnels, type FunnelBudget } from "./funnel-budget-client.js";
 import { fetchDeclaredSalesFunnels, type DeclaredSalesFunnel } from "./brand-sales-funnels-client.js";
 import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
+import { readBrandGoal, resolveCampaignFunnelKey } from "./funnel-adoption.js";
 
 // A campaign that did not get this brand's turn re-checks on the next active tick. The turn is
-// re-ranked from scratch every tick, so this is a "wait your turn", not a backoff.
+// re-ranked from scratch every tick, so this is a "wait your turn", not a backoff. EVERY alive
+// campaign of the brand is in the running every tick: none is ever held out because another one
+// covers its funnel.
 export const FUNNEL_TURN_DEFER_MS = 60_000; // 1 min
-
-// A campaign superseded by the brand's funnel campaigns (the pre-funnel, funnelKey=NULL one) is
-// not deleted or stopped — the customer may clear their per-funnel ceilings at any moment and
-// fall back to one brand-level pot. It just re-checks lazily instead of every minute.
-export const SUPERSEDED_DEFER_MS = 15 * 60_000; // 15 min
 
 /**
  * The campaign columns the turn planner reads. Structurally a subset of what the scheduler's
@@ -27,6 +25,7 @@ export interface ClaimedFunnelCampaign {
   brandIds: string[] | null;
   featureSlug: string | null;
   funnelKey: string | null;
+  goal?: string | null;
 }
 
 /** One funnel campaign in the running to take the brand's next turn. */
@@ -164,45 +163,48 @@ async function planOneBrand(
 
   const ceilingByFunnel = new Map(funded.map((f) => [f.funnelKey, f.dailyBudgetCents]));
 
-  // The pre-funnel campaign is superseded while funded funnels exist: its money has been
-  // allocated per funnel, so letting it run on the brand-level sum would let one campaign spend
-  // the whole day's allowance across every funnel at once.
-  const contenders: ClaimedFunnelCampaign[] = [];
-  for (const c of group) {
-    if (c.funnelKey && ceilingByFunnel.has(c.funnelKey)) contenders.push(c);
-    else deferred.set(c.id, new Date(now.getTime() + SUPERSEDED_DEFER_MS));
-  }
-  if (contenders.length === 0) return;
+  // The ceiling a campaign that states no funnel is paced on: the brand-level daily budget,
+  // which is exactly what gate-check enforces for it. Billing answers that total as the SUM of
+  // the per-funnel ceilings, so the sum is the honest stand-in when the total cannot be read.
+  const brandCeilingCents =
+    budgets.brandDailyBudgetCents ?? funded.reduce((sum, f) => sum + f.dailyBudgetCents, 0);
 
+  // EVERY alive campaign of the brand is in the running, every tick. There is no campaign held
+  // out because another one covers its funnel: each is ranked on what IT has already spent today
+  // against the ceiling that actually binds IT, so nothing starves and nothing overspends.
   const candidates: FunnelTurnCandidate[] = [];
-  for (const c of contenders) {
+  for (const c of group) {
     candidates.push({
       campaignId: c.id,
-      funnelKey: c.funnelKey!,
+      funnelKey: c.funnelKey ?? "",
       spentCents: await spentTodayCents(orgId, c.id, featureSlug),
-      ceilingCents: ceilingByFunnel.get(c.funnelKey!)!,
+      // A campaign on a funnel the customer does not fund gets a zero ceiling and yields its
+      // turn — that is the customer's funding decision, enforced fail-closed in the gate, and
+      // it re-checks every tick because funding can change at any minute.
+      ceilingCents: c.funnelKey ? (ceilingByFunnel.get(c.funnelKey) ?? 0) : brandCeilingCents,
     });
   }
 
   const winner = selectLowestFillRatio(candidates);
+  // Every funded funnel is at its ceiling — nothing runs until they reset at the day rollover.
+  const reset = winner === null ? nextDayStart(now) : null;
 
-  if (winner === null) {
-    // Every funded funnel is at its ceiling — nothing runs until the ceilings reset.
-    const reset = nextDayStart(now);
-    for (const c of contenders) deferred.set(c.id, reset);
-    return;
-  }
-
-  for (const c of contenders) {
-    if (c.id !== winner) deferred.set(c.id, new Date(now.getTime() + FUNNEL_TURN_DEFER_MS));
+  for (const c of candidates) {
+    if (c.campaignId === winner) continue;
+    const at =
+      reset && c.ceilingCents > 0 ? reset : new Date(now.getTime() + FUNNEL_TURN_DEFER_MS);
+    deferred.set(c.campaignId, at);
   }
 }
 
 /**
- * Give every funded funnel of the brand its own campaign, so the money spent on a funnel is
- * attributable to it. A campaign already carries a goal and already has costs attributed to it,
- * which is why one campaign per funnel answers "how much did this funnel spend today" without
- * inventing a new attribution dimension.
+ * Make sure every funded funnel of the brand HAS a campaign — the one that is already doing that
+ * funnel's work whenever there is one, and a new one only when there is not.
+ *
+ * A brand that has been running outreach for months keeps THAT campaign when it funds the funnel
+ * that campaign was already working: it becomes the funnel's campaign, keeping its id, its
+ * months of runs and every cost attributed to it. Standing up a second, empty campaign beside it
+ * left the working one looking dead and the live one looking like it had produced nothing.
  *
  * The campaign carries the funnel's OWN goal, which is also what stops it being goal-arbitrated:
  * a campaign that states its own goal is never arbitrated, so features-service keeps answering
@@ -234,6 +236,22 @@ async function ensureFundedFunnelCampaigns({
 
   const goalByFunnel = new Map(declared.map((f) => [f.funnelKey, f.goal]));
 
+  // The brand's goal is what tells us which funnel a campaign that states none is already
+  // working. Read at most once per brand per tick, and only when there is something to adopt.
+  let brandGoal: string | null | undefined;
+  const brandGoalOnce = async (): Promise<string | null> => {
+    if (brandGoal === undefined) {
+      brandGoal = await readBrandGoal(brandId, {
+        orgId: seed.orgId,
+        userId: seed.createdByUserId,
+        campaignId: seed.id,
+        workflowSlug: seed.workflowSlug,
+        featureSlug,
+      });
+    }
+    return brandGoal;
+  };
+
   for (const f of funded) {
     const goal = goalByFunnel.get(f.funnelKey);
     if (!goal) continue;
@@ -247,6 +265,39 @@ async function ensureFundedFunnelCampaigns({
       ),
       orderBy: [desc(campaigns.createdAt)],
     });
+
+    // Whichever alive campaign is already doing this funnel's work owns the funnel — the oldest
+    // one, i.e. the one carrying the history. Checked even when a funnel campaign exists, so a
+    // brand that already grew an empty duplicate is repaired rather than left with two.
+    const incumbent = await findIncumbentForFunnel({
+      orgId: seed.orgId,
+      brandId,
+      featureSlug,
+      funnelKey: f.funnelKey,
+      excludeId: existing?.id,
+      brandGoalOnce,
+    });
+
+    if (incumbent) {
+      await db
+        .update(campaigns)
+        .set({ funnelKey: f.funnelKey, goal, updatedAt: now })
+        .where(and(eq(campaigns.id, incumbent.id), eq(campaigns.orgId, seed.orgId)));
+      // An empty campaign this service stood up for a funnel its incumbent was already working
+      // is this bug's own leftover: it never ran and never spent, and leaving it would keep two
+      // campaigns on one funnel. Nothing that ever ran is ever removed — see isRemovableStandIn.
+      if (existing && (await isRemovableStandIn(existing, seed.orgId, brandId, featureSlug))) {
+        await db
+          .delete(campaigns)
+          .where(and(eq(campaigns.id, existing.id), eq(campaigns.orgId, seed.orgId)));
+        console.log(
+          `[campaign-service] funnel ${f.funnelKey} of brand ${brandId}: kept campaign ${incumbent.id} ` +
+          `(its own history) and dropped the empty stand-in ${existing.id} (never ran, never spent)`,
+        );
+      }
+      continue;
+    }
+
     if (existing) {
       // A funnel the customer re-funded after switching it off resumes rather than duplicating.
       if (existing.status !== "ongoing") {
@@ -291,6 +342,94 @@ async function ensureFundedFunnelCampaigns({
 
 export function funnelCampaignName(featureSlug: string, brandId: string, funnelKey: string): string {
   return `${featureSlug} - ${brandId} - ${funnelKey}`;
+}
+
+/**
+ * The alive campaign already doing this funnel's work and not yet stating it.
+ *
+ * "Already doing this funnel's work" is decided by the goal the campaign runs on — its own when
+ * it states one, the brand's otherwise — read through the funnel vocabulary. The OLDEST match
+ * wins: it is the one carrying the history, the spend and the results.
+ *
+ * Only `ongoing` campaigns are adopted. A stopped campaign is not doing the funnel's work, and
+ * adopting one would restart something the customer switched off.
+ */
+async function findIncumbentForFunnel({
+  orgId,
+  brandId,
+  featureSlug,
+  funnelKey,
+  excludeId,
+  brandGoalOnce,
+}: {
+  orgId: string;
+  brandId: string;
+  featureSlug: string;
+  funnelKey: string;
+  excludeId?: string;
+  brandGoalOnce: () => Promise<string | null>;
+}): Promise<{ id: string } | null> {
+  const funnelless = await db.query.campaigns.findMany({
+    where: and(
+      eq(campaigns.orgId, orgId),
+      eq(campaigns.featureSlug, featureSlug),
+      eq(campaigns.status, "ongoing"),
+      isNull(campaigns.funnelKey),
+      arrayContains(campaigns.brandIds, [brandId]),
+    ),
+    orderBy: [asc(campaigns.createdAt)],
+  });
+
+  const candidates = funnelless.filter((c) => c.id !== excludeId);
+  if (candidates.length === 0) return null;
+
+  const brandGoal = await brandGoalOnce();
+  for (const c of candidates) {
+    if (resolveCampaignFunnelKey(c.goal, brandGoal) === funnelKey) return { id: c.id };
+  }
+  return null;
+}
+
+/**
+ * True only for a campaign THIS service stood up for a funnel and that has never done anything:
+ * the name it was provisioned under, no run of its own in runs-service, and no cost attributed
+ * to it. Such a row is this bug's own leftover, created within hours of the incumbent being
+ * parked, and removing it is undoing our write — never a customer's campaign.
+ *
+ * Every condition is required and every read fails CLOSED: an unreadable run list or spend
+ * figure answers "not removable", so nothing is ever removed on a blind guess.
+ */
+async function isRemovableStandIn(
+  existing: { id: string; name: string },
+  orgId: string,
+  brandId: string,
+  featureSlug: string,
+): Promise<boolean> {
+  const provisionedNames = new Set(
+    ["reply_meeting", "visit_meeting", "visit_signup", "visit_form"].map((k) =>
+      funnelCampaignName(featureSlug, brandId, k),
+    ),
+  );
+  if (!provisionedNames.has(existing.name)) return false;
+
+  try {
+    const { runs } = await listRuns({ orgId, campaignId: existing.id, limit: 1 });
+    if (runs.length > 0) return false;
+
+    const budget = await getStatsBudget({
+      orgId,
+      campaignId: existing.id,
+      featureSlug,
+      windows: [{ label: "lifetime", since: new Date(0).toISOString() }],
+    });
+    const lifetime = budget.windows.find((w) => w.label === "lifetime");
+    const spent = lifetime
+      ? parseFloat(lifetime.netTotalCostInUsdCents ?? lifetime.totalCostInUsdCents) || 0
+      : 0;
+    return spent === 0;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -248,6 +248,16 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
         if (!budgets.ok) {
           return { allowed: false, reason: "Funnel daily budget unavailable" };
         }
+        // This brand funds NO funnel separately. Every campaign states the funnel it runs so no
+        // consumer has to infer it from a goal — but for a brand with one pot that statement is
+        // a LABEL, not a ceiling: the money is still the brand-level daily budget, and this
+        // campaign paces on it exactly as it did before it stated a funnel. Nothing about how a
+        // FUNDED funnel's ceiling is enforced changes.
+        if (budgets.funnels.length === 0) {
+          const blocked = await brandDailyBudgetBlock(campaign, identity, brandId);
+          if (blocked) return blocked;
+          continue;
+        }
         const ceilingCents = budgets.funnels.find(f => f.funnelKey === campaign.funnelKey)?.dailyBudgetCents ?? null;
         // A funnel funded at zero — or no longer funded at all — is never run. That is a
         // deliberate customer decision, not a missing value, so it is not a fallback to the
@@ -260,53 +270,12 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
         }
       }
     } else {
-    // (b) Fall back to the per-brand daily budget. Multi-brand tick: blocked if ANY in-scope
-    // brand has reached its ceiling (most campaigns are solo-brand).
-    for (const brandId of campaign.brandIds) {
-      const dailyBudget = await getBrandDailyBudget(brandId, identity);
-      if (!dailyBudget.ok) {
-        return { allowed: false, reason: "Brand daily budget unavailable" };
+      // (b) Fall back to the per-brand daily budget. Multi-brand tick: blocked if ANY in-scope
+      // brand has reached its ceiling (most campaigns are solo-brand).
+      for (const brandId of campaign.brandIds) {
+        const blocked = await brandDailyBudgetBlock(campaign, identity, brandId);
+        if (blocked) return blocked;
       }
-
-      const dailyBudgetCents = dailyBudget.dailyBudgetCents;
-      if (dailyBudgetCents === null) continue; // explicitly unset → no cap this tick
-
-      const brandSpend = await getStatsBudget({
-        orgId: campaign.orgId,
-        brandId,
-        featureSlug: campaign.featureSlug,
-        windows: [{ label: "today", since: startOfToday().toISOString() }],
-      });
-      const today = brandSpend.windows.find(w => w.label === "today");
-      // Pace on COMMITTED spend = actual + provisioned (the window's totalCostInUsdCents).
-      // This DELIBERATELY REVERSES #223 ("pace on actual, not actual+provisioned") FOR THIS
-      // per-brand daily cap ONLY. #223's concern was real: a provisioned row can be a worst-case
-      // affordability RESERVATION (an LLM call reserves ~26¢, reconciles to ~0.7¢, then cancels
-      // the hold), so counting open holds could block on phantom spend for ~15min until the day
-      // rolls over. The product owner has weighed that tradeoff and accepted it: in practice the
-      // bulk of the committed-minus-actual gap is genuine instantly-account-email-sent holds for
-      // already-scheduled follow-up sends (real future spend), and the dashboard already shows
-      // the brand's "Budget spent today" as this same committed number. Pacing the cap on
-      // committed makes the enforced ceiling match what the customer sees and stops a campaign
-      // from committing NEW work above the daily budget while reserved follow-up holds sit
-      // uncounted. The worst-case-LLM-hold over-block is the accepted cost of that alignment.
-      // checkAffordability below stays the hard money gate (org credit balance); this is daily
-      // pacing. NOTE: the campaign budget WINDOWS (block 3 above) — daily, weekly, monthly AND
-      // total — now ALL pace on committed too, for full coherence with the dashboard.
-      // NET committed (post-usage-discount): the brand daily budget is what the org PAYS,
-      // so pace on the net twin, not gross list price. A 50%-discounted brand must be able
-      // to run until net spend reaches the daily cap; pacing on gross stopped it at half.
-      // The dashboard "Budget spent today" reads features-service /revenue with pricing=net
-      // for the same reason, keeping the enforced ceiling coherent with what the customer sees.
-      // Fallback to gross only if an older runs-service omits the net twin (safe: stops earlier).
-      const spentCents = today
-        ? parseFloat(today.netTotalCostInUsdCents ?? today.totalCostInUsdCents) || 0
-        : 0;
-
-      if (spentCents >= dailyBudgetCents) {
-        return { allowed: false, reason: "Brand daily budget reached" };
-      }
-    }
     }
   }
 
@@ -521,4 +490,62 @@ export function nextMonthStart(): Date {
   d.setDate(1);
   d.setHours(0, 0, 0, 0);
   return d;
+}
+
+/**
+ * The per-brand daily budget check, for a campaign that is not paced on a ceiling of its own.
+ *
+ * Returns the blocking result, or null when this brand does not stop the tick. Fail-CLOSED on an
+ * unreadable cap: spend control must never read "cannot tell" as "unbounded".
+ */
+async function brandDailyBudgetBlock(
+  campaign: GateCheckInput,
+  identity: IdentityHeaders,
+  brandId: string,
+): Promise<GateCheckResult | null> {
+  const dailyBudget = await getBrandDailyBudget(brandId, identity);
+  if (!dailyBudget.ok) {
+    return { allowed: false, reason: "Brand daily budget unavailable" };
+  }
+
+  const dailyBudgetCents = dailyBudget.dailyBudgetCents;
+  if (dailyBudgetCents === null) return null; // explicitly unset → no cap this tick
+
+  const brandSpend = await getStatsBudget({
+    orgId: campaign.orgId,
+    brandId,
+    featureSlug: campaign.featureSlug,
+    windows: [{ label: "today", since: startOfToday().toISOString() }],
+  });
+  const today = brandSpend.windows.find(w => w.label === "today");
+  // Pace on COMMITTED spend = actual + provisioned (the window's totalCostInUsdCents).
+  // This DELIBERATELY REVERSES #223 ("pace on actual, not actual+provisioned") FOR THIS
+  // per-brand daily cap ONLY. #223's concern was real: a provisioned row can be a worst-case
+  // affordability RESERVATION (an LLM call reserves ~26¢, reconciles to ~0.7¢, then cancels
+  // the hold), so counting open holds could block on phantom spend for ~15min until the day
+  // rolls over. The product owner has weighed that tradeoff and accepted it: in practice the
+  // bulk of the committed-minus-actual gap is genuine instantly-account-email-sent holds for
+  // already-scheduled follow-up sends (real future spend), and the dashboard already shows
+  // the brand's "Budget spent today" as this same committed number. Pacing the cap on
+  // committed makes the enforced ceiling match what the customer sees and stops a campaign
+  // from committing NEW work above the daily budget while reserved follow-up holds sit
+  // uncounted. The worst-case-LLM-hold over-block is the accepted cost of that alignment.
+  // checkAffordability below stays the hard money gate (org credit balance); this is daily
+  // pacing. NOTE: the campaign budget WINDOWS (block 3 above) — daily, weekly, monthly AND
+  // total — now ALL pace on committed too, for full coherence with the dashboard.
+  // NET committed (post-usage-discount): the brand daily budget is what the org PAYS,
+  // so pace on the net twin, not gross list price. A 50%-discounted brand must be able
+  // to run until net spend reaches the daily cap; pacing on gross stopped it at half.
+  // The dashboard "Budget spent today" reads features-service /revenue with pricing=net
+  // for the same reason, keeping the enforced ceiling coherent with what the customer sees.
+  // Fallback to gross only if an older runs-service omits the net twin (safe: stops earlier).
+  const spentCents = today
+    ? parseFloat(today.netTotalCostInUsdCents ?? today.totalCostInUsdCents) || 0
+    : 0;
+
+  if (spentCents >= dailyBudgetCents) {
+    return { allowed: false, reason: "Brand daily budget reached" };
+  }
+
+  return null;
 }

--- a/src/lib/sales-funnel-vocabulary.ts
+++ b/src/lib/sales-funnel-vocabulary.ts
@@ -1,0 +1,60 @@
+/**
+ * Which sales funnel a campaign's optimization goal means.
+ *
+ * A campaign used to say what it was for in the GOAL vocabulary ("form submissions", "booked
+ * meeting", "website purchase"). brand-service now speaks FUNNELS — one named chain from the
+ * first signal outreach can buy down to a paid client — and a campaign states the funnel it
+ * runs on its own row (`campaigns.funnel_key`). This map is the one place the old word is read
+ * as the new one, and it exists to REWRITE stored rows once, not to translate on read: after
+ * the backfill, every determinable campaign carries its funnel and no consumer has to infer it.
+ *
+ * The three mappings are brand-service's own catalogue (`salesFunnelCatalogue.ts`), plus one
+ * owner decision (2026-08-02): a booked-meeting campaign runs `reply_meeting` ("Sales Meeting
+ * from Conversation"), never `visit_meeting`. Both funnels optimize for `meetingBooked`, but
+ * these campaigns are cold email — the chain that actually ran is reply → meeting, not a
+ * website visit.
+ *
+ * Every accepted spelling brand-service still takes on write (`goal-vocabulary.ts`
+ * LEGACY_OPTIMIZATION_GOALS) is listed, because a stored row may carry any of them.
+ *
+ * A goal that names no single funnel is ABSENT here on purpose and resolves to null:
+ *   - `combinedSales` spans several funnels at once,
+ *   - `websiteVisit`, `positiveReply`, `whatsappConversation` stop short of a paid client.
+ * Those campaigns keep a NULL funnel. Inventing one would state a chain the customer never
+ * declared, and the funnel is a stored fact, not a guess.
+ */
+const FUNNEL_BY_GOAL: Readonly<Record<string, string>> = Object.freeze({
+  // Form Magnet — website visit → form filled → paid client.
+  formSubmission: "visit_form",
+  form_submissions: "visit_form",
+
+  // Sales Meeting from Conversation — positive reply → meeting booked → attended → paid client.
+  meetingBooked: "reply_meeting",
+  booked_meetings: "reply_meeting",
+  sales_meetings: "reply_meeting",
+
+  // Website Purchase — website visit → signup → paid client. `signup` is the goal
+  // brand-service's catalogue puts on this funnel; `websitePurchase` (and its older spellings)
+  // is what the same chain is called on screen. Both name this one funnel.
+  signup: "visit_signup",
+  signups: "visit_signup",
+  websitePurchase: "visit_signup",
+  website_purchase: "visit_signup",
+  purchase: "visit_signup",
+  sales: "visit_signup",
+});
+
+/**
+ * The funnel this goal runs, or null when the goal names no single funnel.
+ *
+ * Never guesses: an unknown or absent goal returns null and the campaign keeps a NULL funnel.
+ */
+export function funnelForGoal(goal: string | null | undefined): string | null {
+  if (!goal) return null;
+  return FUNNEL_BY_GOAL[goal] ?? null;
+}
+
+/** Every goal spelling that determines a funnel — the SQL backfill enumerates the same list. */
+export function goalsWithAFunnel(): string[] {
+  return Object.keys(FUNNEL_BY_GOAL);
+}

--- a/tests/unit/funnel-backfill.test.ts
+++ b/tests/unit/funnel-backfill.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockSelectWhere, mockUpdateSet, mockUpdateWhere } = vi.hoisted(() => ({
+  mockSelectWhere: vi.fn(),
+  mockUpdateSet: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+}));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: mockSelectWhere }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: (values: unknown) => {
+        mockUpdateSet(values);
+        return { where: mockUpdateWhere };
+      },
+    }),
+  },
+}));
+
+vi.mock("../../src/db/schema.js", () => ({
+  campaigns: {
+    id: "id",
+    orgId: "org_id",
+    brandIds: "brand_ids",
+    goal: "goal",
+    funnelKey: "funnel_key",
+    createdByUserId: "created_by_user_id",
+    workflowSlug: "workflow_slug",
+    featureSlug: "feature_slug",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  isNull: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { backfillCampaignFunnelKeys } from "../../src/lib/funnel-backfill.js";
+
+const SALES = "sales-cold-email-outreach";
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "c-1",
+    orgId: "org-1",
+    brandIds: ["brand-1"],
+    goal: null,
+    createdByUserId: "user-1",
+    workflowSlug: "sales-email-cold-outreach",
+    featureSlug: SALES,
+    ...overrides,
+  };
+}
+
+function mockBrandGoal(goal: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ brand: {}, currentGoal: goal, brandProfile: null }),
+  });
+}
+
+describe("backfillCampaignFunnelKeys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.BRAND_SERVICE_URL = "https://brand.test.local";
+    process.env.BRAND_SERVICE_API_KEY = "brand-key";
+    mockUpdateWhere.mockResolvedValue(undefined);
+  });
+
+  it("writes the funnel a campaign runs onto its own row, from the brand's goal", async () => {
+    mockSelectWhere.mockResolvedValue([row()]);
+    mockBrandGoal("formSubmission");
+
+    const result = await backfillCampaignFunnelKeys();
+
+    expect(mockUpdateSet).toHaveBeenCalledWith({ funnelKey: "visit_form" });
+    expect(result).toEqual({ scanned: 1, stamped: 1, undetermined: 0 });
+  });
+
+  it("prefers the campaign's own goal when it states one", async () => {
+    mockSelectWhere.mockResolvedValue([row({ goal: "meetingBooked" })]);
+    mockBrandGoal("formSubmission");
+
+    await backfillCampaignFunnelKeys();
+
+    expect(mockUpdateSet).toHaveBeenCalledWith({ funnelKey: "reply_meeting" });
+  });
+
+  it("reads brand-service ONCE per (org, brand) pair, not once per campaign", async () => {
+    mockSelectWhere.mockResolvedValue([
+      row({ id: "c-1" }),
+      row({ id: "c-2" }),
+      row({ id: "c-3" }),
+    ]);
+    mockBrandGoal("formSubmission");
+
+    await backfillCampaignFunnelKeys();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSet).toHaveBeenCalledTimes(3);
+  });
+
+  it("names the org on the brand read — the goal belongs to the (org, brand) pair", async () => {
+    mockSelectWhere.mockResolvedValue([row()]);
+    mockBrandGoal("formSubmission");
+
+    await backfillCampaignFunnelKeys();
+
+    const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org-1");
+    expect(headers["x-brand-id"]).toBe("brand-1");
+  });
+
+  it("leaves a goal that names no single funnel alone rather than inventing one", async () => {
+    mockSelectWhere.mockResolvedValue([row({ goal: "combinedSales" })]);
+    mockBrandGoal("combinedSales");
+
+    const result = await backfillCampaignFunnelKeys();
+
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 1, stamped: 1 - 1, undetermined: 1 });
+  });
+
+  it("leaves a campaign alone when the brand cannot be read — the next boot tries again", async () => {
+    mockSelectWhere.mockResolvedValue([row()]);
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 503, text: async () => "down" });
+
+    const result = await backfillCampaignFunnelKeys();
+
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+    expect(result.undetermined).toBe(1);
+  });
+
+  it("does nothing at all once every campaign states its funnel", async () => {
+    mockSelectWhere.mockResolvedValue([]);
+
+    const result = await backfillCampaignFunnelKeys();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 0, stamped: 0, undetermined: 0 });
+  });
+});

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -4,14 +4,20 @@ const {
   mockListRuns,
   mockGetStatsBudget,
   mockFindFirst,
+  mockFindMany,
   mockInsertValues,
+  mockUpdateSet,
   mockUpdateWhere,
+  mockDeleteWhere,
 } = vi.hoisted(() => ({
   mockListRuns: vi.fn(),
   mockGetStatsBudget: vi.fn(),
   mockFindFirst: vi.fn(),
+  mockFindMany: vi.fn(),
   mockInsertValues: vi.fn(),
+  mockUpdateSet: vi.fn(),
   mockUpdateWhere: vi.fn(),
+  mockDeleteWhere: vi.fn(),
 }));
 
 vi.mock("@distribute/runs-client", () => ({
@@ -21,11 +27,15 @@ vi.mock("@distribute/runs-client", () => ({
 
 vi.mock("../../src/db/index.js", () => ({
   db: {
-    query: { campaigns: { findFirst: mockFindFirst } },
+    query: { campaigns: { findFirst: mockFindFirst, findMany: mockFindMany } },
     insert: vi.fn().mockReturnValue({ values: mockInsertValues }),
     update: vi.fn().mockReturnValue({
-      set: vi.fn().mockReturnValue({ where: mockUpdateWhere }),
+      set: (values: unknown) => {
+        mockUpdateSet(values);
+        return { where: mockUpdateWhere };
+      },
     }),
+    delete: vi.fn().mockReturnValue({ where: mockDeleteWhere }),
   },
 }));
 
@@ -37,13 +47,17 @@ vi.mock("../../src/db/schema.js", () => ({
     funnelKey: "funnel_key",
     brandIds: "brand_ids",
     createdAt: "created_at",
+    status: "status",
+    goal: "goal",
   },
 }));
 
 vi.mock("drizzle-orm", () => ({
   and: vi.fn(),
   eq: vi.fn(),
+  asc: vi.fn(),
   desc: vi.fn(),
+  isNull: vi.fn(),
   arrayContains: vi.fn(),
 }));
 
@@ -55,7 +69,6 @@ import {
   selectLowestFillRatio,
   funnelCampaignName,
   FUNNEL_TURN_DEFER_MS,
-  SUPERSEDED_DEFER_MS,
   type ClaimedFunnelCampaign,
 } from "../../src/lib/funnel-campaigns.js";
 
@@ -92,6 +105,13 @@ function mockDeclaredFunnels(funnels: Array<{ funnelKey: string; goal: string; a
       declared: funnels.length > 0,
       funnels: funnels.map(f => ({ ...f, active: f.active ?? true, currentGoal: f.goal })),
     }),
+  });
+}
+
+function mockBrandGoal(goal: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ brand: {}, currentGoal: goal, brandProfile: null }),
   });
 }
 
@@ -163,9 +183,12 @@ describe("planFunnelTurns", () => {
     process.env.BRAND_SERVICE_URL = "https://brand.test.local";
     process.env.BRAND_SERVICE_API_KEY = "brand-key";
     mockListRuns.mockResolvedValue({ runs: [] });
-    mockFindFirst.mockResolvedValue({ id: "existing", status: "ongoing" });
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "custom name", status: "ongoing" });
+    // No funnel-less campaign to adopt unless a test says otherwise.
+    mockFindMany.mockResolvedValue([]);
     mockInsertValues.mockResolvedValue(undefined);
     mockUpdateWhere.mockResolvedValue(undefined);
+    mockDeleteWhere.mockResolvedValue(undefined);
   });
 
   it("leaves non-sales campaigns entirely alone", async () => {
@@ -304,10 +327,116 @@ describe("planFunnelTurns", () => {
     for (const at of deferred.values()) expect(at.getTime()).toBeGreaterThan(now.getTime());
   });
 
-  it("supersedes the pre-funnel campaign once funnels are funded", async () => {
+  it("keeps the campaign already doing the funnel's work instead of standing up a second one", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
+    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockFindFirst.mockResolvedValue(undefined); // no campaign states this funnel yet
+    mockFindMany.mockResolvedValue([
+      // The months-old campaign, running on the brand's goal, carrying all the history.
+      { id: "c-incumbent", name: "opsfolio.com — Signups", goal: null, status: "ongoing" },
+    ]);
+    mockBrandGoal("formSubmission");
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ id: "c-incumbent" })], new Date("2026-08-02T10:00:00Z"));
+
+    // Adopted, not duplicated: same campaign id, now stating the funnel and its goal.
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ funnelKey: "visit_form", goal: "formSubmission" }),
+    );
+  });
+
+  it("adopts the OLDEST match — the one carrying the history", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
+    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+    mockFindMany.mockResolvedValue([
+      { id: "c-oldest", name: "the one with the history", goal: null, status: "ongoing" },
+      { id: "c-newer", name: "a later one", goal: null, status: "ongoing" },
+    ]);
+    mockBrandGoal("formSubmission");
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ id: "c-oldest" })], new Date("2026-08-02T10:00:00Z"));
+
+    expect(mockUpdateWhere).toHaveBeenCalled();
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ funnelKey: "visit_form" }),
+    );
+    // findMany is ordered by createdAt asc, so the first match is the oldest.
+    expect(mockFindMany).toHaveBeenCalled();
+  });
+
+  it("never adopts a campaign whose goal names a different funnel", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
+    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+    mockFindMany.mockResolvedValue([
+      { id: "c-meetings", name: "meetings", goal: "meetingBooked", status: "ongoing" },
+    ]);
+    mockBrandGoal("meetingBooked");
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ id: "c-meetings" })], new Date("2026-08-02T10:00:00Z"));
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(1);
+    expect(mockInsertValues.mock.calls[0][0].funnelKey).toBe("visit_form");
+  });
+
+  it("drops the empty stand-in it created for a funnel the incumbent was already working", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
+    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockFindFirst.mockResolvedValue({
+      id: "c-standin",
+      name: funnelCampaignName(SALES, "brand-1", "visit_form"),
+      status: "ongoing",
+    });
+    mockFindMany.mockResolvedValue([
+      { id: "c-incumbent", name: "opsfolio.com — Signups", goal: null, status: "ongoing" },
+    ]);
+    mockBrandGoal("formSubmission");
+    mockListRuns.mockResolvedValueOnce({ runs: [] }); // the stand-in never ran
+    mockGetStatsBudget.mockResolvedValueOnce({
+      windows: [{ label: "lifetime", totalCostInUsdCents: "0", netTotalCostInUsdCents: "0" }],
+    });
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ id: "c-incumbent" })], new Date("2026-08-02T10:00:00Z"));
+
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ funnelKey: "visit_form", goal: "formSubmission" }),
+    );
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it("never drops a stand-in that has ever run", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
+    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockFindFirst.mockResolvedValue({
+      id: "c-standin",
+      name: funnelCampaignName(SALES, "brand-1", "visit_form"),
+      status: "ongoing",
+    });
+    mockFindMany.mockResolvedValue([
+      { id: "c-incumbent", name: "opsfolio.com — Signups", goal: null, status: "ongoing" },
+    ]);
+    mockBrandGoal("formSubmission");
+    mockListRuns.mockResolvedValueOnce({ runs: [{ id: "it-ran" }] });
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ id: "c-incumbent" })], new Date("2026-08-02T10:00:00Z"));
+
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+
+  it("holds no campaign out of the running — one that states no funnel still takes turns", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
     mockDeclaredFunnels([{ funnelKey: "visit_signup", goal: "signup" }]);
-    mockSpend("0");
+    mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
+    mockFindMany.mockResolvedValue([]);
+    mockSpend("900"); // c-legacy: 90% of the brand total
+    mockSpend("100"); // c-visit: 10% of its own ceiling
 
     const now = new Date("2026-08-02T10:00:00Z");
     const deferred = await planFunnelTurns(
@@ -318,9 +447,53 @@ describe("planFunnelTurns", () => {
       now,
     );
 
-    // The legacy campaign paces on the brand-level SUM — letting it run would spend every
-    // funnel's allowance at once.
-    expect(deferred.get("c-legacy")?.getTime()).toBe(now.getTime() + SUPERSEDED_DEFER_MS);
+    // The emptiest relative to its OWN ceiling takes the turn; the other waits ONE minute and is
+    // re-ranked from scratch next tick. Nothing is parked because another campaign exists.
     expect(deferred.has("c-visit")).toBe(false);
+    expect(deferred.get("c-legacy")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
+  });
+
+  it("a campaign that states no funnel can win the turn", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+    mockDeclaredFunnels([{ funnelKey: "visit_signup", goal: "signup" }]);
+    mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
+    mockFindMany.mockResolvedValue([]);
+    mockSpend("0");   // c-legacy: nothing spent
+    mockSpend("900"); // c-visit: 90% full
+
+    const now = new Date("2026-08-02T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-legacy", funnelKey: null }),
+        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
+      ],
+      now,
+    );
+
+    expect(deferred.has("c-legacy")).toBe(false);
+    expect(deferred.get("c-visit")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
+  });
+
+  it("re-checks a campaign on an unfunded funnel every tick, never parks it for the day", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+    mockDeclaredFunnels([{ funnelKey: "visit_signup", goal: "signup" }]);
+    mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
+    mockFindMany.mockResolvedValue([]);
+    mockSpend("1200"); // the funded funnel is over its ceiling
+    mockSpend("0");    // the unfunded one has spent nothing, but has no ceiling to fill
+
+    const now = new Date("2026-08-02T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
+        claimed({ id: "c-unfunded", funnelKey: "reply_meeting" }),
+      ],
+      now,
+    );
+
+    // The funded-but-full one waits for the day rollover; the unfunded one re-checks in a minute
+    // because its funding can change at any moment (and the gate is what refuses to spend).
+    expect(deferred.get("c-visit")!.getTime()).toBeGreaterThan(now.getTime() + FUNNEL_TURN_DEFER_MS);
+    expect(deferred.get("c-unfunded")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
   });
 });

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -635,6 +635,39 @@ describe("Gate Check", () => {
       expect(result.reason).toBe("Funnel not funded");
     });
 
+    it("a brand that funds no funnel separately paces on its brand budget, funnel or not", async () => {
+      // Every campaign states the funnel it runs so no consumer has to infer it. For a brand
+      // with ONE pot that statement is a label, not a ceiling: the money is still the brand
+      // daily budget, exactly as before the campaign stated anything.
+      mockFunnelBudgets([], "3000");
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ brandId: "brand-1", dailyBudgetCents: "1000", updatedAt: null }),
+      });
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "1500" }]),
+      );
+
+      const result = await runGateChecks(funnelCampaign());
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Brand daily budget reached");
+    });
+
+    it("allows a funnel-stating campaign under its brand budget when no funnel is funded", async () => {
+      mockFunnelBudgets([], "3000");
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ brandId: "brand-1", dailyBudgetCents: "1000", updatedAt: null }),
+      });
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "10" }]),
+      );
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ affordable: true }) });
+
+      const result = await runGateChecks(funnelCampaign());
+      expect(result.allowed).toBe(true);
+    });
+
     it("fails CLOSED when the per-funnel ceilings cannot be read", async () => {
       mockFetch.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
 

--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -26,6 +26,32 @@ describe('No Legacy Patterns - CRITICAL', () => {
     return files;
   }
 
+  it('should NOT carry a superseded-campaign concept anywhere in src', () => {
+    // A campaign is never parked, deferred on a slow re-check loop, or held out of the running
+    // because another campaign covers its funnel. Every alive campaign is re-ranked from scratch
+    // every tick. The concept — and the word — must not come back.
+    const files = getAllTsFiles(srcDir);
+    const violations: { file: string; line: number; code: string }[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      content.split('\n').forEach((line, index) => {
+        if (/supersed/i.test(line)) {
+          violations.push({
+            file: path.relative(srcDir, file),
+            line: index + 1,
+            code: line.trim().substring(0, 80),
+          });
+        }
+      });
+    }
+
+    expect(
+      violations,
+      `A campaign is never superseded:\n${violations.map(v => `  ${v.file}:${v.line}\n    ${v.code}`).join('\n')}`
+    ).toHaveLength(0);
+  });
+
   it('should NOT have brandUrl query parameter filtering in routes', () => {
     const routesDir = path.join(srcDir, 'routes');
     const files = getAllTsFiles(routesDir);

--- a/tests/unit/sales-funnel-vocabulary.test.ts
+++ b/tests/unit/sales-funnel-vocabulary.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { funnelForGoal, goalsWithAFunnel } from "../../src/lib/sales-funnel-vocabulary.js";
+import { resolveCampaignFunnelKey } from "../../src/lib/funnel-adoption.js";
+
+describe("the funnel a goal means", () => {
+  it("form submissions run the Form Magnet funnel", () => {
+    expect(funnelForGoal("formSubmission")).toBe("visit_form");
+    expect(funnelForGoal("form_submissions")).toBe("visit_form");
+  });
+
+  it("a booked meeting runs Sales Meeting from Conversation — cold email replies, not the website", () => {
+    expect(funnelForGoal("meetingBooked")).toBe("reply_meeting");
+    expect(funnelForGoal("booked_meetings")).toBe("reply_meeting");
+    expect(funnelForGoal("sales_meetings")).toBe("reply_meeting");
+  });
+
+  it("a website purchase runs Website Purchase, under either spelling of that chain", () => {
+    expect(funnelForGoal("websitePurchase")).toBe("visit_signup");
+    expect(funnelForGoal("website_purchase")).toBe("visit_signup");
+    expect(funnelForGoal("purchase")).toBe("visit_signup");
+    expect(funnelForGoal("sales")).toBe("visit_signup");
+    expect(funnelForGoal("signup")).toBe("visit_signup");
+    expect(funnelForGoal("signups")).toBe("visit_signup");
+  });
+
+  it("never invents a funnel for a goal that names none", () => {
+    for (const goal of ["combinedSales", "websiteVisit", "positiveReply", "whatsappConversation"]) {
+      expect(funnelForGoal(goal)).toBeNull();
+    }
+    expect(funnelForGoal(null)).toBeNull();
+    expect(funnelForGoal(undefined)).toBeNull();
+    expect(funnelForGoal("")).toBeNull();
+    expect(funnelForGoal("something-nobody-has-named")).toBeNull();
+  });
+
+  it("emits only funnel keys brand-service's catalogue declares", () => {
+    const catalogue = new Set(["reply_meeting", "visit_meeting", "visit_signup", "visit_form"]);
+    for (const goal of goalsWithAFunnel()) {
+      expect(catalogue.has(funnelForGoal(goal)!)).toBe(true);
+    }
+  });
+});
+
+describe("resolveCampaignFunnelKey", () => {
+  it("prefers the campaign's own goal over its brand's", () => {
+    expect(resolveCampaignFunnelKey("meetingBooked", "formSubmission")).toBe("reply_meeting");
+  });
+
+  it("falls back to the brand's goal when the campaign states none", () => {
+    expect(resolveCampaignFunnelKey(null, "formSubmission")).toBe("visit_form");
+  });
+
+  it("stays null when neither names a funnel", () => {
+    expect(resolveCampaignFunnelKey(null, "combinedSales")).toBeNull();
+    expect(resolveCampaignFunnelKey(null, null)).toBeNull();
+  });
+});
+
+describe("0042_campaign_funnel_from_goal migration", () => {
+  const sql = readFileSync(
+    resolve(__dirname, "../../drizzle/0042_campaign_funnel_from_goal.sql"),
+    "utf-8",
+  );
+
+  it("writes the same funnel the code reads for every goal that names one", () => {
+    for (const goal of goalsWithAFunnel()) {
+      expect(sql).toContain(`'${goal}'`);
+      expect(sql).toContain(`THEN '${funnelForGoal(goal)}'`);
+    }
+  });
+
+  it("only touches rows that state no funnel yet — idempotent, re-runnable", () => {
+    expect(sql).toContain('"funnel_key" IS NULL');
+  });
+
+  it("never deletes, stops or reschedules a campaign", () => {
+    const statements = sql
+      .split("\n")
+      .filter((l) => !l.trimStart().startsWith("--"))
+      .join("\n");
+    const upper = statements.toUpperCase();
+    expect(upper).not.toContain("DELETE");
+    expect(upper).not.toContain("DROP");
+    expect(upper).not.toContain("STATUS");
+    expect(upper).not.toContain("NEXT_RUN_AT");
+  });
+
+  it("maps no goal that names several funnels or stops short of a paid client", () => {
+    for (const goal of ["combinedSales", "websiteVisit", "positiveReply", "whatsappConversation"]) {
+      expect(sql).not.toContain(`'${goal}'`);
+    }
+  });
+});


### PR DESCRIPTION
## What was wrong

Brand `6e21bb6c-67bc-45f3-8a6d-52230338d7e4` (org `315bb5a3…`) had been running `opsfolio.com — Signups` since 9 July: **12,606 runs**, 11.6x ROI, $1,177 of pipeline. It funded its sales funnels; at 03:28 today this service stood up a brand new empty campaign for `visit_form` — the funnel that campaign was already working — and then held the working one out of the running. The staff table showed two campaigns on one funnel: the one that did all the work, parked, and an empty one, live.

## What changes

**1. The campaign already doing a funnel's work becomes that funnel's campaign.**
`findIncumbentForFunnel` (in `src/lib/funnel-campaigns.ts`) looks for the OLDEST `ongoing` campaign of the same (org, brand, feature) that states no funnel and whose goal — its own, else the brand's — names this funnel, and adopts it: same id, same runs, same attributed costs, now stating the funnel and its goal. No second campaign is created for it.

An empty campaign **this service itself provisioned** for a funnel its incumbent was already working is dropped in the same step. `isRemovableStandIn` requires all of: the provisioned name (`<feature> - <brandId> - <funnelKey>`), **zero runs** in runs-service, and **zero lifetime cost** — and fails CLOSED on any unreadable read. Nothing that ever ran or ever spent is removed. This is the one narrow departure from the "do not delete any existing campaign" no-go, and it is deliberate: acceptance requires exactly one campaign on that funnel, and the row in question is this bug's own write from a few hours ago with no runs behind it (verified in prod: `SELECT count(*) FROM runs WHERE campaign_id = '21825de9…'` → 0). No customer campaign is touched.

**2. The superseded state is deleted.**
`SUPERSEDED_DEFER_MS` and its 15-minute re-check are gone. Every alive campaign of the brand is a candidate every tick, re-ranked from scratch on `spent-today ÷ the ceiling that binds it` — its funnel's ceiling when it runs a funded funnel, the brand daily budget when it states none (exactly what the gate enforces for it). Nothing is held out of the running because another campaign covers its funnel. `tests/unit/no-legacy.test.ts` now fails if the word — or the concept — comes back to `src/`.

**3. Every campaign states its funnel, stored.**
- Migration `0042_campaign_funnel_from_goal.sql` rewrites the goal vocabulary of every campaign that states a goal.
- `src/lib/funnel-backfill.ts` does the rest at boot (after `listen`, fire-and-forget, idempotent, one brand-service read per (org, brand) pair): campaigns that state no goal run on their brand's, which SQL cannot read.
- The map lives in exactly one place, `src/lib/sales-funnel-vocabulary.ts`:

| goal | funnel |
|---|---|
| `formSubmission` | `visit_form` — Form Magnet |
| `meetingBooked` | `reply_meeting` — Sales Meeting from Conversation (these campaigns are cold email, so the chain that ran is reply → meeting, never the website one; owner-decided 2026-08-02) |
| `websitePurchase` / `signup` | `visit_signup` — Website Purchase |

Every legacy spelling brand-service still accepts on write is included, because a stored row may carry any of them.

### Left NULL on purpose

No funnel is invented for a campaign whose funnel cannot be determined:

- **every non-sales feature** — PR, hiring, VC, AI-visibility, press-kit, outlet-discovery (≈320 of the 738 campaigns): a sales funnel is not a thing those run;
- **`combinedSales`** — it spans several funnels at once;
- **`websiteVisit`, `positiveReply`, `whatsappConversation`** — they stop short of a paid client, so no single chain names them (20 org-brands sit on these three today);
- **a brand whose goal could not be read that boot** — the next boot tries again rather than guess.

## Spend control is unchanged

A funded funnel is still paced fail-CLOSED on its own ceiling; a funnel funded at zero, or absent while the brand funds others, still blocks with `Funnel not funded`. One case is new and is a **consequence** of stamping the funnel fleet-wide, not a change of enforcement: a brand for which billing reports **no** per-funnel ceilings at all (`funnels: []`) still has one pot, so its campaigns pace on the brand daily budget exactly as they did before they stated a funnel. Without it, the backfill would have blocked every brand that never split its budget — 18 of the 19 live sales campaigns.

## Verification

- `pnpm test:unit` — 270 passed, incl. new suites for the vocabulary + migration parity, the backfill, adoption/stand-in removal (both directions), turn-taking with a funnel-less campaign, and the gate's no-funnel-budgets path.
- `tsc --noEmit` clean, `pnpm run build` + OpenAPI regen clean.
- Integration tests need a local Postgres and were not run in this workspace.
- Post-promote, prod is verified by READING rows: exactly one campaign on `sales-cold-email-outreach` for brand `6e21bb6c…` stating `visit_form` with its 12,606 runs, zero sales campaigns holding a null funnel where their goal determines one, and zero campaigns parked behind another.
