### PR TITLE
hotfix: a campaign is unique on (org, brand, funnel, channel) — the workflow is not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,63 @@ funded funnels get worked, each spending up to its own ceiling and stopping ther
 - The brand-level PAUSE is untouched: the dashboard still reads and renders it.
 (Set 2026-08-02; adoption + fleet-wide funnel statement, same day.)
 
+## A campaign is unique on (org, brand, sales funnel, acquisition channel) — the WORKFLOW is not part of it
+
+Nothing else is part of that identity. A campaign changes workflow whenever selection picks a
+better one; it is not replaced by a second campaign each time it does. Treating the workflow as
+identity is what grew brand `f4d73dab` **137 stopped rows**, one per workflow version (`Aurora`,
+`Aurora V2`, `V3`, `Hassium` ×12, `Tributary` ×5 …), each holding a slice of a history nobody could
+read as one campaign.
+
+- **Two of the four were not stored facts** until migration 0044. `brand_id` (scalar) exists
+  because no unique index can span `brand_ids text[]` — the reality is one brand per campaign, and
+  every `ongoing` row in prod carries exactly one. `acquisition_channel` exists because consumers
+  derived the channel from the WORKFLOW SLUG, i.e. from the one attribute that legitimately
+  changes. Both are written once at creation by `campaignIdentityColumns`
+  (`src/lib/campaign-identity.ts`) — every `insert(campaigns)` goes through it, so a new write site
+  cannot leave a row Postgres will not police. Nothing re-derives either at read time.
+- **The channel is named per FEATURE FAMILY, not per medium alone.** `cold_email` for the sales
+  funnels; every other product family names its own (`pr_cold_email`, `expert_quote_outreach`, …).
+  A bare `cold_email` for all of them would make a brand's PR cold-email campaign and its SALES
+  cold-email campaign one identity, so the second could never exist. An unknown feature gets its
+  own slug with `-` as `_` — a feature shipped later can never silently share another's identity.
+- **`uniq_campaigns_org_brand_funnel_channel`** enforces it, partial on `status='ongoing'`: a
+  stopped row is history, not a competitor for the brand's turn. `coalesce(funnel_key,'')` is
+  load-bearing — Postgres treats NULLs as distinct, so without it a brand could grow unlimited
+  funnel-less campaigns on one channel.
+- **`POST /campaigns` on an identity already alive UPDATES that campaign** to the requested
+  workflow + configuration and returns it `200`, instead of inserting a second row. The NAME is
+  deliberately left alone (it is the campaign's own label, unique per org, not a restatement of
+  which workflow runs). A create that loses a race on the index gets the winner back, not an error.
+- **Still open**: the 134 historical stopped rows that DO carry runs cannot be collapsed from here
+  — their history lives in runs-service, keyed on `campaign_id`, and repointing it is runs-service's
+  own ledger to move. Deleting them would orphan the history, which is the one thing never allowed.
+
+## The funnel of a brand that sells through several is UNKNOWN, and unknown never costs the working campaign its turn
+
+A funnel-less campaign is attributed to a funnel by reading the goal it runs on (its own, else the
+brand's) through `funnelForGoal`. A goal that spans several funnels — `combinedSales` — names none,
+by design: a stated funnel is a fact, never a guess.
+
+**While such a campaign is alive, the brand grows NO funnel campaigns** (`ensureFundedFunnelCampaigns`),
+and an empty stand-in already provisioned for one is dropped (`isRemovableStandIn` — provisioned
+name, zero runs, zero lifetime cost, fails CLOSED on any unreadable read). Standing one up beside an
+unattributable incumbent duplicates its work AND lets the pair spend both ceilings on top of the
+incumbent's, which paces on the brand-level pot billing answers as the SUM of exactly those funnels.
+Prod, brand `f4d73dab` 2026-08-02: goal `combinedSales`, two funded funnels, two empty campaigns
+provisioned at 09:53 beside a campaign carrying six weeks and 69,442 runs.
+
+## Brand serialization counts SALES runs only — a brand's PR run is not its sales outreach's business
+
+`hasLiveSalesRunForBrand` asks runs-service campaign by campaign, over the brand's `ongoing`
+sales-family campaigns. It must NOT be a brand-wide `listRuns({ brandId })`: runs of the brand's PR,
+AI-visibility, hiring and VC campaigns carry the same brand, so a brand whose PR outreach ticks
+continuously (736 completed runs in one morning, one always in flight) reads as permanently busy and
+EVERY sales campaign of that brand is deferred 60s, every tick, forever. That is a full stop, and it
+appears in no log at all because the defer is the routine path. The candidate set is read from the
+DB, not from the campaigns claimed this tick — the one actually running is precisely the one NOT
+claimed (its `nextRunAt` is null while in flight). (Set 2026-08-02.)
+
 The per-campaign audience SUBSET (`campaigns.audience_ids`, Campaign v2) is a HARD filter on the audience bandit (`requiredAudienceIds` in `selectAudienceFromProjection`): a campaign never contacts an audience outside its targeted subset (no fallback). NULL/empty → inherit the brand's full active audience set. (The old workflow-conditioning `eligibleAudienceIds` soft-filter was REMOVED in v0.44.1 — see the single-endpoint note below.) Distinct from the singular `audienceId` column (per-campaign attribution; the per-RUN chosen audience is re-selected fresh at /start-run).
 
 ## Commands

--- a/drizzle/0044_campaign_identity_key.sql
+++ b/drizzle/0044_campaign_identity_key.sql
@@ -1,0 +1,59 @@
+-- A campaign is unique on (org, brand, sales funnel, acquisition channel).
+--
+-- Two of those four were not stored facts, which is why nothing could enforce the key:
+--
+--   * the BRAND lived in `brand_ids text[]`. No unique index can span an array, so Postgres was
+--     never able to police anything. The reality is one brand per campaign — every `ongoing` row
+--     in prod carries exactly one — so `brand_id` states it. Historical multi-brand rows (all
+--     stopped) keep their array and take its first element.
+--   * the ACQUISITION CHANNEL was not stored at all: consumers derived it from the workflow slug,
+--     i.e. from the one attribute that legitimately CHANGES under a campaign. It is now written
+--     once, from the feature the campaign already states.
+--
+-- The workflow is NOT part of the identity and never was: a campaign changes workflow every time
+-- selection picks a better one. Treating it as identity is what grew brand
+-- f4d73dab-1f9d-49b2-b16e-63ecde76a5eb 137 stopped rows — one per workflow version — each holding
+-- a slice of a history nobody could read as one campaign.
+--
+-- Idempotent and re-runnable: the columns are added IF NOT EXISTS, the backfill only writes rows
+-- that are still NULL, and the index is created IF NOT EXISTS. Nothing is deleted, stopped,
+-- rescheduled or re-budgeted, and no row that ever ran is touched beyond gaining two columns that
+-- restate what it already said.
+
+ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "brand_id" text;
+ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "acquisition_channel" text;
+
+-- The brand a campaign works. `brand_ids[1]` is Postgres' first element (1-indexed).
+UPDATE "campaigns"
+SET "brand_id" = "brand_ids"[1]
+WHERE "brand_id" IS NULL AND "brand_ids" IS NOT NULL AND array_length("brand_ids", 1) >= 1;
+
+-- The channel it acquires through. Byte-equal with `acquisitionChannelForFeature` in
+-- src/lib/campaign-identity.ts, INCLUDING its fallback: a feature neither list names keeps its own
+-- slug with '-' as '_', so a feature shipped later can never silently share another one's identity.
+UPDATE "campaigns"
+SET "acquisition_channel" = CASE "feature_slug"
+      WHEN 'sales-cold-email-outreach'     THEN 'cold_email'
+      WHEN 'sales-crm-email-outreach'      THEN 'crm_email'
+      WHEN 'pr-cold-email-outreach'        THEN 'pr_cold_email'
+      WHEN 'hiring-cold-email-outreach'    THEN 'hiring_cold_email'
+      WHEN 'vc-cold-email-outreach'        THEN 'vc_cold_email'
+      WHEN 'pr-expert-quote-outreach'      THEN 'expert_quote_outreach'
+      WHEN 'pr-expert-quote-opportunities' THEN 'expert_quote_opportunities'
+      WHEN 'ai-visibility-scoring'         THEN 'ai_visibility'
+      WHEN 'press-kit-page-generation'     THEN 'press_kit'
+      WHEN 'outlet-database-discovery'     THEN 'outlet_discovery'
+      ELSE replace("feature_slug", '-', '_')
+    END
+WHERE "acquisition_channel" IS NULL AND "feature_slug" IS NOT NULL;
+
+-- Enforce the key on the campaigns that are ALIVE. A stopped row is history: it is not competing
+-- for a brand's turn, it spends nothing, and collapsing the historical rows is a separate,
+-- reversible data operation — this index must never make a deploy fail on data that predates it.
+--
+-- `coalesce(funnel_key, '')` is load-bearing: Postgres treats NULLs as distinct in a unique index,
+-- so without it a brand could grow unlimited funnel-less campaigns on one channel — which is the
+-- exact duplication this key exists to stop.
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_campaigns_org_brand_funnel_channel"
+  ON "campaigns" ("org_id", "brand_id", coalesce("funnel_key", ''), "acquisition_channel")
+  WHERE "status" = 'ongoing' AND "brand_id" IS NOT NULL AND "acquisition_channel" IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1776800000000,
       "tag": "0043_canonical_funnel_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1776900000000,
+      "tag": "0044_campaign_identity_key",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { pgTable, text, timestamp, index, uniqueIndex, date, decimal, integer, jsonb, boolean, primaryKey } from "drizzle-orm/pg-core";
 
 // Campaigns table
@@ -19,6 +20,19 @@ export const campaigns = pgTable(
     // Brand IDs from brand-service (CSV in x-brand-id header, stored as array)
     // Nullable initially, populated when brands are created/found in brand-service
     brandIds: text("brand_ids").array(),
+
+    // The brand this campaign works — HALF THE IDENTITY KEY, and the reason it exists beside the
+    // array above: no unique index can span a `text[]`, so Postgres could not police
+    // one-campaign-per-(org, brand, funnel, channel) at all while the brand was only ever an array.
+    // The reality is one brand per campaign; this states it. Written once at creation from
+    // brandIds[0] (see campaignIdentityColumns) — the historical multi-brand rows are all stopped.
+    brandId: text("brand_id"),
+
+    // The medium this campaign acquires through — the OTHER half of the key that was not a stored
+    // fact: consumers derived it from the workflow slug, i.e. from the one attribute that
+    // legitimately changes under a campaign. Derived ONCE from the feature at creation
+    // (`acquisitionChannelForFeature`) and read here afterwards; nothing re-derives it.
+    acquisitionChannel: text("acquisition_channel"),
 
     // Feature slug — references features-service catalogue (e.g. "sales-cold-email-outreach")
     featureSlug: text("feature_slug"),
@@ -132,6 +146,15 @@ export const campaigns = pgTable(
     index("idx_campaigns_org").on(table.orgId),
     uniqueIndex("uniq_campaigns_org_name").on(table.orgId, table.name),
     index("idx_campaigns_org_feature_funnel").on(table.orgId, table.featureSlug, table.funnelKey),
+    // A campaign is unique on (org, brand, sales funnel, acquisition channel) — see migration 0044.
+    // Scoped to `ongoing`: a stopped row is history, not a competitor for the brand's turn.
+    // `coalesce(funnel_key, '')` is load-bearing — Postgres treats NULLs as distinct, so without it
+    // a brand could grow unlimited funnel-less campaigns on one channel.
+    uniqueIndex("uniq_campaigns_org_brand_funnel_channel")
+      .on(table.orgId, table.brandId, sql`coalesce(${table.funnelKey}, '')`, table.acquisitionChannel)
+      .where(
+        sql`${table.status} = 'ongoing' and ${table.brandId} is not null and ${table.acquisitionChannel} is not null`,
+      ),
   ]
 );
 

--- a/src/lib/campaign-identity.ts
+++ b/src/lib/campaign-identity.ts
@@ -1,0 +1,76 @@
+/**
+ * A campaign's IDENTITY: (org, brand, sales funnel, acquisition channel).
+ *
+ * Nothing else is part of it. In particular the WORKFLOW is not: a campaign changes workflow over
+ * time — selection re-picks one every run — and it does not get replaced by a new campaign each
+ * time it does. Treating the workflow as part of the identity is what grew one brand 137 stopped
+ * rows, one per workflow version (`Aurora`, `Aurora V2`, `V3`, `Hassium` x12, `Tributary` x5 …),
+ * each holding a slice of the history nobody could read as one campaign.
+ *
+ * Two of the four were not stored facts before this module:
+ *
+ *   - the BRAND was an ARRAY (`brand_ids`), which no unique index can span, so Postgres could not
+ *     enforce anything. The reality is one brand per campaign; `brand_id` states it.
+ *   - the ACQUISITION CHANNEL was not stored at all — consumers derived it from the workflow slug,
+ *     i.e. from the one attribute that legitimately changes under a campaign.
+ *
+ * Both are written once, at creation, from what the campaign already states. Nothing re-derives
+ * either at read time.
+ */
+
+/**
+ * The medium a campaign reaches people through, as a stored token.
+ *
+ * Named per FEATURE FAMILY rather than per medium alone, and that is deliberate: `cold_email`
+ * would make a brand's PR cold-email campaign and its SALES cold-email campaign the same identity
+ * while they sell different things, so a legitimate second campaign would collide with the first.
+ * The sales funnels — the only campaigns that state a funnel — get the plain medium name, and
+ * every other product family names its own channel.
+ *
+ * Total by construction: a feature absent from this map yields its own slug with `-` as `_`, so a
+ * feature shipped after this file can never silently share another one's identity.
+ */
+const CHANNEL_BY_FEATURE: Readonly<Record<string, string>> = Object.freeze({
+  // The sales funnels. `cold_email` and `crm_email` are the two mediums a sales funnel is worked
+  // through today; a brand may fund the same funnel on both, and those are two campaigns.
+  "sales-cold-email-outreach": "cold_email",
+  "sales-crm-email-outreach": "crm_email",
+
+  // Everything else. A sales funnel is not something these run — their funnel stays NULL — but
+  // they still carry a channel so the identity key is enforceable for them too.
+  "pr-cold-email-outreach": "pr_cold_email",
+  "hiring-cold-email-outreach": "hiring_cold_email",
+  "vc-cold-email-outreach": "vc_cold_email",
+  "pr-expert-quote-outreach": "expert_quote_outreach",
+  "pr-expert-quote-opportunities": "expert_quote_opportunities",
+  "ai-visibility-scoring": "ai_visibility",
+  "press-kit-page-generation": "press_kit",
+  "outlet-database-discovery": "outlet_discovery",
+});
+
+/**
+ * The channel a feature acquires through, or null when the campaign states no feature.
+ *
+ * Null is honest, not a default: a campaign with no feature slug states no channel, and the
+ * uniqueness index skips it rather than folding every such row onto one key.
+ */
+export function acquisitionChannelForFeature(featureSlug: string | null | undefined): string | null {
+  if (!featureSlug) return null;
+  return CHANNEL_BY_FEATURE[featureSlug] ?? featureSlug.replace(/-/g, "_");
+}
+
+/**
+ * The identity columns to stamp on a campaign at creation.
+ *
+ * Every `insert(campaigns)` in this service goes through here, so a new write site cannot forget
+ * one half of the key and leave a row Postgres will not police.
+ */
+export function campaignIdentityColumns(input: {
+  brandIds?: string[] | null;
+  featureSlug?: string | null;
+}): { brandId: string | null; acquisitionChannel: string | null } {
+  return {
+    brandId: input.brandIds?.[0] ?? null,
+    acquisitionChannel: acquisitionChannelForFeature(input.featureSlug),
+  };
+}

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -7,6 +7,7 @@ import { fetchDeclaredSalesFunnels, type DeclaredSalesFunnel } from "./brand-sal
 import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
 import { readBrandGoal, resolveCampaignFunnelKey } from "./funnel-adoption.js";
 import { acceptedFunnelKeys, goalForFunnel, toFunnelKey } from "./sales-funnel-vocabulary.js";
+import { campaignIdentityColumns } from "./campaign-identity.js";
 
 // A campaign that did not get this brand's turn re-checks on the next active tick. The turn is
 // re-ranked from scratch every tick, so this is a "wait your turn", not a backoff. EVERY alive
@@ -81,10 +82,13 @@ export function selectLowestFillRatio(candidates: FunnelTurnCandidate[]): string
  * Three things happen per brand, in this order:
  *   1. Provision — every funded funnel of the brand gets its own campaign (created on the spot,
  *      due immediately, so the next tick can claim it).
- *   2. Serialize — at most ONE run in flight per BRAND. This is the deliberate constraint that
- *      keeps funnels from running concurrently; removing it is what unlocks parallelism later,
- *      and nothing else has to be undone for that. It is not a lock: the same runs-service
- *      liveness read the per-campaign guard already uses, widened to the brand.
+ *   2. Serialize — at most ONE run in flight per brand ACROSS ITS SALES CAMPAIGNS. This is the
+ *      deliberate constraint that keeps funnels from running concurrently; removing it is what
+ *      unlocks parallelism later, and nothing else has to be undone for that. It is not a lock:
+ *      the same runs-service liveness read the per-campaign guard already uses, asked of each of
+ *      the brand's sales campaigns. It deliberately does NOT count the brand's PR / AI-visibility
+ *      / hiring / VC runs — those share neither leads nor sending accounts, and counting them
+ *      stopped a brand's sales outreach outright (see hasLiveSalesRunForBrand).
  *   3. Rank — the funded funnel with the lowest spent/ceiling ratio takes the turn.
  *
  * Fail-SOFT throughout: any unreadable budget, funnel set or spend leaves the brand on today's
@@ -154,10 +158,10 @@ async function planOneBrand(
   const declared = await fetchDeclaredSalesFunnels(brandId, identity);
   await ensureFundedFunnelCampaigns({ seed, brandId, featureSlug, funded, declared, now });
 
-  // Serial, for now: at most one run in flight per brand. Running funnels concurrently needs an
-  // audit of lead de-duplication and of sending-account load that nobody has done, so it is
+  // Serial, for now: at most one SALES run in flight per brand. Running funnels concurrently needs
+  // an audit of lead de-duplication and of sending-account load that nobody has done, so it is
   // deliberately out of scope — delete this block and the funnels run in parallel.
-  if (await hasLiveRunForBrand(orgId, brandId, now)) {
+  if (await hasLiveSalesRunForBrand(orgId, brandId, now)) {
     for (const c of group) deferred.set(c.id, new Date(now.getTime() + FUNNEL_TURN_DEFER_MS));
     return;
   }
@@ -243,21 +247,46 @@ async function ensureFundedFunnelCampaigns({
 
   const declaredKeys = new Set(declared.map((f) => f.funnelKey));
 
+  // Every alive campaign of this (org, brand, feature) that has not yet stated a funnel, oldest
+  // first — the oldest is the one carrying the history, the spend and the results.
+  const funnelless = await db.query.campaigns.findMany({
+    where: and(
+      eq(campaigns.orgId, seed.orgId),
+      eq(campaigns.featureSlug, featureSlug),
+      eq(campaigns.status, "ongoing"),
+      isNull(campaigns.funnelKey),
+      arrayContains(campaigns.brandIds, [brandId]),
+    ),
+    orderBy: [asc(campaigns.createdAt)],
+  });
+
   // The brand's goal is what tells us which funnel a campaign that states none is already
   // working. Read at most once per brand per tick, and only when there is something to adopt.
-  let brandGoal: string | null | undefined;
-  const brandGoalOnce = async (): Promise<string | null> => {
-    if (brandGoal === undefined) {
-      brandGoal = await readBrandGoal(brandId, {
+  const brandGoal = funnelless.length > 0
+    ? await readBrandGoal(brandId, {
         orgId: seed.orgId,
         userId: seed.createdByUserId,
         campaignId: seed.id,
         workflowSlug: seed.workflowSlug,
         featureSlug,
-      });
+      })
+    : null;
+
+  const incumbentByFunnel = new Map<string, { id: string }>();
+  // A funnel-less campaign whose goal names no single funnel — the brand sells through several
+  // (`combinedSales`), or the goal stops short of a paid client. We do NOT guess which funnel it
+  // works: the funnel is a stored fact, not an inference. But "unknown" must not mean the working
+  // campaign loses its turn to an empty one, so while such a campaign is alive this brand grows NO
+  // new funnel campaigns — see the provisioning branch below.
+  let hasUnattributableIncumbent = false;
+  for (const c of funnelless) {
+    const key = resolveCampaignFunnelKey(c.goal, brandGoal);
+    if (!key) {
+      hasUnattributableIncumbent = true;
+      continue;
     }
-    return brandGoal;
-  };
+    if (!incumbentByFunnel.has(key)) incumbentByFunnel.set(key, c);
+  }
 
   for (const f of funded) {
     if (!declaredKeys.has(f.funnelKey)) continue;
@@ -278,14 +307,7 @@ async function ensureFundedFunnelCampaigns({
     // Whichever alive campaign is already doing this funnel's work owns the funnel — the oldest
     // one, i.e. the one carrying the history. Checked even when a funnel campaign exists, so a
     // brand that already grew an empty duplicate is repaired rather than left with two.
-    const incumbent = await findIncumbentForFunnel({
-      orgId: seed.orgId,
-      brandId,
-      featureSlug,
-      funnelKey: f.funnelKey,
-      excludeId: existing?.id,
-      brandGoalOnce,
-    });
+    const incumbent = incumbentByFunnel.get(f.funnelKey) ?? null;
 
     if (incumbent) {
       await db
@@ -302,6 +324,26 @@ async function ensureFundedFunnelCampaigns({
         console.log(
           `[campaign-service] funnel ${f.funnelKey} of brand ${brandId}: kept campaign ${incumbent.id} ` +
           `(its own history) and dropped the empty stand-in ${existing.id} (never ran, never spent)`,
+        );
+      }
+      continue;
+    }
+
+    // The brand sells through several funnels and the campaign already doing the work does not say
+    // which. Standing a funnel campaign up beside it would duplicate its work AND let the pair
+    // spend both ceilings on top of each other — the incumbent paces on the brand-level pot, which
+    // billing answers as the SUM of exactly these funnels. So nothing new is provisioned while the
+    // ambiguity lasts; the working campaign keeps running on that pot, exactly as it did before
+    // per-funnel funding existed. An empty stand-in this bug already produced is dropped here.
+    if (hasUnattributableIncumbent) {
+      if (existing && (await isRemovableStandIn(existing, seed.orgId, brandId, featureSlug))) {
+        await db
+          .delete(campaigns)
+          .where(and(eq(campaigns.id, existing.id), eq(campaigns.orgId, seed.orgId)));
+        console.log(
+          `[campaign-service] funnel ${f.funnelKey} of brand ${brandId}: dropped the empty stand-in ` +
+          `${existing.id} (never ran, never spent) — the brand's alive campaign states no funnel and ` +
+          `its goal names no single one, so nothing is provisioned beside it`,
         );
       }
       continue;
@@ -330,6 +372,7 @@ async function ensureFundedFunnelCampaigns({
         name,
         workflowSlug: seed.workflowSlug,
         brandIds: [brandId],
+        ...campaignIdentityColumns({ brandIds: [brandId], featureSlug }),
         featureSlug,
         funnelKey: f.funnelKey,
         // The funnel says what this campaign sells. `goal` is the legacy alias of that same
@@ -352,52 +395,6 @@ async function ensureFundedFunnelCampaigns({
 
 export function funnelCampaignName(featureSlug: string, brandId: string, funnelKey: string): string {
   return `${featureSlug} - ${brandId} - ${funnelKey}`;
-}
-
-/**
- * The alive campaign already doing this funnel's work and not yet stating it.
- *
- * "Already doing this funnel's work" is decided by the goal the campaign runs on — its own when
- * it states one, the brand's otherwise — read through the funnel vocabulary. The OLDEST match
- * wins: it is the one carrying the history, the spend and the results.
- *
- * Only `ongoing` campaigns are adopted. A stopped campaign is not doing the funnel's work, and
- * adopting one would restart something the customer switched off.
- */
-async function findIncumbentForFunnel({
-  orgId,
-  brandId,
-  featureSlug,
-  funnelKey,
-  excludeId,
-  brandGoalOnce,
-}: {
-  orgId: string;
-  brandId: string;
-  featureSlug: string;
-  funnelKey: string;
-  excludeId?: string;
-  brandGoalOnce: () => Promise<string | null>;
-}): Promise<{ id: string } | null> {
-  const funnelless = await db.query.campaigns.findMany({
-    where: and(
-      eq(campaigns.orgId, orgId),
-      eq(campaigns.featureSlug, featureSlug),
-      eq(campaigns.status, "ongoing"),
-      isNull(campaigns.funnelKey),
-      arrayContains(campaigns.brandIds, [brandId]),
-    ),
-    orderBy: [asc(campaigns.createdAt)],
-  });
-
-  const candidates = funnelless.filter((c) => c.id !== excludeId);
-  if (candidates.length === 0) return null;
-
-  const brandGoal = await brandGoalOnce();
-  for (const c of candidates) {
-    if (resolveCampaignFunnelKey(c.goal, brandGoal) === funnelKey) return { id: c.id };
-  }
-  return null;
 }
 
 /**
@@ -470,19 +467,50 @@ async function spentTodayCents(orgId: string, campaignId: string, featureSlug: s
 }
 
 // Same "alive" definition the per-campaign guard uses (any running run within the freshness
-// window, whichever service owns it), widened from the campaign to the BRAND. Runs are tagged
-// with the campaign's brandId CSV, which for a funnel campaign is the single brand.
+// window, whichever service owns it), widened from the campaign to the brand's SALES campaigns.
 const LIVE_RUN_FRESHNESS_MS = 15 * 60_000;
 
-async function hasLiveRunForBrand(orgId: string, brandId: string, now: Date): Promise<boolean> {
-  const { runs } = await listRuns({
-    orgId,
-    brandId,
-    status: "running",
-    startedAfter: new Date(now.getTime() - LIVE_RUN_FRESHNESS_MS).toISOString(),
-    limit: 1,
+/**
+ * Is one of this brand's SALES campaigns running right now?
+ *
+ * Asked campaign by campaign, and that is the whole point: a brand-wide `listRuns({ brandId })`
+ * also counts the runs of the brand's PR, AI-visibility, hiring and VC campaigns, which are tagged
+ * with the same brand. A brand whose PR outreach ticks continuously — 736 completed runs in one
+ * morning, one always in flight — then reads as permanently busy, so EVERY sales campaign of that
+ * brand is deferred 60s, every tick, forever. That is not a slowdown: it is a full stop, and it
+ * shows up in no log at all because the defer is the routine path. It halted brand
+ * f4d73dab-1f9d-49b2-b16e-63ecde76a5eb outright (prod, 2026-08-02).
+ *
+ * The constraint this serialization exists for is about SALES funnels sharing leads and sending
+ * accounts. A PR pitch shares neither, so it was never meant to hold a sales funnel back.
+ *
+ * The candidate set is read from the DB rather than from the campaigns claimed this tick: the one
+ * that is actually running is precisely the one NOT claimed (its nextRunAt is null while in
+ * flight), so a group-scoped check would be blind to it.
+ */
+async function hasLiveSalesRunForBrand(orgId: string, brandId: string, now: Date): Promise<boolean> {
+  const alive = await db.query.campaigns.findMany({
+    where: and(
+      eq(campaigns.orgId, orgId),
+      eq(campaigns.status, "ongoing"),
+      arrayContains(campaigns.brandIds, [brandId]),
+    ),
+    columns: { id: true, featureSlug: true },
   });
-  return runs.length > 0;
+
+  const startedAfter = new Date(now.getTime() - LIVE_RUN_FRESHNESS_MS).toISOString();
+  for (const c of alive) {
+    if (!isSalesOutreachFeature(c.featureSlug)) continue;
+    const { runs } = await listRuns({
+      orgId,
+      campaignId: c.id,
+      status: "running",
+      startedAfter,
+      limit: 1,
+    });
+    if (runs.length > 0) return true;
+  }
+  return false;
 }
 
 function startOfToday(): Date {

--- a/src/lib/sales-outreach-campaign.ts
+++ b/src/lib/sales-outreach-campaign.ts
@@ -1,6 +1,7 @@
 import { and, arrayContains, desc, eq } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { campaigns, type Campaign } from "../db/schema.js";
+import { campaignIdentityColumns } from "./campaign-identity.js";
 
 export const SALES_OUTREACH_FEATURE_SLUG = "sales-cold-email-outreach";
 export const SALES_CRM_FEATURE_SLUG = "sales-crm-email-outreach";
@@ -141,6 +142,7 @@ export async function ensureRunnableSalesOutreachCampaign(
       name: defaultSalesOutreachCampaignName(resolvedFeatureSlug, brandId),
       workflowSlug: seedWorkflowSlugForFeature(resolvedFeatureSlug),
       brandIds: [brandId],
+      ...campaignIdentityColumns({ brandIds: [brandId], featureSlug: resolvedFeatureSlug }),
       featureSlug: resolvedFeatureSlug,
       featureInputs: null,
       status: "ongoing",

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and, desc, inArray } from "drizzle-orm";
+import { eq, and, desc, inArray, isNull } from "drizzle-orm";
 import { arrayContains } from "drizzle-orm/sql/expressions/conditions";
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
@@ -9,6 +9,7 @@ import { CreateCampaignBody, UpdateCampaignBody, CampaignsFilterQuery } from "..
 import { executeCampaignWorkflow, validateWorkflowInputs } from "../lib/workflows.js";
 import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
+import { campaignIdentityColumns } from "../lib/campaign-identity.js";
 
 const router = Router();
 
@@ -160,9 +161,89 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       }, req.headers).catch(() => {});
     }
 
+    // A campaign is unique on (org, brand, sales funnel, acquisition channel). The WORKFLOW is not
+    // part of that identity: a campaign changes workflow whenever selection picks a better one, and
+    // it is not replaced by a new campaign each time it does. Creating one per workflow is what grew
+    // a single brand 137 rows — one per workflow version — each holding a slice of a history nobody
+    // could read as one campaign. So a create that names an identity already alive UPDATES that
+    // campaign to the requested workflow and configuration and hands it back.
+    const identity = campaignIdentityColumns({ brandIds, featureSlug: resolvedFeatureSlug });
+    const incumbent = identity.brandId && identity.acquisitionChannel
+      ? await db.query.campaigns.findFirst({
+          where: and(
+            eq(campaigns.orgId, req.orgId!),
+            eq(campaigns.status, "ongoing"),
+            eq(campaigns.brandId, identity.brandId),
+            eq(campaigns.acquisitionChannel, identity.acquisitionChannel),
+            // This route never states a funnel, so the identity it names is the funnel-less one.
+            isNull(campaigns.funnelKey),
+          ),
+          orderBy: [campaigns.createdAt],
+        })
+      : null;
+
+    if (incumbent) {
+      // Only what the caller actually sent moves. The NAME is deliberately left alone: it is the
+      // campaign's own label (and unique per org), not a restatement of which workflow is running.
+      const [updated] = await db
+        .update(campaigns)
+        .set({
+          workflowSlug,
+          ...(featureInputs !== undefined ? { featureInputs } : {}),
+          ...(activeGoalId !== undefined ? { activeGoalId } : {}),
+          ...(brandProfileId !== undefined ? { brandProfileId } : {}),
+          ...(audienceId !== undefined ? { audienceId } : {}),
+          ...(goal !== undefined ? { goal } : {}),
+          ...(audienceIds !== undefined ? { audienceIds } : {}),
+          ...(servicesOffered !== undefined ? { servicesOffered } : {}),
+          ...(clickDestinationUrl !== undefined ? { clickDestinationUrl } : {}),
+          ...(maxBudgetDailyUsd !== undefined ? { maxBudgetDailyUsd } : {}),
+          ...(maxBudgetWeeklyUsd !== undefined ? { maxBudgetWeeklyUsd } : {}),
+          ...(maxBudgetMonthlyUsd !== undefined ? { maxBudgetMonthlyUsd } : {}),
+          ...(maxBudgetTotalUsd !== undefined ? { maxBudgetTotalUsd } : {}),
+          ...(dailyBudgetCents !== undefined ? { dailyBudgetCents } : {}),
+          ...(maxLeads !== undefined ? { maxLeads } : {}),
+          ...(startDate !== undefined ? { startDate } : {}),
+          ...(endDate !== undefined ? { endDate } : {}),
+          ...(notifyFrequency !== undefined ? { notifyFrequency } : {}),
+          ...(notifyChannel !== undefined ? { notifyChannel } : {}),
+          ...(notifyDestination !== undefined ? { notifyDestination } : {}),
+          updatedAt: new Date(),
+        })
+        .where(and(eq(campaigns.id, incumbent.id), eq(campaigns.orgId, req.orgId!)))
+        .returning();
+
+      if (req.runId) {
+        traceEvent(req.runId, {
+          service: "campaign-service",
+          event: "campaign-workflow-changed",
+          detail: `Campaign ${updated.id} already runs this (brand, funnel, channel) — switched its workflow to "${workflowSlug}" instead of creating a second campaign`,
+          data: { campaignId: updated.id, workflowSlug, brandId: identity.brandId, acquisitionChannel: identity.acquisitionChannel },
+        }, req.headers).catch(() => {});
+      }
+
+      executeCampaignWorkflow(updated.workflowSlug, {
+        campaignId: updated.id,
+        orgId: req.orgId!,
+        brandId: (updated.brandIds ?? []).join(","),
+        userId: req.userId!,
+        runId: req.runId!,
+        featureSlug: updated.featureSlug!,
+        activeGoalId: updated.activeGoalId,
+        brandProfileId: updated.brandProfileId,
+        audienceId: updated.audienceId,
+      }).catch((err) => {
+        console.error(`[campaign-service] Failed to trigger workflow for campaign ${updated.id}:`, err);
+      });
+
+      wakeScheduler();
+      return res.status(200).json({ campaign: updated });
+    }
+
     const [campaign] = await db
       .insert(campaigns)
       .values({
+        ...identity,
         orgId: req.orgId!,
         createdByUserId: req.userId ?? null,
         parentRunId: req.runId ?? null,
@@ -223,8 +304,23 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
 
     res.status(201).json({ campaign });
   } catch (error: any) {
-    if (error?.code === "23505" && (error?.constraint === "uniq_campaigns_org_name" || error?.constraint_name === "uniq_campaigns_org_name")) {
+    const constraint = error?.constraint ?? error?.constraint_name;
+    if (error?.code === "23505" && constraint === "uniq_campaigns_org_name") {
       return res.status(409).json({ error: "A campaign with this name already exists in your organization" });
+    }
+    // Two creates raced the same identity. The loser does not get a second campaign for it — the
+    // one that won IS this identity's campaign, so hand that one back rather than an error.
+    if (error?.code === "23505" && constraint === "uniq_campaigns_org_brand_funnel_channel") {
+      const winner = await db.query.campaigns.findFirst({
+        where: and(
+          eq(campaigns.orgId, req.orgId!),
+          eq(campaigns.status, "ongoing"),
+          eq(campaigns.brandId, (req.body.brandIds as string[])[0]),
+          isNull(campaigns.funnelKey),
+        ),
+        orderBy: [campaigns.createdAt],
+      });
+      if (winner) return res.status(200).json({ campaign: winner });
     }
     console.error("[campaign-service] Create campaign error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -28,15 +28,24 @@ describe("Campaign CRUD", () => {
   };
 
   /** Helper: create a campaign with all required headers */
-  function createCampaign(body: Record<string, unknown> = validBody, orgId = "org_test_crud") {
+  function createCampaign(
+    body: Record<string, unknown> = validBody,
+    orgId = "org_test_crud",
+    featureSlug = "sales-cold-email-v1",
+  ) {
     return request(app)
       .post("/campaigns")
       .set("x-api-key", API_KEY)
       .set("x-org-id", orgId)
       .set("x-user-id", "user_test_crud")
       .set("x-run-id", crypto.randomUUID())
-      .set("x-feature-slug", "sales-cold-email-v1")
+      .set("x-feature-slug", featureSlug)
       .send(body);
+  }
+
+  /** A brand nothing else in this test file is using — a fresh campaign identity. */
+  function freshBrand() {
+    return [crypto.randomUUID()];
   }
 
   describe("POST /campaigns", () => {
@@ -173,8 +182,31 @@ describe("Campaign CRUD", () => {
     it("should reject duplicate campaign name within same org with 409", async () => {
       await createCampaign().expect(201);
 
-      const res = await createCampaign().expect(409);
+      // A DIFFERENT identity (another brand) reusing the name — the name is what conflicts here.
+      // Re-posting the SAME identity is not a conflict at all; it switches that campaign's
+      // workflow, which is what the next test covers.
+      const res = await createCampaign({ ...validBody, brandIds: freshBrand() }).expect(409);
       expect(res.body.error).toBe("A campaign with this name already exists in your organization");
+    });
+
+    it("switches the workflow of the campaign that already IS this identity, never creating a second", async () => {
+      // (org, brand, funnel, channel) is the identity. The WORKFLOW is not part of it: a campaign
+      // changes workflow whenever selection picks a better one. Creating one per workflow is what
+      // grew a single brand 137 stopped rows, one per workflow version.
+      const brandIds = freshBrand();
+      const first = await createCampaign({ ...validBody, name: "Identity", brandIds }).expect(201);
+
+      const again = await createCampaign({
+        ...validBody,
+        name: "Identity — a later workflow",
+        brandIds,
+        workflowSlug: "sales-cold-email-outreach-osprey",
+      }).expect(200);
+
+      expect(again.body.campaign.id).toBe(first.body.campaign.id);
+      expect(again.body.campaign.workflowSlug).toBe("sales-cold-email-outreach-osprey");
+      // The name is the campaign's own label, not a restatement of which workflow runs.
+      expect(again.body.campaign.name).toBe("Identity");
     });
 
     it("should allow same campaign name in different orgs", async () => {
@@ -237,7 +269,7 @@ describe("Campaign CRUD", () => {
     it("should reject renaming to a name that already exists in the same org", async () => {
       await createCampaign().expect(201);
 
-      const res2 = await createCampaign({ ...validBody, name: "Other Campaign" }).expect(201);
+      const res2 = await createCampaign({ ...validBody, name: "Other Campaign", brandIds: freshBrand() }).expect(201);
 
       const renameRes = await request(app)
         .patch(`/campaigns/${res2.body.campaign.id}`)
@@ -361,7 +393,13 @@ describe("Campaign CRUD", () => {
     it("does NOT clobber a sibling campaign under the same brand", async () => {
       const sharedBrand = crypto.randomUUID();
       const a = await createCampaign({ ...validBody, name: "Sibling A", brandIds: [sharedBrand] }).expect(201);
-      const b = await createCampaign({ ...validBody, name: "Sibling B", brandIds: [sharedBrand] }).expect(201);
+      // Two campaigns CAN share a brand — on different acquisition channels. Same brand, same
+      // channel and same funnel would be one identity, so B runs a different feature.
+      const b = await createCampaign(
+        { ...validBody, name: "Sibling B", brandIds: [sharedBrand] },
+        "org_test_crud",
+        "sales-crm-email-outreach",
+      ).expect(201);
 
       // Configure A only.
       await patch(a.body.campaign.id, ownConfig).expect(200);

--- a/tests/unit/campaign-identity.test.ts
+++ b/tests/unit/campaign-identity.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  acquisitionChannelForFeature,
+  campaignIdentityColumns,
+} from "../../src/lib/campaign-identity.js";
+
+describe("acquisitionChannelForFeature", () => {
+  it("names the medium for the features that state a sales funnel", () => {
+    expect(acquisitionChannelForFeature("sales-cold-email-outreach")).toBe("cold_email");
+    expect(acquisitionChannelForFeature("sales-crm-email-outreach")).toBe("crm_email");
+  });
+
+  it("never folds two different products onto one channel", () => {
+    // A brand can legitimately run PR outreach and sales outreach at once, both by cold email, and
+    // both stating no funnel. Naming them both `cold_email` would make them ONE identity, so the
+    // second would collide with the first and could never exist.
+    const channels = [
+      "sales-cold-email-outreach",
+      "pr-cold-email-outreach",
+      "hiring-cold-email-outreach",
+      "vc-cold-email-outreach",
+      "sales-crm-email-outreach",
+      "pr-expert-quote-outreach",
+      "pr-expert-quote-opportunities",
+      "ai-visibility-scoring",
+      "press-kit-page-generation",
+      "outlet-database-discovery",
+    ].map(acquisitionChannelForFeature);
+    expect(new Set(channels).size).toBe(channels.length);
+  });
+
+  it("gives a feature it has never heard of its own channel rather than someone else's", () => {
+    expect(acquisitionChannelForFeature("some-future-feature")).toBe("some_future_feature");
+  });
+
+  it("states no channel for a campaign that states no feature", () => {
+    expect(acquisitionChannelForFeature(null)).toBeNull();
+    expect(acquisitionChannelForFeature(undefined)).toBeNull();
+    expect(acquisitionChannelForFeature("")).toBeNull();
+  });
+});
+
+describe("campaignIdentityColumns", () => {
+  it("states the brand as a scalar — no unique index can span the array", () => {
+    expect(campaignIdentityColumns({ brandIds: ["brand-1"], featureSlug: "sales-cold-email-outreach" }))
+      .toEqual({ brandId: "brand-1", acquisitionChannel: "cold_email" });
+  });
+
+  it("takes the first brand of a historical multi-brand row", () => {
+    expect(campaignIdentityColumns({ brandIds: ["a", "b"], featureSlug: null }).brandId).toBe("a");
+  });
+
+  it("leaves both null when the campaign states neither", () => {
+    expect(campaignIdentityColumns({})).toEqual({ brandId: null, acquisitionChannel: null });
+    expect(campaignIdentityColumns({ brandIds: [] }).brandId).toBeNull();
+  });
+});

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -74,6 +74,14 @@ import {
 
 const SALES = "sales-cold-email-outreach";
 
+// The brand's alive campaigns, as the sales-scoped liveness check reads them.
+let aliveBrandCampaigns: Array<{ id: string; featureSlug: string | null }> = [];
+// The brand's alive campaigns that have not yet stated a funnel, as adoption reads them.
+let funnellessCampaigns: Array<Record<string, unknown>> = [];
+function setFunnelless(rows: Array<Record<string, unknown>>) {
+  funnellessCampaigns = rows;
+}
+
 function claimed(overrides: Partial<ClaimedFunnelCampaign> = {}): ClaimedFunnelCampaign {
   return {
     id: "campaign-1",
@@ -198,8 +206,15 @@ describe("planFunnelTurns", () => {
     process.env.BRAND_SERVICE_API_KEY = "brand-key";
     mockListRuns.mockResolvedValue({ runs: [] });
     mockFindFirst.mockResolvedValue({ id: "existing", name: "custom name", status: "ongoing" });
-    // No funnel-less campaign to adopt unless a test says otherwise.
-    mockFindMany.mockResolvedValue([]);
+    // db.query.campaigns.findMany serves two different reads. The liveness check asks for
+    // { id, featureSlug } only; the adoption read asks for whole rows. Route on that so a test can
+    // set either independently — and default the brand to ONE alive sales campaign, so the
+    // liveness read is genuinely exercised (with no live run) rather than short-circuited.
+    aliveBrandCampaigns = [{ id: "campaign-1", featureSlug: SALES }];
+    mockFindMany.mockImplementation(async (args: { columns?: Record<string, boolean> }) =>
+      args?.columns?.featureSlug ? aliveBrandCampaigns : funnellessCampaigns,
+    );
+    funnellessCampaigns = [];
     mockInsertValues.mockResolvedValue(undefined);
     mockUpdateWhere.mockResolvedValue(undefined);
     mockDeleteWhere.mockResolvedValue(undefined);
@@ -292,7 +307,11 @@ describe("planFunnelTurns", () => {
     expect(deferred.get("c-canonical")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
   });
 
-  it("holds the whole brand while a run is in flight — one run per brand", async () => {
+  it("holds the whole brand while a SALES run is in flight — one run per brand", async () => {
+    aliveBrandCampaigns = [
+      { id: "c-visit", featureSlug: SALES },
+      { id: "c-reply", featureSlug: SALES },
+    ];
     mockFunnelBudgets([
       { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
       { funnelKey: "reply_meeting", dailyBudgetCents: "2000" },
@@ -314,9 +333,39 @@ describe("planFunnelTurns", () => {
 
     expect(deferred.get("c-visit")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
     expect(deferred.get("c-reply")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
-    // The brand's liveness is what is checked, not one campaign's.
+    // Asked of the brand's SALES campaigns, one at a time — never brand-wide, which would also
+    // count the brand's PR / AI-visibility / hiring / VC runs and hold sales forever.
     expect(mockListRuns).toHaveBeenCalledWith(
-      expect.objectContaining({ orgId: "org-1", brandId: "brand-1", status: "running" }),
+      expect.objectContaining({ orgId: "org-1", campaignId: "c-visit", status: "running" }),
+    );
+    expect(mockListRuns).not.toHaveBeenCalledWith(
+      expect.objectContaining({ brandId: "brand-1" }),
+    );
+  });
+
+  it("a brand's PR run never holds its sales outreach — the liveness check skips other features", async () => {
+    // Prod, brand f4d73dab (2026-08-02): PR outreach ticks continuously, so a brand-wide liveness
+    // read always saw a live run and every sales campaign was deferred 60s, every tick, forever.
+    aliveBrandCampaigns = [
+      { id: "c-pr", featureSlug: "pr-expert-quote-outreach" },
+      { id: "c-visit", featureSlug: SALES },
+    ];
+    mockListRuns.mockImplementation(async ({ campaignId }: { campaignId?: string }) =>
+      campaignId === "c-pr" ? { runs: [{ id: "live-pr" }] } : { runs: [] },
+    );
+    mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+    mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
+    mockSpend("0");
+
+    const now = new Date("2026-08-02T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [claimed({ id: "c-visit", funnelKey: "website_purchases" })],
+      now,
+    );
+
+    expect(deferred.has("c-visit")).toBe(false); // takes its turn — the PR run is not its business
+    expect(mockListRuns).not.toHaveBeenCalledWith(
+      expect.objectContaining({ campaignId: "c-pr" }),
     );
   });
 
@@ -374,7 +423,7 @@ describe("planFunnelTurns", () => {
     mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
     mockDeclaredFunnels([{ funnelKey: "form_magnet" }]);
     mockFindFirst.mockResolvedValue(undefined); // no campaign states this funnel yet
-    mockFindMany.mockResolvedValue([
+    setFunnelless([
       // The months-old campaign, running on the brand's goal, carrying all the history.
       { id: "c-incumbent", name: "opsfolio.com — Signups", goal: null, status: "ongoing" },
     ]);
@@ -394,7 +443,7 @@ describe("planFunnelTurns", () => {
     mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
     mockDeclaredFunnels([{ funnelKey: "form_magnet" }]);
     mockFindFirst.mockResolvedValue(undefined);
-    mockFindMany.mockResolvedValue([
+    setFunnelless([
       { id: "c-oldest", name: "the one with the history", goal: null, status: "ongoing" },
       { id: "c-newer", name: "a later one", goal: null, status: "ongoing" },
     ]);
@@ -415,7 +464,7 @@ describe("planFunnelTurns", () => {
     mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
     mockDeclaredFunnels([{ funnelKey: "form_magnet" }]);
     mockFindFirst.mockResolvedValue(undefined);
-    mockFindMany.mockResolvedValue([
+    setFunnelless([
       { id: "c-meetings", name: "meetings", goal: "meetingBooked", status: "ongoing" },
     ]);
     mockBrandGoal("meetingBooked");
@@ -435,7 +484,7 @@ describe("planFunnelTurns", () => {
       name: funnelCampaignName(SALES, "brand-1", "form_magnet"),
       status: "ongoing",
     });
-    mockFindMany.mockResolvedValue([
+    setFunnelless([
       { id: "c-incumbent", name: "opsfolio.com — Signups", goal: null, status: "ongoing" },
     ]);
     mockBrandGoal("formSubmission");
@@ -453,6 +502,58 @@ describe("planFunnelTurns", () => {
     expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
   });
 
+  it("provisions nothing beside a campaign whose goal names no single funnel", async () => {
+    // Prod, brand f4d73dab (2026-08-02): the brand's goal is `combinedSales`, which spans BOTH its
+    // funded funnels, so nothing could say which one its six-week-old campaign was working. Two
+    // empty campaigns were stood up beside it — which is the duplication this whole key exists to
+    // stop, and which would have let the pair spend both ceilings on top of the incumbent's.
+    mockFunnelBudgets([
+      { funnelKey: "reply_meeting", dailyBudgetCents: "3000" },
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+    ]);
+    mockDeclaredFunnels([
+      { funnelKey: "sales_meetings_from_conversation" },
+      { funnelKey: "website_purchases" },
+    ]);
+    mockFindFirst.mockResolvedValue(undefined); // no funnel campaign exists yet
+    setFunnelless([
+      { id: "c-incumbent", name: "Sales Cold Email Outreach Pelican", goal: null, status: "ongoing" },
+    ]);
+    mockBrandGoal("combinedSales");
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ id: "c-incumbent" })], new Date("2026-08-02T10:00:00Z"));
+
+    // Nothing created, nothing adopted: the funnel is a stored fact, never a guess — and the
+    // working campaign keeps its turn on the brand-level pot.
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+  });
+
+  it("drops the empty stand-ins already provisioned beside an unattributable campaign", async () => {
+    mockFunnelBudgets([{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }]);
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue({
+      id: "c-standin",
+      name: funnelCampaignName(SALES, "brand-1", "sales_meetings_from_conversation"),
+      status: "ongoing",
+    });
+    setFunnelless([
+      { id: "c-incumbent", name: "Sales Cold Email Outreach Pelican", goal: null, status: "ongoing" },
+    ]);
+    mockBrandGoal("combinedSales");
+    mockListRuns.mockResolvedValueOnce({ runs: [] }); // the stand-in never ran
+    mockGetStatsBudget.mockResolvedValueOnce({
+      windows: [{ label: "lifetime", totalCostInUsdCents: "0", netTotalCostInUsdCents: "0" }],
+    });
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ id: "c-incumbent" })], new Date("2026-08-02T10:00:00Z"));
+
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
   it("never drops a stand-in that has ever run", async () => {
     mockFunnelBudgets([{ funnelKey: "visit_form", dailyBudgetCents: "1000" }]);
     mockDeclaredFunnels([{ funnelKey: "form_magnet" }]);
@@ -461,7 +562,7 @@ describe("planFunnelTurns", () => {
       name: funnelCampaignName(SALES, "brand-1", "form_magnet"),
       status: "ongoing",
     });
-    mockFindMany.mockResolvedValue([
+    setFunnelless([
       { id: "c-incumbent", name: "opsfolio.com — Signups", goal: null, status: "ongoing" },
     ]);
     mockBrandGoal("formSubmission");
@@ -477,7 +578,7 @@ describe("planFunnelTurns", () => {
     mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
     mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
     mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
-    mockFindMany.mockResolvedValue([]);
+    setFunnelless([]);
     mockSpend("900"); // c-legacy: 90% of the brand total
     mockSpend("100"); // c-visit: 10% of its own ceiling
 
@@ -500,7 +601,7 @@ describe("planFunnelTurns", () => {
     mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
     mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
     mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
-    mockFindMany.mockResolvedValue([]);
+    setFunnelless([]);
     mockSpend("0");   // c-legacy: nothing spent
     mockSpend("900"); // c-visit: 90% full
 
@@ -521,7 +622,7 @@ describe("planFunnelTurns", () => {
     mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
     mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
     mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
-    mockFindMany.mockResolvedValue([]);
+    setFunnelless([]);
     mockSpend("1200"); // the funded funnel is over its ceiling
     mockSpend("0");    // the unfunded one has spent nothing, but has no ceiling to fill
 


### PR DESCRIPTION
## What happened in prod

Brand `f4d73dab-1f9d-49b2-b16e-63ecde76a5eb` (org `f0420eb5`) ran 1,137 sales runs today and spent **4019.25¢ of its 4000¢ daily budget** by 09:38 UTC. At 09:53 two empty campaigns were provisioned beside the campaign carrying six weeks and 69,442 runs, and both have been deferred 60s per tick ever since, producing zero runs.

Three defects, one identity.

### 1. The brand's goal spans both its funded funnels, so nothing could say which one its campaign worked

`combinedSales` names no single funnel — deliberately, since a stated funnel is a fact rather than a guess. Adoption therefore matched nothing and both funded funnels got a fresh, empty campaign.

While a funnel-less campaign cannot be attributed, the brand now grows **no** funnel campaigns, and an empty stand-in already provisioned for one is dropped (`isRemovableStandIn`: provisioned name, zero runs, zero lifetime cost, fails CLOSED on any unreadable read). The working campaign keeps its turn on the brand-level pot — which billing answers as the SUM of exactly those funnels, so a funnel campaign beside it would have spent both ceilings on top of the incumbent's.

### 2. A brand's PR run was holding its sales outreach

`hasLiveRunForBrand` asked runs-service for **any** running run of the brand. The brand's PR outreach ticks continuously (736 completed runs this morning, one always in flight) and carries the same brand, so the brand read as permanently busy and every sales campaign was deferred 60s, every tick, forever. No log at all — the defer is the routine path.

It now asks campaign by campaign over the brand's `ongoing` **sales** campaigns. The candidate set is read from the DB, not from the campaigns claimed this tick: the one actually running is precisely the one not claimed (its `nextRunAt` is null while in flight).

### 3. The identity was unenforceable, and the workflow was acting as part of it

A campaign is unique on **(org, brand, sales funnel, acquisition channel)**. Two of those four were not stored facts:

- the brand lived in `brand_ids text[]`, which no unique index can span. Every `ongoing` row in prod carries exactly one brand; `brand_id` states it.
- the acquisition channel was not stored at all — consumers derived it from the workflow slug, i.e. from the one attribute that legitimately changes under a campaign.

Migration `0044` adds both, backfills them, and creates `uniq_campaigns_org_brand_funnel_channel` (partial on `ongoing`; `coalesce(funnel_key,'')` so NULLs collide rather than multiply). `POST /campaigns` on an identity already alive now switches that campaign's workflow and configuration and returns it `200` — creating one per workflow is what grew this brand 137 stopped rows, one per workflow version.

The channel is named per feature family, not per medium alone: `cold_email` for the sales funnels, its own token for every other product. A bare `cold_email` everywhere would make a brand's PR cold-email campaign and its sales cold-email campaign one identity, so the second could never exist.

## Not in this PR

134 of the 137 stopped rows carry real runs. Collapsing them means repointing history that lives in **runs-service**, keyed on `campaign_id` — that service owns its ledger, and deleting the rows from here would orphan the history, which is the one thing never allowed. Filed separately.

## Verification

- `pnpm test:unit` — 293 passed, including the two new prod scenarios (unattributable incumbent provisions nothing; a PR run never holds sales) and `campaign-identity`.
- `tsc --noEmit` clean, build + OpenAPI regenerated (no API shape change).
- Prod before: 4 `ongoing` campaigns for the brand, 2 of them empty; 0 sales runs since 09:38. Post-deploy state reported against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
