### PR TITLE
feat(funnels): the funnel is the only word for what a campaign sells

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ A gate block caused by a **normal, expected** business state — out of credits,
 
 Two services own this concept and neither is this one: **brand-service** owns which goals a brand authorizes (its `brands.current_goal` check constraint already permits `websiteVisit`, `positiveReply`, `whatsappConversation`, `combinedSales` on top of the three we had names for), and **features-service** owns the spelling — it normalises every fleet spelling and returns **400 on a goal it cannot resolve**, which is the fail-loud boundary. campaign-service only carries the value from one to the other.
 
-The enum was never a real constraint, and that is the point: **the brand-goal path never passed through it.** `fetchBrandRuntimeContext` returns `await res.json() as BrandRuntimeContext` — a bare cast, no Zod — so a brand set to `combinedSales` already flowed end-to-end untouched. The enum only capped what a CALLER could ask for on `campaign.goal`, i.e. it made the brand's own goal unrepresentable per-campaign while the brand-level path carried it fine.
+The enum never constrained the brand-goal path (`fetchBrandRuntimeContext` is a bare cast, no Zod), only what a CALLER could ask for on `campaign.goal` — which made the brand's own goal unrepresentable per-campaign. **A funnel campaign's `goal` is now DERIVED from its funnel** (`goalForFunnel`) rather than forwarded from brand-service, which no longer emits one per funnel; the brand-level `currentGoal` it still serves is unchanged and still the fallback everywhere.
 
 **Non-empty is the one rule that stays, and it is fail-loud, not taste**: features-service reads an ABSENT goal as "default to meeting-booked", so `""` would forward as a silent default instead of an error. Never relax `.min(1)`.
 
@@ -94,8 +94,7 @@ funded funnels get worked, each spending up to its own ceiling and stopping ther
   already keyed on campaignId, so a funnel's spend today IS its campaign's spend today — no new
   attribution dimension. Reconciled by the scheduler (`src/lib/funnel-campaigns.ts`) from
   billing's `GET /internal/brands/:id/funnel-budgets` ∩ brand-service's
-  `GET /internal/brands/:id/sales-funnels` (which carries the goal each funnel optimizes for,
-  forwarded verbatim onto `campaigns.goal`). A funnel billing funds but brand-service does not
+  `GET /internal/brands/:id/sales-funnels`. A funnel billing funds but brand-service does not
   declare ACTIVE is never provisioned.
 - **The campaign ALREADY doing a funnel's work becomes that funnel's campaign — a second one is
   never stood up beside it.** `findIncumbentForFunnel` looks for the OLDEST `ongoing` campaign of
@@ -107,15 +106,34 @@ funded funnels get worked, each spending up to its own ceiling and stopping ther
   the same step — and only then: `isRemovableStandIn` requires the provisioned name, zero runs in
   runs-service AND zero lifetime cost, and fails CLOSED on any unreadable read. Nothing that ever
   ran is ever removed.
-- **Every campaign STATES its funnel, persisted — no consumer infers it from a goal.** Migration
-  0042 rewrites the goal vocabulary of every campaign that states a goal; `src/lib/funnel-backfill.ts`
-  (boot, after `listen`, fire-and-forget, idempotent) does the rest by reading each (org, brand)
-  pair's goal from brand-service once. The goal→funnel map lives in ONE place,
-  `src/lib/sales-funnel-vocabulary.ts`: form submissions → `visit_form`, booked meeting →
-  `reply_meeting` (these campaigns are cold email, so the chain that ran is reply→meeting, never
-  the website one — owner-decided 2026-08-02), website purchase / signup → `visit_signup`. A goal
-  naming no single funnel (`combinedSales`, `websiteVisit`, `positiveReply`,
-  `whatsappConversation`) keeps a NULL funnel: a funnel is a stored fact, never a guess.
+- **THE FUNNEL IS THE ONLY WORD. A campaign STATES it, persisted, and a consumer names what the
+  campaign buys without a translation table.** The four canonical keys are
+  `sales_meetings_from_conversation`, `sales_meetings_from_website`, `website_purchases`,
+  `form_magnet`. brand-service retired the goal set and renamed the keys (#434, 2026-08-02): its
+  funnel reads carry NO goal, so reading one is what silently stops every funnel campaign being
+  provisioned — pinned by `tests/unit/no-legacy.test.ts`. `campaigns.goal` survives as a DERIVED
+  LEGACY ALIAS of the same statement (`goalForFunnel`, byte-equal with what brand-service's
+  catalogue used to emit per funnel), so a consumer still reading a goal keeps working and none has
+  to change in lockstep — but it cannot tell the two meeting funnels apart, which is why nothing
+  here reads it back. It is also what keeps a funnel campaign out of goal arbitration.
+- **Every spelling in, one canonical token out** — `toFunnelKey` in
+  `src/lib/sales-funnel-vocabulary.ts`, the ONE place the vocabulary lives. Load-bearing on THREE
+  boundaries, not just history: **billing-service still emits the pre-rename keys today**
+  (`reply_meeting`, `visit_meeting`, `visit_signup`, `visit_form`), brand-service emits the
+  canonical four, and a campaign row can carry either. Compare raw tokens on any of the three and a
+  fully-funded funnel reads as UNFUNDED — the gate blocks it and it silently stops sending. Never
+  delete a legacy entry.
+- **Two migrations, then the goal is never read for a funnel again.** 0042 wrote the funnel of
+  every campaign stating a goal; 0043 renames those stored keys (and the provisioned campaign NAME,
+  which carries the same token) to the canonical four. `src/lib/funnel-backfill.ts` (boot, after
+  `listen`, fire-and-forget, idempotent) covers the rest by reading each (org, brand) pair's
+  `currentGoal` once — the one goal-shaped read brand-service deliberately kept. `funnelForGoal`
+  exists for exactly those two: booked meeting → `sales_meetings_from_conversation` (these
+  campaigns are cold email, so the chain that ran is reply→meeting, never the website one —
+  owner-decided 2026-08-02), form submissions → `form_magnet`, website purchase / signup →
+  `website_purchases`. A goal naming no single funnel (`combinedSales`, `websiteVisit`,
+  `positiveReply`, `whatsappConversation`) keeps a NULL funnel: a funnel is a stored fact, never a
+  guess.
 - **The gate paces on that funnel's own ceiling** (`gate-check.ts`, block a2), fail-CLOSED like
   the brand ceiling. Precedence: campaign's own `dailyBudgetCents` → `funnelKey` ceiling → brand
   daily budget. A funnel funded at ZERO, or absent from billing while the brand funds OTHER

--- a/drizzle/0043_canonical_funnel_keys.sql
+++ b/drizzle/0043_canonical_funnel_keys.sql
@@ -1,0 +1,42 @@
+-- Rename every stored funnel to the name it is now called.
+--
+-- brand-service retired the goal vocabulary and renamed the four funnel keys with it (#434):
+--
+--   visit_form     -> form_magnet                        (Form Magnet)
+--   reply_meeting  -> sales_meetings_from_conversation   (Sales Meeting from Conversation)
+--   visit_meeting  -> sales_meetings_from_website        (Sales Meeting from Website)
+--   visit_signup   -> website_purchases                  (Website Purchases)
+--
+-- Campaign rows written before this ship carry the pre-rename spelling. A row that keeps it does
+-- not resolve to the funnel it was provisioned for: its ceiling is looked up under a name billing
+-- and brand-service no longer agree on, so the gate would read it as unfunded and the campaign
+-- would stop sending. This rewrites them once, so every row states its funnel in the one
+-- vocabulary the fleet uses.
+--
+-- The provisioned NAME carries the same token (`<feature> - <brandId> - <funnelKey>`), and it is
+-- the only uniqueness Postgres can enforce for one-campaign-per-funnel — so it moves with the key
+-- in the same statement. Only names matching exactly what this service provisions are touched; a
+-- name a customer chose contains no funnel token and is left alone.
+--
+-- Idempotent and re-runnable: a second pass matches no pre-rename value and updates nothing.
+-- Nothing is deleted, stopped, rescheduled or re-budgeted — no campaign loses its turn, its
+-- pacing or a cent of attribution because of a vocabulary change.
+
+UPDATE "campaigns"
+SET "name" = replace("name", ' - ' || "funnel_key", ' - ' || CASE "funnel_key"
+      WHEN 'visit_form'    THEN 'form_magnet'
+      WHEN 'reply_meeting' THEN 'sales_meetings_from_conversation'
+      WHEN 'visit_meeting' THEN 'sales_meetings_from_website'
+      WHEN 'visit_signup'  THEN 'website_purchases'
+    END)
+WHERE "funnel_key" IN ('visit_form', 'reply_meeting', 'visit_meeting', 'visit_signup')
+  AND "name" LIKE '% - ' || "funnel_key";
+
+UPDATE "campaigns"
+SET "funnel_key" = CASE "funnel_key"
+      WHEN 'visit_form'    THEN 'form_magnet'
+      WHEN 'reply_meeting' THEN 'sales_meetings_from_conversation'
+      WHEN 'visit_meeting' THEN 'sales_meetings_from_website'
+      WHEN 'visit_signup'  THEN 'website_purchases'
+    END
+WHERE "funnel_key" IN ('visit_form', 'reply_meeting', 'visit_meeting', 'visit_signup');

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1776700000000,
       "tag": "0042_campaign_funnel_from_goal",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1776800000000,
+      "tag": "0043_canonical_funnel_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -84,20 +84,29 @@ export const campaigns = pgTable(
     // against runs-service *CostInUsdCents and billing's brand dailyBudgetCents — no ×100.
     dailyBudgetCents: integer("daily_budget_cents"),
 
-    // The sales funnel this campaign works, in brand-service's funnel vocabulary
-    // (reply_meeting | visit_meeting | visit_signup | visit_form). A customer funds each of a
-    // brand's funnels separately (billing-service brand_funnel_budgets), so a funded funnel gets
-    // its OWN campaign: the cost ledger is already keyed on campaignId, which makes "how much did
-    // this funnel spend today" answerable without a new attribution dimension.
+    // The sales funnel this campaign works — the ONE word for what this campaign sells, in
+    // brand-service's canonical vocabulary (sales_meetings_from_conversation |
+    // sales_meetings_from_website | website_purchases | form_magnet). A consumer reads what a
+    // campaign buys HERE and needs no translation table: `goal` above cannot tell a meeting won
+    // from a reply apart from one won on the website, and that is why the goal set was retired.
+    //
+    // A customer funds each of a brand's funnels separately (billing-service
+    // brand_funnel_budgets), so a funded funnel gets its OWN campaign: the cost ledger is already
+    // keyed on campaignId, which makes "how much did this funnel spend today" answerable without
+    // a new attribution dimension.
     //
     // NULL = not funnel-scoped. Every campaign that predates per-funnel funding keeps NULL and
     // paces exactly as before (own dailyBudgetCents, else the brand-level daily budget — which
     // billing still answers as the SUM of the per-funnel ceilings). A brand that never declares
     // per-funnel ceilings never grows funnel campaigns.
     //
-    // A funnel campaign carries the funnel's OWN goal in `goal`, which is why it is never
-    // goal-arbitrated: the customer's funding decided which funnel runs, so features-service is
-    // asked only for the best workflow and the audience evidence FOR THAT funnel's goal.
+    // A funnel campaign also carries that funnel's goal in `goal` — a legacy alias of the same
+    // statement, for consumers that have not migrated — which is why it is never goal-arbitrated:
+    // the customer's funding decided which funnel runs, so features-service is asked only for the
+    // best workflow and the audience evidence.
+    //
+    // Values are canonical past migration 0043; `toFunnelKey` in sales-funnel-vocabulary.ts still
+    // resolves the pre-rename spellings, because billing-service emits them to this day.
     funnelKey: text("funnel_key"),
 
     // Volume limit (optional, total leads across all runs)

--- a/src/lib/brand-sales-funnels-client.ts
+++ b/src/lib/brand-sales-funnels-client.ts
@@ -1,33 +1,38 @@
 import type { IdentityHeaders } from "@distribute/runs-client";
-import type { RuntimeGoal } from "./brand-runtime-client.js";
+import { toFunnelKey, type SalesFunnelKey } from "./sales-funnel-vocabulary.js";
 
 /**
  * One sales funnel a brand has declared it sells through, as brand-service reports it.
  *
  * A funnel is one chain from the first signal outreach can buy (a positive reply, or a click
- * onto the site) down to a paid client, and it carries the GOAL that chain optimizes for. That
- * goal is the only field this service needs: it is what a funnel campaign paces on, so
- * features-service is asked for the best workflow and the audience evidence FOR THAT goal.
+ * onto the site) down to a paid client. The KEY is the only field this service needs: it names
+ * what the campaign sells, it is what the campaign states on its own row, and it is what billing
+ * holds that funnel's ceiling under.
  *
- * The goal is forwarded verbatim, exactly like the brand's currentGoal — brand-service owns the
- * vocabulary and features-service owns the spelling. This service never maps or narrows it.
+ * There is no goal here any more. brand-service retired the goal set (#434) because it was the
+ * poorer of its two words — both meeting funnels collapsed onto one `meetingBooked` — and it now
+ * emits the funnel and nothing else. Reading a goal off this payload is what would have stopped
+ * every funnel campaign being provisioned the moment that shipped.
  */
 export interface DeclaredSalesFunnel {
-  /** reply_meeting | visit_meeting | visit_signup | visit_form. */
-  funnelKey: string;
+  /**
+   * Canonical: sales_meetings_from_conversation | sales_meetings_from_website | website_purchases
+   * | form_magnet. A pre-rename spelling on the wire is resolved to its canonical key here, so no
+   * caller downstream ever sees two names for one funnel.
+   */
+  funnelKey: SalesFunnelKey;
   active: boolean;
-  goal: RuntimeGoal;
 }
 
 /**
  * Read the funnels a brand has declared it sells through.
  *
  * Contract (brand-service): GET /internal/brands/{brandId}/sales-funnels (x-api-key [+ x-org-id])
- *   -> { funnels: [{ funnelKey, active, goal, currentGoal, ... }], declared }
+ *   -> { funnels: [{ funnelKey, active, name, steps, rates, ... }] }
  *
  * Returns null when the set could not be read (missing config, network error, non-2xx,
  * unparseable payload). Callers treat that as "no funnel information this tick" and leave the
- * brand exactly as it is — provisioning a campaign is not worth guessing a goal for.
+ * brand exactly as it is — provisioning a campaign is not worth guessing a funnel for.
  *
  * An EMPTY list is a real answer, not a failure: the org has declared nothing yet. Per
  * brand-service's own contract we never substitute a plausible set for it.
@@ -63,15 +68,18 @@ export async function fetchDeclaredSalesFunnels(
     if (!res.ok) return null;
 
     const data = await res.json() as {
-      funnels?: Array<{ funnelKey?: string; active?: boolean; goal?: string | null }>;
+      funnels?: Array<{ funnelKey?: string; active?: boolean }>;
     };
     if (!Array.isArray(data.funnels)) return null;
 
     const funnels: DeclaredSalesFunnel[] = [];
     for (const raw of data.funnels) {
-      if (!raw?.funnelKey || !raw.goal) continue;
+      // Any spelling in, one canonical token out. A key neither catalogue names is skipped
+      // rather than worked: this service can only run a funnel it has a name for.
+      const funnelKey = toFunnelKey(raw?.funnelKey);
+      if (!funnelKey) continue;
       if (raw.active === false) continue;
-      funnels.push({ funnelKey: raw.funnelKey, active: true, goal: raw.goal });
+      funnels.push({ funnelKey, active: true });
     }
     return funnels;
   } catch {

--- a/src/lib/funnel-adoption.ts
+++ b/src/lib/funnel-adoption.ts
@@ -5,9 +5,11 @@ import { funnelForGoal } from "./sales-funnel-vocabulary.js";
 /**
  * Which funnel a campaign that states none is already running.
  *
- * A campaign's goal is its own when it states one, and the brand's otherwise — the same
- * resolution the runtime uses at /start-run. Read once here so the funnel can be WRITTEN onto
- * the campaign row; nothing downstream re-derives it.
+ * The ONE place a goal is still read as a funnel, and only for campaigns that predate funnels:
+ * a campaign's goal is its own when it states one, and the brand's otherwise — the same
+ * resolution the runtime uses at /start-run. Read once here so the canonical funnel can be
+ * WRITTEN onto the campaign row; nothing downstream re-derives it, and after the row states its
+ * funnel this function is never consulted for it again.
  *
  * Returns null when the goal names no single funnel. A campaign whose funnel cannot be
  * determined keeps a NULL funnel: a stated funnel is a fact, never a guess.

--- a/src/lib/funnel-budget-client.ts
+++ b/src/lib/funnel-budget-client.ts
@@ -1,4 +1,5 @@
 import type { IdentityHeaders } from "@distribute/runs-client";
+import { toFunnelKey, type SalesFunnelKey } from "./sales-funnel-vocabulary.js";
 
 /**
  * Per-funnel daily spend ceilings, as billing-service holds them for ONE org's view of a brand.
@@ -14,8 +15,13 @@ import type { IdentityHeaders } from "@distribute/runs-client";
  * value — billing never fabricates a split, and neither do we.
  */
 export interface FunnelBudget {
-  /** brand-service's funnel vocabulary: reply_meeting | visit_meeting | visit_signup | visit_form. */
-  funnelKey: string;
+  /**
+   * Canonical funnel key. billing-service still names these funnels the pre-rename way
+   * (`reply_meeting`, `visit_meeting`, `visit_signup`, `visit_form`) while brand-service has moved
+   * to the canonical four — so this read canonicalises, and the two sets intersect again. Without
+   * that, every funnel would read as unfunded and the gate would stop the whole fleet.
+   */
+  funnelKey: SalesFunnelKey;
   /** This funnel's own daily ceiling, in CENTS (directly comparable to runs *CostInUsdCents). */
   dailyBudgetCents: number;
 }
@@ -81,7 +87,12 @@ export async function fetchFunnelBudgets(
       // An unparseable ceiling is not "no ceiling" — refuse the whole read rather than let one
       // funnel silently pace on nothing.
       if (!Number.isFinite(cents)) return { ok: false };
-      funnels.push({ funnelKey: raw.funnelKey, dailyBudgetCents: cents });
+      // A funnel neither catalogue names is one no campaign of ours can be on, so it is dropped
+      // rather than refused: refusing would fail the read CLOSED and stop the funnels we DO run
+      // because billing named a fifth one we have not heard of yet.
+      const funnelKey = toFunnelKey(raw.funnelKey);
+      if (!funnelKey) continue;
+      funnels.push({ funnelKey, dailyBudgetCents: cents });
     }
 
     return { ok: true, brandDailyBudgetCents, funnels };

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -6,6 +6,7 @@ import { fetchFunnelBudgets, fundedFunnels, type FunnelBudget } from "./funnel-b
 import { fetchDeclaredSalesFunnels, type DeclaredSalesFunnel } from "./brand-sales-funnels-client.js";
 import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
 import { readBrandGoal, resolveCampaignFunnelKey } from "./funnel-adoption.js";
+import { acceptedFunnelKeys, goalForFunnel, toFunnelKey } from "./sales-funnel-vocabulary.js";
 
 // A campaign that did not get this brand's turn re-checks on the next active tick. The turn is
 // re-ranked from scratch every tick, so this is a "wait your turn", not a backoff. EVERY alive
@@ -174,14 +175,18 @@ async function planOneBrand(
   // against the ceiling that actually binds IT, so nothing starves and nothing overspends.
   const candidates: FunnelTurnCandidate[] = [];
   for (const c of group) {
+    // A row written before the rename still carries the pre-rename spelling until migration 0043
+    // reaches it — and a mixed fleet must rank on one vocabulary or a funnel silently loses its
+    // ceiling and never takes a turn.
+    const canonical = toFunnelKey(c.funnelKey);
     candidates.push({
       campaignId: c.id,
-      funnelKey: c.funnelKey ?? "",
+      funnelKey: canonical ?? "",
       spentCents: await spentTodayCents(orgId, c.id, featureSlug),
       // A campaign on a funnel the customer does not fund gets a zero ceiling and yields its
       // turn — that is the customer's funding decision, enforced fail-closed in the gate, and
       // it re-checks every tick because funding can change at any minute.
-      ceilingCents: c.funnelKey ? (ceilingByFunnel.get(c.funnelKey) ?? 0) : brandCeilingCents,
+      ceilingCents: canonical ? (ceilingByFunnel.get(canonical) ?? 0) : brandCeilingCents,
     });
   }
 
@@ -206,13 +211,15 @@ async function planOneBrand(
  * months of runs and every cost attributed to it. Standing up a second, empty campaign beside it
  * left the working one looking dead and the live one looking like it had produced nothing.
  *
- * The campaign carries the funnel's OWN goal, which is also what stops it being goal-arbitrated:
- * a campaign that states its own goal is never arbitrated, so features-service keeps answering
- * the best workflow and the per-audience evidence — scoped to the funnel being run — and stops
- * being the thing that chooses which funnel runs. The customer's funding decides that.
+ * The campaign STATES its funnel, and that is the whole statement of what it sells. It also
+ * carries the goal that funnel corresponds to — a legacy alias for consumers still reading a goal
+ * off our rows, and what stops the campaign being goal-arbitrated: a campaign that states its own
+ * goal is never arbitrated, so features-service keeps answering the best workflow and the
+ * per-audience evidence and stops being the thing that chooses which funnel runs. The customer's
+ * funding decides that.
  *
- * A funnel billing funds but brand-service does not declare (or declares inactive) is skipped:
- * there is no goal to pace it on, and a switched-off funnel must never be worked.
+ * A funnel billing funds but brand-service does not declare (or declares inactive) is skipped: a
+ * switched-off funnel must never be worked, whatever ceiling billing still holds for it.
  */
 async function ensureFundedFunnelCampaigns({
   seed,
@@ -229,12 +236,12 @@ async function ensureFundedFunnelCampaigns({
   declared: DeclaredSalesFunnel[] | null;
   now: Date;
 }): Promise<void> {
-  // No readable funnel declaration → no goal to pace a new campaign on. Provisioning waits;
-  // whatever campaigns already exist keep running.
+  // No readable funnel declaration → nothing says the brand still sells through these funnels.
+  // Provisioning waits; whatever campaigns already exist keep running.
   if (!declared || declared.length === 0) return;
   if (!seed.createdByUserId) return; // no recipient/owner to attribute a new campaign to
 
-  const goalByFunnel = new Map(declared.map((f) => [f.funnelKey, f.goal]));
+  const declaredKeys = new Set(declared.map((f) => f.funnelKey));
 
   // The brand's goal is what tells us which funnel a campaign that states none is already
   // working. Read at most once per brand per tick, and only when there is something to adopt.
@@ -253,8 +260,10 @@ async function ensureFundedFunnelCampaigns({
   };
 
   for (const f of funded) {
-    const goal = goalByFunnel.get(f.funnelKey);
-    if (!goal) continue;
+    if (!declaredKeys.has(f.funnelKey)) continue;
+    // The goal the funnel corresponds to — a legacy alias for consumers still reading one, and
+    // what keeps this campaign out of goal arbitration. Never read back to find the funnel.
+    const goal = goalForFunnel(f.funnelKey);
 
     const existing = await db.query.campaigns.findFirst({
       where: and(
@@ -323,7 +332,8 @@ async function ensureFundedFunnelCampaigns({
         brandIds: [brandId],
         featureSlug,
         funnelKey: f.funnelKey,
-        // The funnel's own goal — forwarded verbatim from brand-service, never mapped.
+        // The funnel says what this campaign sells. `goal` is the legacy alias of that same
+        // statement, kept for consumers still reading one.
         goal,
         featureInputs: null,
         status: "ongoing",
@@ -405,10 +415,12 @@ async function isRemovableStandIn(
   brandId: string,
   featureSlug: string,
 ): Promise<boolean> {
+  // Both vocabularies: a stand-in provisioned before the funnel rename carries the pre-rename
+  // spelling in its NAME, and migration 0043 rewrites those names — but a replica running the old
+  // code between the two would recreate one. Accepting both costs nothing and never widens what
+  // is removable: every other condition still has to hold.
   const provisionedNames = new Set(
-    ["reply_meeting", "visit_meeting", "visit_signup", "visit_form"].map((k) =>
-      funnelCampaignName(featureSlug, brandId, k),
-    ),
+    acceptedFunnelKeys().map((k) => funnelCampaignName(featureSlug, brandId, k)),
   );
   if (!provisionedNames.has(existing.name)) return false;
 

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { anyBrandPaused } from "./brand-pause.js";
 import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
 import { fetchFunnelBudgets } from "./funnel-budget-client.js";
+import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 
 const STALE_THRESHOLD_MS = 3 * 60 * 60 * 1000; // 3 hours
 
@@ -258,7 +259,13 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
           if (blocked) return blocked;
           continue;
         }
-        const ceilingCents = budgets.funnels.find(f => f.funnelKey === campaign.funnelKey)?.dailyBudgetCents ?? null;
+        // Both sides are canonicalised — billing still names these funnels the pre-rename way and
+        // a campaign row written before migration 0043 does too, so comparing raw tokens would
+        // find no ceiling for a funnel that is fully funded and block it as unfunded.
+        const funnelKey = toFunnelKey(campaign.funnelKey);
+        const ceilingCents = funnelKey
+          ? budgets.funnels.find(f => f.funnelKey === funnelKey)?.dailyBudgetCents ?? null
+          : null;
         // A funnel funded at zero — or no longer funded at all — is never run. That is a
         // deliberate customer decision, not a missing value, so it is not a fallback to the
         // brand total: falling back would let an unfunded funnel spend another funnel's money.

--- a/src/lib/sales-funnel-vocabulary.ts
+++ b/src/lib/sales-funnel-vocabulary.ts
@@ -1,47 +1,118 @@
 /**
- * Which sales funnel a campaign's optimization goal means.
+ * The sales-funnel vocabulary — the ONE word for what a campaign sells.
  *
- * A campaign used to say what it was for in the GOAL vocabulary ("form submissions", "booked
- * meeting", "website purchase"). brand-service now speaks FUNNELS — one named chain from the
- * first signal outreach can buy down to a paid client — and a campaign states the funnel it
- * runs on its own row (`campaigns.funnel_key`). This map is the one place the old word is read
- * as the new one, and it exists to REWRITE stored rows once, not to translate on read: after
- * the backfill, every determinable campaign carries its funnel and no consumer has to infer it.
+ * A campaign runs one sales funnel: one chain from the first signal outreach can buy (a positive
+ * reply, or a click onto the site) down to a paid client. The campaign STATES that funnel on its
+ * own row (`campaigns.funnel_key`) and every consumer reads it there. Nothing infers it.
  *
- * The three mappings are brand-service's own catalogue (`salesFunnelCatalogue.ts`), plus one
- * owner decision (2026-08-02): a booked-meeting campaign runs `reply_meeting` ("Sales Meeting
- * from Conversation"), never `visit_meeting`. Both funnels optimize for `meetingBooked`, but
- * these campaigns are cold email — the chain that actually ran is reply → meeting, not a
- * website visit.
+ * brand-service used to answer "what does this brand sell through?" twice — once with a funnel,
+ * once with a goal — and the goal was strictly the poorer word: `sales_meetings_from_conversation`
+ * and `sales_meetings_from_website` both collapsed onto one `meetingBooked`, so a meeting won from
+ * a reply and one won on the website were the same thing to every consumer. brand-service has now
+ * retired the goal set (#434): the funnel is the only vocabulary it emits, and the four keys were
+ * renamed while it was at it.
  *
- * Every accepted spelling brand-service still takes on write (`goal-vocabulary.ts`
- * LEGACY_OPTIMIZATION_GOALS) is listed, because a stored row may carry any of them.
+ * This module is what makes that switch cost this service nothing:
  *
- * A goal that names no single funnel is ABSENT here on purpose and resolves to null:
+ *   - `toFunnelKey` canonicalises EVERY spelling of a funnel — from brand-service, from
+ *     billing-service (which still emits the pre-rename keys today), and from a campaign row
+ *     written before the rename. One canonical token past this boundary, always.
+ *   - `funnelForGoal` reads a RETIRED GOAL as the funnel it named. Kept for the two places a goal
+ *     is still the only thing on hand: the campaign rows written before funnels existed, and the
+ *     brand's `currentGoal`, which brand-service deliberately still serves.
+ *   - `goalForFunnel` derives the goal token FROM the funnel, for consumers still reading a goal
+ *     off our campaign rows. It is a legacy alias — lossy by construction, since both meeting
+ *     funnels name one goal — and that is exactly why nothing here reads it back.
+ */
+
+/**
+ * The four funnels, in brand-service's canonical spelling. These are the ONLY funnel tokens this
+ * service ever stores or emits.
+ */
+export const SALES_FUNNEL_KEYS = [
+  "sales_meetings_from_conversation",
+  "sales_meetings_from_website",
+  "website_purchases",
+  "form_magnet",
+] as const;
+
+export type SalesFunnelKey = (typeof SALES_FUNNEL_KEYS)[number];
+
+/**
+ * The pre-rename spelling of each funnel, as brand-service emitted it until #434, as
+ * billing-service STILL emits it on `/internal/brands/:id/funnel-budgets` today, and as every
+ * campaign row written before migration 0043 carries it.
+ *
+ * Accepted forever on the way in; never emitted. Deleting an entry silently unfunds every funnel
+ * a producer still names the old way — which is the whole failure this map exists to prevent.
+ */
+const LEGACY_FUNNEL_KEYS: Readonly<Record<string, SalesFunnelKey>> = Object.freeze({
+  reply_meeting: "sales_meetings_from_conversation",
+  visit_meeting: "sales_meetings_from_website",
+  visit_signup: "website_purchases",
+  visit_form: "form_magnet",
+});
+
+const CANONICAL_FUNNEL_KEYS: ReadonlySet<string> = new Set(SALES_FUNNEL_KEYS);
+
+/**
+ * The canonical funnel a value names, under any spelling — or null when it names none.
+ *
+ * Never guesses: a token neither catalogue lists returns null, and the caller treats that as "no
+ * funnel", not as a fifth funnel it may quietly work.
+ */
+export function toFunnelKey(value: string | null | undefined): SalesFunnelKey | null {
+  if (!value) return null;
+  if (CANONICAL_FUNNEL_KEYS.has(value)) return value as SalesFunnelKey;
+  return LEGACY_FUNNEL_KEYS[value] ?? null;
+}
+
+/** Every funnel spelling this service accepts on the way in — the canonical four plus the four legacy. */
+export function acceptedFunnelKeys(): string[] {
+  return [...SALES_FUNNEL_KEYS, ...Object.keys(LEGACY_FUNNEL_KEYS)];
+}
+
+/**
+ * Which funnel a RETIRED optimization goal named.
+ *
+ * Only two things still speak goals: campaign rows written before funnels existed, and the brand's
+ * `currentGoal`, which brand-service keeps serving on `/internal/brands/:id/runtime-context` for
+ * every brand with no per-funnel budget. This map is how either is read as a funnel — once, to
+ * WRITE the funnel onto the row. Nothing reads a goal to find a funnel afterwards.
+ *
+ * `meetingBooked` resolves to the CONVERSATION funnel, not the website one, and that is an owner
+ * decision (2026-08-02): these campaigns are cold email, so the chain that actually ran is
+ * reply → meeting. brand-service splits the same goal on whether the brand set a click
+ * destination; here the campaign itself is the evidence and it is unambiguous.
+ *
+ * Every accepted spelling brand-service still takes on write is listed, because a stored row may
+ * carry any of them.
+ *
+ * A goal that names no single funnel is ABSENT on purpose and resolves to null:
  *   - `combinedSales` spans several funnels at once,
  *   - `websiteVisit`, `positiveReply`, `whatsappConversation` stop short of a paid client.
  * Those campaigns keep a NULL funnel. Inventing one would state a chain the customer never
  * declared, and the funnel is a stored fact, not a guess.
  */
-const FUNNEL_BY_GOAL: Readonly<Record<string, string>> = Object.freeze({
+const FUNNEL_BY_GOAL: Readonly<Record<string, SalesFunnelKey>> = Object.freeze({
   // Form Magnet — website visit → form filled → paid client.
-  formSubmission: "visit_form",
-  form_submissions: "visit_form",
+  formSubmission: "form_magnet",
+  form_submissions: "form_magnet",
 
   // Sales Meeting from Conversation — positive reply → meeting booked → attended → paid client.
-  meetingBooked: "reply_meeting",
-  booked_meetings: "reply_meeting",
-  sales_meetings: "reply_meeting",
+  meetingBooked: "sales_meetings_from_conversation",
+  booked_meetings: "sales_meetings_from_conversation",
+  sales_meetings: "sales_meetings_from_conversation",
 
-  // Website Purchase — website visit → signup → paid client. `signup` is the goal
-  // brand-service's catalogue puts on this funnel; `websitePurchase` (and its older spellings)
-  // is what the same chain is called on screen. Both name this one funnel.
-  signup: "visit_signup",
-  signups: "visit_signup",
-  websitePurchase: "visit_signup",
-  website_purchase: "visit_signup",
-  purchase: "visit_signup",
-  sales: "visit_signup",
+  // Website Purchases — website visit → signup → paid client. `signup` is the goal
+  // brand-service's catalogue put on this funnel; `websitePurchase` (and its older spellings) is
+  // what the same chain is called on screen. Both name this one funnel.
+  signup: "website_purchases",
+  signups: "website_purchases",
+  websitePurchase: "website_purchases",
+  website_purchase: "website_purchases",
+  purchase: "website_purchases",
+  sales: "website_purchases",
 });
 
 /**
@@ -49,7 +120,7 @@ const FUNNEL_BY_GOAL: Readonly<Record<string, string>> = Object.freeze({
  *
  * Never guesses: an unknown or absent goal returns null and the campaign keeps a NULL funnel.
  */
-export function funnelForGoal(goal: string | null | undefined): string | null {
+export function funnelForGoal(goal: string | null | undefined): SalesFunnelKey | null {
   if (!goal) return null;
   return FUNNEL_BY_GOAL[goal] ?? null;
 }
@@ -57,4 +128,29 @@ export function funnelForGoal(goal: string | null | undefined): string | null {
 /** Every goal spelling that determines a funnel — the SQL backfill enumerates the same list. */
 export function goalsWithAFunnel(): string[] {
   return Object.keys(FUNNEL_BY_GOAL);
+}
+
+/**
+ * The goal token a funnel corresponds to — a LEGACY ALIAS, kept so a consumer still reading
+ * `campaigns.goal` keeps working until it migrates to the funnel.
+ *
+ * Byte-equal with what brand-service's catalogue emitted per funnel before the retirement, so the
+ * value on a campaign row does not move under a consumer as part of this ship.
+ *
+ * LOSSY, deliberately: both meeting funnels answer `meetingBooked`, which is exactly why the goal
+ * is being retired. Nothing in this service reads the value back to decide anything — the funnel
+ * is on the row. It is also what keeps a funnel campaign out of goal arbitration: a campaign that
+ * states its own goal is never arbitrated, and the customer's funding is what decides which funnel
+ * runs.
+ */
+const GOAL_BY_FUNNEL: Readonly<Record<SalesFunnelKey, string>> = Object.freeze({
+  sales_meetings_from_conversation: "meetingBooked",
+  sales_meetings_from_website: "meetingBooked",
+  website_purchases: "signup",
+  form_magnet: "formSubmission",
+});
+
+export function goalForFunnel(funnelKey: string | null | undefined): string | null {
+  const canonical = toFunnelKey(funnelKey);
+  return canonical ? GOAL_BY_FUNNEL[canonical] : null;
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -51,8 +51,11 @@ export const CampaignSchema = z.object({
   maxBudgetTotalUsd: z.string().nullable(),
   // Per-campaign daily budget for the sales feature (cents). Null = fall back to brand daily budget.
   dailyBudgetCents: z.number().int().nullable(),
-  // The sales funnel this campaign works, in brand-service's vocabulary (reply_meeting |
-  // visit_meeting | visit_signup | visit_form). Null = not funnel-scoped: the campaign paces on
+  // The sales funnel this campaign works — the ONE word for what it sells, in brand-service's
+  // vocabulary (sales_meetings_from_conversation | sales_meetings_from_website |
+  // website_purchases | form_magnet). A consumer reads what a campaign buys HERE; it never has to
+  // consult `goal`, which survives only as a legacy alias of the same statement and cannot tell
+  // the two meeting funnels apart. Null = not funnel-scoped: the campaign paces on
   // the brand-level daily budget as it always has. Set = the campaign is paced on THAT funnel's
   // own daily ceiling in billing, which is what makes a funnel's spend attributable to it.
   // Provisioned by this service from the funnels the customer funds — never set by a caller.

--- a/tests/unit/funnel-backfill.test.ts
+++ b/tests/unit/funnel-backfill.test.ts
@@ -81,7 +81,7 @@ describe("backfillCampaignFunnelKeys", () => {
 
     const result = await backfillCampaignFunnelKeys();
 
-    expect(mockUpdateSet).toHaveBeenCalledWith({ funnelKey: "visit_form" });
+    expect(mockUpdateSet).toHaveBeenCalledWith({ funnelKey: "form_magnet" });
     expect(result).toEqual({ scanned: 1, stamped: 1, undetermined: 0 });
   });
 
@@ -91,7 +91,7 @@ describe("backfillCampaignFunnelKeys", () => {
 
     await backfillCampaignFunnelKeys();
 
-    expect(mockUpdateSet).toHaveBeenCalledWith({ funnelKey: "reply_meeting" });
+    expect(mockUpdateSet).toHaveBeenCalledWith({ funnelKey: "sales_meetings_from_conversation" });
   });
 
   it("reads brand-service ONCE per (org, brand) pair, not once per campaign", async () => {

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -87,6 +87,9 @@ function claimed(overrides: Partial<ClaimedFunnelCampaign> = {}): ClaimedFunnelC
   };
 }
 
+// billing-service still names these funnels the PRE-RENAME way, so every test below feeds this
+// mock the legacy spellings on purpose: the two producers disagree in production today, and the
+// canonicalisation is what keeps a fully-funded funnel from reading as unfunded.
 function mockFunnelBudgets(funnels: Array<{ funnelKey: string; dailyBudgetCents: string }>) {
   mockFetch.mockResolvedValueOnce({
     ok: true,
@@ -98,12 +101,23 @@ function mockFunnelBudgets(funnels: Array<{ funnelKey: string; dailyBudgetCents:
   });
 }
 
-function mockDeclaredFunnels(funnels: Array<{ funnelKey: string; goal: string; active?: boolean }>) {
+// brand-service has retired the goal set: a declared funnel carries its KEY and nothing that
+// names a goal. This mock emits exactly that shape, so a re-introduced goal read would fail here.
+function mockDeclaredFunnels(funnels: Array<{ funnelKey: string; active?: boolean }>) {
   mockFetch.mockResolvedValueOnce({
     ok: true,
     json: async () => ({
-      declared: funnels.length > 0,
-      funnels: funnels.map(f => ({ ...f, active: f.active ?? true, currentGoal: f.goal })),
+      funnels: funnels.map(f => ({
+        funnelKey: f.funnelKey,
+        active: f.active ?? true,
+        name: f.funnelKey,
+        steps: [],
+        rates: {},
+        lifetimeRevenueUsd: null,
+        destinationUrl: null,
+        bookingUrl: null,
+        updatedAt: "2026-08-02T00:00:00.000Z",
+      })),
     }),
   });
 }
@@ -125,8 +139,8 @@ describe("selectLowestFillRatio", () => {
   it("hands the turn to the funnel that has filled the least of its own ceiling", () => {
     // The bigger absolute spend is the EMPTIER funnel relative to what it can absorb.
     const winner = selectLowestFillRatio([
-      { campaignId: "a", funnelKey: "reply_meeting", spentCents: 800, ceilingCents: 1000 },
-      { campaignId: "b", funnelKey: "visit_signup", spentCents: 900, ceilingCents: 5000 },
+      { campaignId: "a", funnelKey: "sales_meetings_from_conversation", spentCents: 800, ceilingCents: 1000 },
+      { campaignId: "b", funnelKey: "website_purchases", spentCents: 900, ceilingCents: 5000 },
     ]);
     expect(winner).toBe("b");
   });
@@ -134,16 +148,16 @@ describe("selectLowestFillRatio", () => {
   it("is not a fixed order — a funnel that can absorb the whole day never starves the others", () => {
     // First in the list, huge ceiling, nothing spent: under a fixed order it would take every
     // turn. It takes this one, and once it has filled 10% the smaller funnel wins the next.
-    const big = { campaignId: "big", funnelKey: "reply_meeting", spentCents: 0, ceilingCents: 100_000 };
-    const small = { campaignId: "small", funnelKey: "visit_signup", spentCents: 0, ceilingCents: 100 };
+    const big = { campaignId: "big", funnelKey: "sales_meetings_from_conversation", spentCents: 0, ceilingCents: 100_000 };
+    const small = { campaignId: "small", funnelKey: "website_purchases", spentCents: 0, ceilingCents: 100 };
     expect(selectLowestFillRatio([big, small])).toBe("big"); // tie at 0 → funnelKey order
     expect(selectLowestFillRatio([{ ...big, spentCents: 10_000 }, small])).toBe("small");
   });
 
   it("a funnel at its ceiling yields to another funded one, with no special case", () => {
     const winner = selectLowestFillRatio([
-      { campaignId: "full", funnelKey: "reply_meeting", spentCents: 1000, ceilingCents: 1000 },
-      { campaignId: "open", funnelKey: "visit_signup", spentCents: 990, ceilingCents: 1000 },
+      { campaignId: "full", funnelKey: "sales_meetings_from_conversation", spentCents: 1000, ceilingCents: 1000 },
+      { campaignId: "open", funnelKey: "website_purchases", spentCents: 990, ceilingCents: 1000 },
     ]);
     expect(winner).toBe("open");
   });
@@ -151,8 +165,8 @@ describe("selectLowestFillRatio", () => {
   it("returns null when every funded funnel is at its ceiling", () => {
     expect(
       selectLowestFillRatio([
-        { campaignId: "a", funnelKey: "reply_meeting", spentCents: 1000, ceilingCents: 1000 },
-        { campaignId: "b", funnelKey: "visit_signup", spentCents: 2500, ceilingCents: 2000 },
+        { campaignId: "a", funnelKey: "sales_meetings_from_conversation", spentCents: 1000, ceilingCents: 1000 },
+        { campaignId: "b", funnelKey: "website_purchases", spentCents: 2500, ceilingCents: 2000 },
       ]),
     ).toBeNull();
   });
@@ -160,15 +174,15 @@ describe("selectLowestFillRatio", () => {
   it("never runs a funnel funded at zero", () => {
     expect(
       selectLowestFillRatio([
-        { campaignId: "zero", funnelKey: "visit_signup", spentCents: 0, ceilingCents: 0 },
+        { campaignId: "zero", funnelKey: "website_purchases", spentCents: 0, ceilingCents: 0 },
       ]),
     ).toBeNull();
   });
 
   it("breaks ties deterministically on funnelKey, not insertion order", () => {
     const rows = [
-      { campaignId: "v", funnelKey: "visit_signup", spentCents: 50, ceilingCents: 100 },
-      { campaignId: "r", funnelKey: "reply_meeting", spentCents: 50, ceilingCents: 100 },
+      { campaignId: "v", funnelKey: "website_purchases", spentCents: 50, ceilingCents: 100 },
+      { campaignId: "r", funnelKey: "sales_meetings_from_conversation", spentCents: 50, ceilingCents: 100 },
     ];
     expect(selectLowestFillRatio(rows)).toBe("r");
     expect(selectLowestFillRatio([...rows].reverse())).toBe("r");
@@ -215,8 +229,8 @@ describe("planFunnelTurns", () => {
       { funnelKey: "reply_meeting", dailyBudgetCents: "2000" },
     ]);
     mockDeclaredFunnels([
-      { funnelKey: "visit_signup", goal: "signup" },
-      { funnelKey: "reply_meeting", goal: "meetingBooked" },
+      { funnelKey: "website_purchases" },
+      { funnelKey: "sales_meetings_from_conversation" },
     ]);
     mockFindFirst.mockResolvedValue(undefined); // neither funnel has a campaign yet
 
@@ -224,11 +238,12 @@ describe("planFunnelTurns", () => {
 
     expect(mockInsertValues).toHaveBeenCalledTimes(2);
     const inserted = mockInsertValues.mock.calls.map(c => c[0]);
-    expect(inserted.map(v => v.funnelKey).sort()).toEqual(["reply_meeting", "visit_signup"]);
-    // The campaign carries the funnel's OWN goal, forwarded verbatim — that is what keeps it
-    // out of goal arbitration.
-    expect(inserted.find(v => v.funnelKey === "reply_meeting").goal).toBe("meetingBooked");
-    expect(inserted.find(v => v.funnelKey === "visit_signup").goal).toBe("signup");
+    expect(inserted.map(v => v.funnelKey).sort()).toEqual(["sales_meetings_from_conversation", "website_purchases"]);
+    // The campaign STATES its funnel in the canonical vocabulary even though billing named those
+    // same two funnels the pre-rename way. It also carries the goal that funnel corresponds to —
+    // a legacy alias for consumers still reading one, and what keeps it out of goal arbitration.
+    expect(inserted.find(v => v.funnelKey === "sales_meetings_from_conversation").goal).toBe("meetingBooked");
+    expect(inserted.find(v => v.funnelKey === "website_purchases").goal).toBe("signup");
     expect(inserted[0].name).toBe(funnelCampaignName(SALES, "brand-1", inserted[0].funnelKey));
   });
 
@@ -238,15 +253,43 @@ describe("planFunnelTurns", () => {
       { funnelKey: "visit_form", dailyBudgetCents: "500" },
     ]);
     mockDeclaredFunnels([
-      { funnelKey: "visit_signup", goal: "signup" },
-      { funnelKey: "visit_form", goal: "formSubmission", active: false },
+      { funnelKey: "website_purchases" },
+      { funnelKey: "form_magnet", active: false },
     ]);
     mockFindFirst.mockResolvedValue(undefined);
 
     await planFunnelTurns([claimed()]);
 
     expect(mockInsertValues).toHaveBeenCalledTimes(1);
-    expect(mockInsertValues.mock.calls[0][0].funnelKey).toBe("visit_signup");
+    expect(mockInsertValues.mock.calls[0][0].funnelKey).toBe("website_purchases");
+  });
+
+  it("ranks a campaign row still on a pre-rename key on its funnel's real ceiling", async () => {
+    // The row has not met migration 0043 yet — or a replica is mid-deploy. It must still find its
+    // own ceiling: reading it as unfunded would give it a zero ceiling, drop it out of the running
+    // and starve the funnel it was provisioned for, silently.
+    mockFunnelBudgets([
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      { funnelKey: "reply_meeting", dailyBudgetCents: "1000" },
+    ]);
+    mockDeclaredFunnels([
+      { funnelKey: "website_purchases" },
+      { funnelKey: "sales_meetings_from_conversation" },
+    ]);
+    mockSpend("900"); // c-canonical is 90% full
+    mockSpend("100"); // c-preRename is 10% full — it must be allowed to win on that
+
+    const now = new Date("2026-08-02T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-canonical", funnelKey: "website_purchases" }),
+        claimed({ id: "c-preRename", funnelKey: "reply_meeting" }),
+      ],
+      now,
+    );
+
+    expect(deferred.has("c-preRename")).toBe(false); // takes the turn on its own ceiling
+    expect(deferred.get("c-canonical")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
   });
 
   it("holds the whole brand while a run is in flight — one run per brand", async () => {
@@ -255,16 +298,16 @@ describe("planFunnelTurns", () => {
       { funnelKey: "reply_meeting", dailyBudgetCents: "2000" },
     ]);
     mockDeclaredFunnels([
-      { funnelKey: "visit_signup", goal: "signup" },
-      { funnelKey: "reply_meeting", goal: "meetingBooked" },
+      { funnelKey: "website_purchases" },
+      { funnelKey: "sales_meetings_from_conversation" },
     ]);
     mockListRuns.mockResolvedValue({ runs: [{ id: "live" }] });
 
     const now = new Date("2026-08-02T10:00:00Z");
     const deferred = await planFunnelTurns(
       [
-        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
-        claimed({ id: "c-reply", funnelKey: "reply_meeting" }),
+        claimed({ id: "c-visit", funnelKey: "website_purchases" }),
+        claimed({ id: "c-reply", funnelKey: "sales_meetings_from_conversation" }),
       ],
       now,
     );
@@ -283,8 +326,8 @@ describe("planFunnelTurns", () => {
       { funnelKey: "reply_meeting", dailyBudgetCents: "1000" },
     ]);
     mockDeclaredFunnels([
-      { funnelKey: "visit_signup", goal: "signup" },
-      { funnelKey: "reply_meeting", goal: "meetingBooked" },
+      { funnelKey: "website_purchases" },
+      { funnelKey: "sales_meetings_from_conversation" },
     ]);
     mockSpend("900"); // c-visit is 90% full
     mockSpend("100"); // c-reply is 10% full
@@ -292,8 +335,8 @@ describe("planFunnelTurns", () => {
     const now = new Date("2026-08-02T10:00:00Z");
     const deferred = await planFunnelTurns(
       [
-        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
-        claimed({ id: "c-reply", funnelKey: "reply_meeting" }),
+        claimed({ id: "c-visit", funnelKey: "website_purchases" }),
+        claimed({ id: "c-reply", funnelKey: "sales_meetings_from_conversation" }),
       ],
       now,
     );
@@ -308,8 +351,8 @@ describe("planFunnelTurns", () => {
       { funnelKey: "reply_meeting", dailyBudgetCents: "1000" },
     ]);
     mockDeclaredFunnels([
-      { funnelKey: "visit_signup", goal: "signup" },
-      { funnelKey: "reply_meeting", goal: "meetingBooked" },
+      { funnelKey: "website_purchases" },
+      { funnelKey: "sales_meetings_from_conversation" },
     ]);
     mockSpend("1000");
     mockSpend("1200");
@@ -317,8 +360,8 @@ describe("planFunnelTurns", () => {
     const now = new Date("2026-08-02T10:00:00Z");
     const deferred = await planFunnelTurns(
       [
-        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
-        claimed({ id: "c-reply", funnelKey: "reply_meeting" }),
+        claimed({ id: "c-visit", funnelKey: "website_purchases" }),
+        claimed({ id: "c-reply", funnelKey: "sales_meetings_from_conversation" }),
       ],
       now,
     );
@@ -329,7 +372,7 @@ describe("planFunnelTurns", () => {
 
   it("keeps the campaign already doing the funnel's work instead of standing up a second one", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
-    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockDeclaredFunnels([{ funnelKey: "form_magnet" }]);
     mockFindFirst.mockResolvedValue(undefined); // no campaign states this funnel yet
     mockFindMany.mockResolvedValue([
       // The months-old campaign, running on the brand's goal, carrying all the history.
@@ -343,13 +386,13 @@ describe("planFunnelTurns", () => {
     // Adopted, not duplicated: same campaign id, now stating the funnel and its goal.
     expect(mockInsertValues).not.toHaveBeenCalled();
     expect(mockUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ funnelKey: "visit_form", goal: "formSubmission" }),
+      expect.objectContaining({ funnelKey: "form_magnet" }),
     );
   });
 
   it("adopts the OLDEST match — the one carrying the history", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
-    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockDeclaredFunnels([{ funnelKey: "form_magnet" }]);
     mockFindFirst.mockResolvedValue(undefined);
     mockFindMany.mockResolvedValue([
       { id: "c-oldest", name: "the one with the history", goal: null, status: "ongoing" },
@@ -362,7 +405,7 @@ describe("planFunnelTurns", () => {
 
     expect(mockUpdateWhere).toHaveBeenCalled();
     expect(mockUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ funnelKey: "visit_form" }),
+      expect.objectContaining({ funnelKey: "form_magnet" }),
     );
     // findMany is ordered by createdAt asc, so the first match is the oldest.
     expect(mockFindMany).toHaveBeenCalled();
@@ -370,7 +413,7 @@ describe("planFunnelTurns", () => {
 
   it("never adopts a campaign whose goal names a different funnel", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
-    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockDeclaredFunnels([{ funnelKey: "form_magnet" }]);
     mockFindFirst.mockResolvedValue(undefined);
     mockFindMany.mockResolvedValue([
       { id: "c-meetings", name: "meetings", goal: "meetingBooked", status: "ongoing" },
@@ -381,15 +424,15 @@ describe("planFunnelTurns", () => {
     await planFunnelTurns([claimed({ id: "c-meetings" })], new Date("2026-08-02T10:00:00Z"));
 
     expect(mockInsertValues).toHaveBeenCalledTimes(1);
-    expect(mockInsertValues.mock.calls[0][0].funnelKey).toBe("visit_form");
+    expect(mockInsertValues.mock.calls[0][0].funnelKey).toBe("form_magnet");
   });
 
   it("drops the empty stand-in it created for a funnel the incumbent was already working", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
-    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockDeclaredFunnels([{ funnelKey: "form_magnet" }]);
     mockFindFirst.mockResolvedValue({
       id: "c-standin",
-      name: funnelCampaignName(SALES, "brand-1", "visit_form"),
+      name: funnelCampaignName(SALES, "brand-1", "form_magnet"),
       status: "ongoing",
     });
     mockFindMany.mockResolvedValue([
@@ -405,17 +448,17 @@ describe("planFunnelTurns", () => {
     await planFunnelTurns([claimed({ id: "c-incumbent" })], new Date("2026-08-02T10:00:00Z"));
 
     expect(mockUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ funnelKey: "visit_form", goal: "formSubmission" }),
+      expect.objectContaining({ funnelKey: "form_magnet" }),
     );
     expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
   });
 
   it("never drops a stand-in that has ever run", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
-    mockDeclaredFunnels([{ funnelKey: "visit_form", goal: "formSubmission" }]);
+    mockDeclaredFunnels([{ funnelKey: "form_magnet" }]);
     mockFindFirst.mockResolvedValue({
       id: "c-standin",
-      name: funnelCampaignName(SALES, "brand-1", "visit_form"),
+      name: funnelCampaignName(SALES, "brand-1", "form_magnet"),
       status: "ongoing",
     });
     mockFindMany.mockResolvedValue([
@@ -432,7 +475,7 @@ describe("planFunnelTurns", () => {
 
   it("holds no campaign out of the running — one that states no funnel still takes turns", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
-    mockDeclaredFunnels([{ funnelKey: "visit_signup", goal: "signup" }]);
+    mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
     mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
     mockFindMany.mockResolvedValue([]);
     mockSpend("900"); // c-legacy: 90% of the brand total
@@ -442,7 +485,7 @@ describe("planFunnelTurns", () => {
     const deferred = await planFunnelTurns(
       [
         claimed({ id: "c-legacy", funnelKey: null }),
-        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
+        claimed({ id: "c-visit", funnelKey: "website_purchases" }),
       ],
       now,
     );
@@ -455,7 +498,7 @@ describe("planFunnelTurns", () => {
 
   it("a campaign that states no funnel can win the turn", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
-    mockDeclaredFunnels([{ funnelKey: "visit_signup", goal: "signup" }]);
+    mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
     mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
     mockFindMany.mockResolvedValue([]);
     mockSpend("0");   // c-legacy: nothing spent
@@ -465,7 +508,7 @@ describe("planFunnelTurns", () => {
     const deferred = await planFunnelTurns(
       [
         claimed({ id: "c-legacy", funnelKey: null }),
-        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
+        claimed({ id: "c-visit", funnelKey: "website_purchases" }),
       ],
       now,
     );
@@ -476,7 +519,7 @@ describe("planFunnelTurns", () => {
 
   it("re-checks a campaign on an unfunded funnel every tick, never parks it for the day", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
-    mockDeclaredFunnels([{ funnelKey: "visit_signup", goal: "signup" }]);
+    mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
     mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
     mockFindMany.mockResolvedValue([]);
     mockSpend("1200"); // the funded funnel is over its ceiling
@@ -485,8 +528,8 @@ describe("planFunnelTurns", () => {
     const now = new Date("2026-08-02T10:00:00Z");
     const deferred = await planFunnelTurns(
       [
-        claimed({ id: "c-visit", funnelKey: "visit_signup" }),
-        claimed({ id: "c-unfunded", funnelKey: "reply_meeting" }),
+        claimed({ id: "c-visit", funnelKey: "website_purchases" }),
+        claimed({ id: "c-unfunded", funnelKey: "sales_meetings_from_conversation" }),
       ],
       now,
     );

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -581,7 +581,11 @@ describe("Gate Check", () => {
       });
     }
 
-    function funnelCampaign(funnelKey = "visit_signup") {
+    // The campaign row states its funnel in the CANONICAL vocabulary while billing-service still
+    // names the same funnels the pre-rename way. Every case below therefore crosses that gap: if
+    // the two spellings stopped resolving to one key, a fully-funded funnel would read as
+    // unfunded and the campaign would stop sending.
+    function funnelCampaign(funnelKey = "website_purchases") {
       return makeCampaign({ brandIds: ["brand-1"], funnelKey });
     }
 
@@ -612,6 +616,19 @@ describe("Gate Check", () => {
       mockFetch.mockResolvedValue({ ok: true, json: async () => ({ affordable: true }) });
 
       const result = await runGateChecks(funnelCampaign());
+      expect(result.allowed).toBe(true);
+    });
+
+    it("finds its ceiling for a row still on a pre-rename key", async () => {
+      // Both directions of the gap: this row has not met migration 0043 yet, and billing names
+      // the funnel the old way too. It is funded, so it must be allowed to spend.
+      mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "10" }]),
+      );
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ affordable: true }) });
+
+      const result = await runGateChecks(funnelCampaign("visit_signup"));
       expect(result.allowed).toBe(true);
     });
 

--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -52,6 +52,35 @@ describe('No Legacy Patterns - CRITICAL', () => {
     ).toHaveLength(0);
   });
 
+  it('should NOT read a goal off brand-service, except the brand-level currentGoal', () => {
+    // brand-service retired the goal set: the funnel is the only word it emits for what a brand
+    // sells. Reading a goal off a DECLARED FUNNEL is what silently stopped every funnel campaign
+    // being provisioned. The one goal-shaped read that survives is the brand's own currentGoal on
+    // /runtime-context, which brand-service deliberately still serves for brands with one pot.
+    const client = fs.readFileSync(
+      path.join(srcDir, 'lib/brand-sales-funnels-client.ts'),
+      'utf-8',
+    );
+    const code = client
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('*') && !l.trimStart().startsWith('/*') && !l.trimStart().startsWith('//'))
+      .join('\n');
+
+    expect(code).not.toMatch(/\bgoal\b/);
+    expect(code).not.toMatch(/\bcurrentGoal\b/);
+  });
+
+  it('should emit only the canonical funnel vocabulary from the funnel map', () => {
+    // The pre-rename spellings are ACCEPTED forever on the way in (billing still sends them) and
+    // never emitted. A canonical key is what gets stored and what a consumer reads.
+    const vocab = fs.readFileSync(path.join(srcDir, 'lib/sales-funnel-vocabulary.ts'), 'utf-8');
+    const maps = vocab.slice(vocab.indexOf('const FUNNEL_BY_GOAL'));
+
+    for (const preRename of ['visit_form', 'reply_meeting', 'visit_meeting', 'visit_signup']) {
+      expect(maps).not.toContain(`"${preRename}"`);
+    }
+  });
+
   it('should NOT have brandUrl query parameter filtering in routes', () => {
     const routesDir = path.join(srcDir, 'routes');
     const files = getAllTsFiles(routesDir);

--- a/tests/unit/sales-funnel-vocabulary.test.ts
+++ b/tests/unit/sales-funnel-vocabulary.test.ts
@@ -1,28 +1,69 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import { funnelForGoal, goalsWithAFunnel } from "../../src/lib/sales-funnel-vocabulary.js";
+import {
+  SALES_FUNNEL_KEYS,
+  acceptedFunnelKeys,
+  funnelForGoal,
+  goalForFunnel,
+  goalsWithAFunnel,
+  toFunnelKey,
+} from "../../src/lib/sales-funnel-vocabulary.js";
 import { resolveCampaignFunnelKey } from "../../src/lib/funnel-adoption.js";
 
-describe("the funnel a goal means", () => {
+const PRE_RENAME = {
+  visit_form: "form_magnet",
+  reply_meeting: "sales_meetings_from_conversation",
+  visit_meeting: "sales_meetings_from_website",
+  visit_signup: "website_purchases",
+} as const;
+
+describe("the funnel a value names", () => {
+  it("passes a canonical key through untouched", () => {
+    for (const key of SALES_FUNNEL_KEYS) {
+      expect(toFunnelKey(key)).toBe(key);
+    }
+  });
+
+  it("resolves every pre-rename spelling — billing still emits them today", () => {
+    for (const [legacy, canonical] of Object.entries(PRE_RENAME)) {
+      expect(toFunnelKey(legacy)).toBe(canonical);
+    }
+  });
+
+  it("never invents a funnel for a token no catalogue names", () => {
+    expect(toFunnelKey("whatsapp_chain")).toBeNull();
+    expect(toFunnelKey(null)).toBeNull();
+    expect(toFunnelKey(undefined)).toBeNull();
+    expect(toFunnelKey("")).toBeNull();
+  });
+
+  it("accepts the canonical four plus the four pre-rename spellings, and nothing else", () => {
+    expect(new Set(acceptedFunnelKeys())).toEqual(
+      new Set([...SALES_FUNNEL_KEYS, ...Object.keys(PRE_RENAME)]),
+    );
+  });
+});
+
+describe("the funnel a retired goal meant", () => {
   it("form submissions run the Form Magnet funnel", () => {
-    expect(funnelForGoal("formSubmission")).toBe("visit_form");
-    expect(funnelForGoal("form_submissions")).toBe("visit_form");
+    expect(funnelForGoal("formSubmission")).toBe("form_magnet");
+    expect(funnelForGoal("form_submissions")).toBe("form_magnet");
   });
 
   it("a booked meeting runs Sales Meeting from Conversation — cold email replies, not the website", () => {
-    expect(funnelForGoal("meetingBooked")).toBe("reply_meeting");
-    expect(funnelForGoal("booked_meetings")).toBe("reply_meeting");
-    expect(funnelForGoal("sales_meetings")).toBe("reply_meeting");
+    expect(funnelForGoal("meetingBooked")).toBe("sales_meetings_from_conversation");
+    expect(funnelForGoal("booked_meetings")).toBe("sales_meetings_from_conversation");
+    expect(funnelForGoal("sales_meetings")).toBe("sales_meetings_from_conversation");
   });
 
-  it("a website purchase runs Website Purchase, under either spelling of that chain", () => {
-    expect(funnelForGoal("websitePurchase")).toBe("visit_signup");
-    expect(funnelForGoal("website_purchase")).toBe("visit_signup");
-    expect(funnelForGoal("purchase")).toBe("visit_signup");
-    expect(funnelForGoal("sales")).toBe("visit_signup");
-    expect(funnelForGoal("signup")).toBe("visit_signup");
-    expect(funnelForGoal("signups")).toBe("visit_signup");
+  it("a website purchase runs Website Purchases, under either spelling of that chain", () => {
+    expect(funnelForGoal("websitePurchase")).toBe("website_purchases");
+    expect(funnelForGoal("website_purchase")).toBe("website_purchases");
+    expect(funnelForGoal("purchase")).toBe("website_purchases");
+    expect(funnelForGoal("sales")).toBe("website_purchases");
+    expect(funnelForGoal("signup")).toBe("website_purchases");
+    expect(funnelForGoal("signups")).toBe("website_purchases");
   });
 
   it("never invents a funnel for a goal that names none", () => {
@@ -35,21 +76,52 @@ describe("the funnel a goal means", () => {
     expect(funnelForGoal("something-nobody-has-named")).toBeNull();
   });
 
-  it("emits only funnel keys brand-service's catalogue declares", () => {
-    const catalogue = new Set(["reply_meeting", "visit_meeting", "visit_signup", "visit_form"]);
+  it("emits only canonical funnel keys — never a pre-rename spelling", () => {
+    const canonical = new Set<string>(SALES_FUNNEL_KEYS);
     for (const goal of goalsWithAFunnel()) {
-      expect(catalogue.has(funnelForGoal(goal)!)).toBe(true);
+      expect(canonical.has(funnelForGoal(goal)!)).toBe(true);
     }
+  });
+});
+
+describe("the goal a funnel corresponds to — a legacy alias, never read back", () => {
+  it("answers what brand-service's catalogue put on each funnel before the retirement", () => {
+    expect(goalForFunnel("sales_meetings_from_conversation")).toBe("meetingBooked");
+    expect(goalForFunnel("sales_meetings_from_website")).toBe("meetingBooked");
+    expect(goalForFunnel("website_purchases")).toBe("signup");
+    expect(goalForFunnel("form_magnet")).toBe("formSubmission");
+  });
+
+  it("answers the same for a pre-rename spelling of the same funnel", () => {
+    for (const [legacy, canonical] of Object.entries(PRE_RENAME)) {
+      expect(goalForFunnel(legacy)).toBe(goalForFunnel(canonical));
+    }
+  });
+
+  it("is a real alias: every funnel it names round-trips to a canonical funnel", () => {
+    for (const key of SALES_FUNNEL_KEYS) {
+      const goal = goalForFunnel(key)!;
+      // Lossy on purpose — both meeting funnels answer one goal — so the round trip lands on A
+      // funnel, not necessarily the same one. That loss is exactly why nothing reads it back.
+      expect(SALES_FUNNEL_KEYS).toContain(funnelForGoal(goal));
+    }
+  });
+
+  it("names no funnel for a token no catalogue lists", () => {
+    expect(goalForFunnel("whatsapp_chain")).toBeNull();
+    expect(goalForFunnel(null)).toBeNull();
   });
 });
 
 describe("resolveCampaignFunnelKey", () => {
   it("prefers the campaign's own goal over its brand's", () => {
-    expect(resolveCampaignFunnelKey("meetingBooked", "formSubmission")).toBe("reply_meeting");
+    expect(resolveCampaignFunnelKey("meetingBooked", "formSubmission")).toBe(
+      "sales_meetings_from_conversation",
+    );
   });
 
   it("falls back to the brand's goal when the campaign states none", () => {
-    expect(resolveCampaignFunnelKey(null, "formSubmission")).toBe("visit_form");
+    expect(resolveCampaignFunnelKey(null, "formSubmission")).toBe("form_magnet");
   });
 
   it("stays null when neither names a funnel", () => {
@@ -58,38 +130,49 @@ describe("resolveCampaignFunnelKey", () => {
   });
 });
 
-describe("0042_campaign_funnel_from_goal migration", () => {
-  const sql = readFileSync(
-    resolve(__dirname, "../../drizzle/0042_campaign_funnel_from_goal.sql"),
-    "utf-8",
-  );
+describe("0042 then 0043: every goal that names a funnel reaches its canonical key", () => {
+  const from = (file: string) => readFileSync(resolve(__dirname, "../../drizzle", file), "utf-8");
+  const sql0042 = from("0042_campaign_funnel_from_goal.sql").replace(/[ \t]+/g, " ");
+  const sql0043 = from("0043_canonical_funnel_keys.sql").replace(/[ \t]+/g, " ");
 
-  it("writes the same funnel the code reads for every goal that names one", () => {
+  it("0042 writes the pre-rename key and 0043 renames it to what the code reads today", () => {
     for (const goal of goalsWithAFunnel()) {
-      expect(sql).toContain(`'${goal}'`);
-      expect(sql).toContain(`THEN '${funnelForGoal(goal)}'`);
+      expect(sql0042).toContain(`'${goal}'`);
+      const canonical = funnelForGoal(goal)!;
+      const preRename = Object.entries(PRE_RENAME).find(([, c]) => c === canonical)![0];
+      expect(sql0042).toContain(`THEN '${preRename}'`);
+      expect(sql0043).toContain(`WHEN '${preRename}' THEN '${canonical}'`);
     }
   });
 
-  it("only touches rows that state no funnel yet — idempotent, re-runnable", () => {
-    expect(sql).toContain('"funnel_key" IS NULL');
+  it("0043 renames every pre-rename spelling, so no row is left on a name nothing agrees on", () => {
+    for (const [legacy, canonical] of Object.entries(PRE_RENAME)) {
+      expect(sql0043).toContain(`WHEN '${legacy}' THEN '${canonical}'`);
+    }
   });
 
-  it("never deletes, stops or reschedules a campaign", () => {
-    const statements = sql
-      .split("\n")
-      .filter((l) => !l.trimStart().startsWith("--"))
-      .join("\n");
-    const upper = statements.toUpperCase();
-    expect(upper).not.toContain("DELETE");
-    expect(upper).not.toContain("DROP");
-    expect(upper).not.toContain("STATUS");
-    expect(upper).not.toContain("NEXT_RUN_AT");
+  it("0043 moves the provisioned NAME with the key it contains", () => {
+    expect(sql0043).toContain('SET "name" = replace(');
+  });
+
+  it("neither migration deletes, stops or reschedules a campaign", () => {
+    for (const sql of [sql0042, sql0043]) {
+      const upper = sql
+        .split("\n")
+        .filter((l) => !l.trimStart().startsWith("--"))
+        .join("\n")
+        .toUpperCase();
+      expect(upper).not.toContain("DELETE");
+      expect(upper).not.toContain("DROP");
+      expect(upper).not.toContain("STATUS");
+      expect(upper).not.toContain("NEXT_RUN_AT");
+      expect(upper).not.toContain("DAILY_BUDGET");
+    }
   });
 
   it("maps no goal that names several funnels or stops short of a paid client", () => {
     for (const goal of ["combinedSales", "websiteVisit", "positiveReply", "whatsappConversation"]) {
-      expect(sql).not.toContain(`'${goal}'`);
+      expect(sql0042).not.toContain(`'${goal}'`);
     }
   });
 });


### PR DESCRIPTION
## ⚠️ Deploy ordering — this must reach prod BEFORE or WITH brand-service v0.65.0, never after

brand-service #434 is merged to `staging` and not yet promoted. The moment it promotes, this
service — as it stands on prod today — stops provisioning funnel campaigns:
`brand-sales-funnels-client.ts` does `if (!raw?.funnelKey || !raw.goal) continue`, and #434 stops
emitting `goal` on every declared funnel. Every funnel is skipped, a brand on per-funnel budgets
gets no campaign at all, and **nothing errors** — the funnels simply never run.

So: merge this to `staging`, promote it to prod, and only then (or in the same window) promote
brand-service v0.65.0. The goal is not coming back to unblock it.

## Why

brand-service answered "what does this brand sell through?" twice, and the goal was the poorer
word: `sales_meetings_from_conversation` and `sales_meetings_from_website` both collapsed onto one
`meetingBooked`, so a meeting won from a reply and one won on the website were the same thing to
every consumer. #434 retires the goal set, backfills every brand onto funnels, and renames the four
keys. A campaign row here still carried a copy of that retired word beside its funnel key.

**A campaign runs ONE sales funnel. It says only that.**

## What changed

**`src/lib/sales-funnel-vocabulary.ts` is the one place the vocabulary lives.**

| | |
|---|---|
| `toFunnelKey` | every spelling in, one canonical token out |
| `funnelForGoal` | a RETIRED goal read as the funnel it named — for rows written before funnels existed |
| `goalForFunnel` | the goal a funnel corresponds to — a legacy alias, never read back |

**Canonicalised on three boundaries, and all three are load-bearing right now:**

- **billing-service still emits the pre-rename keys** (`reply_meeting`, `visit_meeting`,
  `visit_signup`, `visit_form`) on `/internal/brands/:id/funnel-budgets` — verified against the
  deployed staging registry, not source.
- **brand-service emits the canonical four** (`sales_meetings_from_conversation`,
  `sales_meetings_from_website`, `website_purchases`, `form_magnet`).
- **a campaign row can carry either**, until migration 0043 reaches it.

Compare raw tokens on any of the three and a fully-funded funnel reads as UNFUNDED: the gate blocks
it (`Funnel not funded`) and it silently stops sending. That is the second, quieter way this ship
could have broken the fleet, and it is covered on both the scheduler's ranking and the gate's
ceiling lookup.

**`campaigns.goal` survives as a derived legacy alias.** `goalForFunnel` is byte-equal with what
brand-service's catalogue emitted per funnel before the retirement (`…_from_conversation` and
`…_from_website` → `meetingBooked`, `website_purchases` → `signup`, `form_magnet` →
`formSubmission`), so the value on a row does not move under a consumer and the dashboard is not
forced into a lockstep change. It is also what keeps a funnel campaign out of goal arbitration.
Nothing in this service reads it back — the funnel is on the row.

**Migration 0043** renames the stored `funnel_key` and the provisioned campaign NAME that carries
the same token (`<feature> - <brandId> - <funnelKey>`, the only uniqueness Postgres can enforce for
one-campaign-per-funnel). Idempotent and re-runnable; a second pass matches nothing. No `DELETE`,
no `DROP`, no `status`, no `next_run_at`, no budget column — pinned by a test.

## Nothing in flight changes

- **Turn selection is untouched**: still `argmin(spent today ÷ own ceiling)` in
  `selectLowestFillRatio`, still every alive campaign a candidate every tick, still no fixed order
  and no tier scan.
- **A campaign that states no funnel** is still ranked on, and paced on, the brand daily budget.
- **#312's adoption rule is intact** — `findIncumbentForFunnel` still adopts the campaign already
  doing a funnel's work rather than standing up a twin. It resolves that funnel FROM a goal, which
  is exactly one of the readers re-keyed here: it now lands on the canonical key.
- **`isRemovableStandIn`** accepts a stand-in named under either vocabulary, so a row provisioned
  before this ship is still recognised — and every other condition (zero runs, zero lifetime cost,
  fail-closed on an unreadable read) is unchanged. Nothing that ever ran is ever removed.

## Tests

20 unit files green, `tsc` clean, `pnpm build` regenerates `openapi.json`.

- `sales-funnel-vocabulary.test.ts` — rewritten: canonicalisation both ways, the derived alias, and
  the 0042 → 0043 chain (every goal that names a funnel reaches its canonical key).
- `funnel-campaigns.test.ts` — the billing mock now feeds the pre-rename spellings on purpose, so
  every case crosses the producer gap. New: a campaign row still on a pre-rename key must rank on
  its funnel's real ceiling, not read as unfunded and starve.
- `gate-check.test.ts` — the campaign row states the canonical key against a legacy-speaking
  billing. New: a row on a pre-rename key still finds its ceiling.
- `no-legacy.test.ts` — two guards: no goal is read off a declared funnel, and no pre-rename key is
  ever emitted from the funnel map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
