### PR TITLE
hotfix: Brand f4d73dab: the owner answered its funnel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,20 @@ incumbent's, which paces on the brand-level pot billing answers as the SUM of ex
 Prod, brand `f4d73dab` 2026-08-02: goal `combinedSales`, two funded funnels, two empty campaigns
 provisioned at 09:53 beside a campaign carrying six weeks and 69,442 runs.
 
+**Only the OWNER lifts that unknown, per (org, brand), and every such answer is written through
+`campaign_funnel_owner_decisions`** — one row per campaign it wrote, holding the value it replaced
+and the migration tag that wrote it, so the write is auditable, re-runnable and undoable by that
+tag. Nothing in the runtime reads the table: the funnel lives on the campaign row like every other
+one. First answer, migration 0045 (org `f0420eb5` / brand `f4d73dab`, Kevin 2026-08-02): the live
+campaign `d5a759bf` states `sales_meetings_from_conversation`, its 51 stopped sales campaigns state
+`website_purchases`. The brand switched funnel on 19 July WITHOUT creating a campaign, so no row
+marks the transition; a run-date split was declined — a campaign's history is not cut in two — and
+the accepted cost is that 33,229 of `d5a759bf`'s 54,809 runs predate the switch and sit under the
+meeting funnel (one-directional: a meeting reads MORE expensive than it was, never less). Do NOT
+"fix" it. Do NOT extend the answer to any other brand in the same state, and note that a brand row
+is claimed by several orgs — three stopped campaigns other orgs hold on `f4d73dab` are other
+customers' and keep a NULL funnel.
+
 ## Brand serialization counts SALES runs only — a brand's PR run is not its sales outreach's business
 
 `hasLiveSalesRunForBrand` asks runs-service campaign by campaign, over the brand's `ongoing`
@@ -317,8 +331,6 @@ The campaign picks, per run, WHICH audience to contact and WHICH workflow to run
 
 **Downstream honors the choice — already correct, don't rebuild:** lead-service `buffer/next` uses the passed `x-audience-id` and does NOT re-select; human-service suppression is **per-brand atomic, cross-audience** (the serve cursor is per-audience) so overlapping audiences never double-contact. `workflowSlug == workflowDynastySlug` (v1) so the projection row's dynasty slug is executable by `/by-slug/{slug}/execute`.
 
-**Per-workflow outcome tagging + full active-audience enumeration SHIPPED (features-service#638, prod v0.101.2, 2026-07-22).** The projection audience grain is now per `(audienceId × workflowDynastySlug)`, send-tagged (real per-workflow outcomes — the old "byte-identical to `/audience-stats`, same across couples" caveat is DEAD), AND the handler emits a row for EVERY active audience × every active dynasty (audiences with no couple floor brand→crossOrg via the cascade). This is what enables the single-endpoint audience Thompson above: the chosen workflow's rows already ARE the brand's active-audience candidate set with workflow-discriminated evidence, so campaign-service needs no separate `/audience-stats` call. Coverage is forward-only (send-tags from workflow-service#333 / email-gateway#168-170); the cascade floors history.
+**The projection's audience grain is `(audienceId × workflowDynastySlug)`, send-tagged, and it emits a row for EVERY active audience × every active dynasty** (features-service#638) — audiences with no couple floor brand→crossOrg via the cascade. That is what makes the single-endpoint Thompson above possible: the chosen workflow's rows already ARE the brand's active-audience candidate set with workflow-discriminated evidence. `/features/:slug/candidates` no longer exists; its evidence lives in the reshaped `workflow-projection` (`rows[]` grain-ladder + `resolved`), read via `src/lib/features-workflow-projection-client.ts`, which sends `brandId` + `goal` only.
 
-**Endpoint migration (2026-07-06):** features-service DELETED `/features/:slug/candidates` and folded its evidence into the reshaped `GET /features/:slug/workflow-projection` (`rows[]` grain-ladder + `resolved`). campaign-service reads `rows[]`, ranks on `row.resolved.costPerOutcomeUsd`, scopes audiences via `row.audienceId`. Client: `src/lib/features-workflow-projection-client.ts` (was `features-candidates-client.ts`). Sends `brandId` + `goal` only (brandProfileId dropped — the new endpoint derives economics from brandId).
-
-**Spin deadlock fixed by the single-endpoint move (v0.44.1, 2026-07-22).** BEFORE: the workflow-conditioning soft-filter narrowed the audience candidate set (from `/audience-stats`) to the audiences that had RUN the chosen workflow. When the greedy workflow locked onto a dynasty whose only run-attributed audience was exhausted (prod brand `75d7e3e8`, workflow `granite` → sole audience `729e06f0`, exhausted), the soft-filter collapsed the set to that one exhausted audience, then the exhaustion exclusion emptied it → `/start-run` picked NO audience (`audience_id` NULL) → empty `lead-serve` → ~20s spin, while the stop-guard `hasServeableAudience` (which used a DIFFERENT, unscoped eligibility) saw the brand's OTHER active audiences and refused to stop. The two legs used mismatched eligibility, so they never agreed. The producer-side enumeration fix (features#638) + the consumer-side single-endpoint move (this repo) both close it: the chosen workflow's rows now include every active audience, so exhausting one leaves the others serveable and `selectAudienceFromProjection` picks among them. Do NOT reintroduce a workflow-scoped candidate filter that can collapse to a subset the stop-guard doesn't see.
+**Never reintroduce a workflow-scoped audience filter that can collapse to a subset the stop-guard doesn't see.** The removed soft-filter narrowed the candidates to audiences that had RUN the chosen workflow; when greedy locked onto a dynasty whose only run-attributed audience was exhausted, the exhaustion exclusion then emptied the set → `/start-run` picked NO audience → empty `lead-serve` → ~20s spin, while `hasServeableAudience` (unscoped) saw the brand's other audiences and refused to stop. Two legs on mismatched eligibility never agree.

--- a/drizzle/0045_owner_funnel_decision_f4d73dab.sql
+++ b/drizzle/0045_owner_funnel_decision_f4d73dab.sql
@@ -1,0 +1,105 @@
+-- The funnel of a brand that sells through several is UNKNOWN — until its owner answers it.
+--
+-- Migration 0042 and the boot backfill both read a campaign's goal to write the funnel it runs,
+-- and both deliberately stopped at a goal naming no single funnel. `combinedSales` is that case:
+-- it spans several funnels, so a campaign running on it keeps a NULL funnel, because the funnel
+-- is a stored fact and never a guess. That branch is correct and stays for every brand nobody
+-- has answered for.
+--
+-- For ONE (org, brand) pair the owner has now answered it. Kevin, 2026-08-02, on
+-- org f0420eb5-8f72-4f0a-a150-f473746df1e6 / brand f4d73dab-1f9d-49b2-b16e-63ecde76a5eb:
+--
+--   * the brand optimized WEBSITE PURCHASES from the start, and switched to SALES MEETINGS FROM
+--     CONVERSATION on 19 July 2026. It did NOT create a new campaign to do so — the same campaign
+--     kept running under a new goal, so no campaign row marks the transition;
+--   * the live campaign d5a759bf-6729-4325-b3cd-f1ff357d0538 (created 15 June) therefore states
+--     `sales_meetings_from_conversation`;
+--   * every one of the pair's STOPPED sales campaigns states `website_purchases`.
+--
+-- A run-date split is what the truth would require, and the owner was shown it and declined: he
+-- does not want a campaign's history cut in two. The funnel stays ONE value per campaign, and the
+-- accepted cost is recorded here so nobody "fixes" it later: 33,229 of d5a759bf's 54,809 runs
+-- predate the switch and sit under the meeting funnel. The distortion is one-directional — a
+-- meeting reads MORE expensive than it was, never less.
+--
+-- What this does NOT touch, on purpose:
+--   * `goal` — the campaigns state none and keep stating none. The funnel is what a consumer
+--     reads; writing a goal would change what the runtime optimizes, which is not a labelling
+--     decision and was not asked for.
+--   * status, schedule, budget, history. Nothing is deleted, stopped, rescheduled or re-budgeted.
+--   * the brand's PR, AI-visibility and VC campaigns: they run no sales funnel, and a NULL funnel
+--     is the true statement for them.
+--   * the same brand's campaigns under OTHER orgs. A brand row is a shared global identity — four
+--     orgs claim this one — and everything configured on top of it belongs to the (org, brand)
+--     pair. The owner answered for HIS pair; the three stopped campaigns other orgs hold on this
+--     brand are other customers' and keep a NULL funnel.
+--   * every OTHER brand still sitting in the same unattributable state. None of them has been
+--     answered for, and this migration names exactly one pair.
+--
+-- REVERSIBLE. Every row it writes is recorded in `campaign_funnel_owner_decisions` with the value
+-- it replaced, so an operator can read back exactly what was written and undo it:
+--
+--   SELECT * FROM campaign_funnel_owner_decisions WHERE source = '0045_owner_funnel_decision_f4d73dab';
+--
+--   UPDATE campaigns c
+--   SET funnel_key = d.previous_funnel_key
+--   FROM campaign_funnel_owner_decisions d
+--   WHERE c.id::text = d.campaign_id
+--     AND d.source = '0045_owner_funnel_decision_f4d73dab'
+--     AND c.funnel_key = d.funnel_key;
+--
+-- IDEMPOTENT: the decision rows are inserted ON CONFLICT DO NOTHING and the campaign write only
+-- ever touches a row whose funnel is still NULL, so a re-boot (or a second replica booting at the
+-- same moment) re-runs it for free and converges on the same rows.
+
+CREATE TABLE IF NOT EXISTS "campaign_funnel_owner_decisions" (
+  "campaign_id" text PRIMARY KEY,
+  "org_id" text NOT NULL,
+  "brand_id" text,
+  "previous_funnel_key" text,
+  "funnel_key" text NOT NULL,
+  "decided_by" text NOT NULL,
+  "decided_on" date NOT NULL,
+  "source" text NOT NULL,
+  "applied_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_cfod_source" ON "campaign_funnel_owner_decisions" ("source");
+
+-- Record the decision first, so the rows it is about to write are readable even if the apply step
+-- is interrupted.
+INSERT INTO "campaign_funnel_owner_decisions" (
+  "campaign_id", "org_id", "brand_id", "previous_funnel_key", "funnel_key",
+  "decided_by", "decided_on", "source"
+)
+-- `campaigns.id` is a uuid in the database while `schema.ts` declares it text (a historical
+-- drift, older than funnels). The decision row keys on the text spelling so this table matches
+-- what Drizzle materializes, and every join casts — never compare the two raw.
+SELECT
+  c."id"::text,
+  c."org_id",
+  c."brand_id",
+  c."funnel_key",
+  CASE WHEN c."id" = 'd5a759bf-6729-4325-b3cd-f1ff357d0538'
+    THEN 'sales_meetings_from_conversation'
+    ELSE 'website_purchases'
+  END,
+  'kevin',
+  DATE '2026-08-02',
+  '0045_owner_funnel_decision_f4d73dab'
+FROM "campaigns" c
+WHERE c."org_id" = 'f0420eb5-8f72-4f0a-a150-f473746df1e6'
+  AND c."brand_id" = 'f4d73dab-1f9d-49b2-b16e-63ecde76a5eb'
+  AND c."feature_slug" IN ('sales-cold-email-outreach', 'sales-crm-email-outreach')
+  AND c."funnel_key" IS NULL
+ON CONFLICT ("campaign_id") DO NOTHING;
+
+-- Apply it. The `funnel_key IS NULL` guard is what makes a second run a no-op, and it also means a
+-- funnel written by anything else later is never overwritten by this pass.
+UPDATE "campaigns" c
+SET "funnel_key" = d."funnel_key",
+    "updated_at" = now()
+FROM "campaign_funnel_owner_decisions" d
+WHERE c."id"::text = d."campaign_id"
+  AND d."source" = '0045_owner_funnel_decision_f4d73dab'
+  AND c."funnel_key" IS NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1776900000000,
       "tag": "0044_campaign_identity_key",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1777000000000,
+      "tag": "0045_owner_funnel_decision_f4d73dab",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -234,3 +234,32 @@ export const campaignAudienceExhaustion = pgTable(
 
 export type CampaignAudienceExhaustion = typeof campaignAudienceExhaustion.$inferSelect;
 export type NewCampaignAudienceExhaustion = typeof campaignAudienceExhaustion.$inferInsert;
+
+// The funnel a campaign runs is a stored fact, derived from what the campaign itself said. When
+// what it said names no single funnel — a brand selling through several under one `combinedSales`
+// goal — the funnel stays NULL rather than being guessed, and only the OWNER can answer it.
+//
+// This table is the record of those answers: one row per campaign an owner decision wrote, holding
+// the value it replaced. It is what makes such a write auditable and reversible — an operator reads
+// back exactly which rows a decision touched and can restore `previous_funnel_key` — and what makes
+// re-running one a no-op. Nothing in the runtime reads it: the funnel itself lives on the campaign
+// row, as it does for every other campaign.
+export const campaignFunnelOwnerDecisions = pgTable(
+  "campaign_funnel_owner_decisions",
+  {
+    campaignId: text("campaign_id").primaryKey(),
+    orgId: text("org_id").notNull(),
+    brandId: text("brand_id"),
+    previousFunnelKey: text("previous_funnel_key"),
+    funnelKey: text("funnel_key").notNull(),
+    decidedBy: text("decided_by").notNull(),
+    decidedOn: date("decided_on").notNull(),
+    // The migration (or script) that applied the decision — the handle an operator undoes by.
+    source: text("source").notNull(),
+    appliedAt: timestamp("applied_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("idx_cfod_source").on(table.source)]
+);
+
+export type CampaignFunnelOwnerDecision = typeof campaignFunnelOwnerDecisions.$inferSelect;
+export type NewCampaignFunnelOwnerDecision = typeof campaignFunnelOwnerDecisions.$inferInsert;

--- a/tests/unit/funnel-owner-decision.test.ts
+++ b/tests/unit/funnel-owner-decision.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { funnelForGoal, SALES_FUNNEL_KEYS } from "../../src/lib/sales-funnel-vocabulary.js";
+import { resolveCampaignFunnelKey } from "../../src/lib/funnel-adoption.js";
+import { SALES_OUTREACH_FEATURE_SLUGS } from "../../src/lib/sales-outreach-campaign.js";
+
+const TAG = "0045_owner_funnel_decision_f4d73dab";
+const SQL = readFileSync(join(process.cwd(), "drizzle", `${TAG}.sql`), "utf8");
+
+// The pair the owner answered for, and the one campaign of it that is alive.
+const ORG_ID = "f0420eb5-8f72-4f0a-a150-f473746df1e6";
+const BRAND_ID = "f4d73dab-1f9d-49b2-b16e-63ecde76a5eb";
+const LIVE_CAMPAIGN_ID = "d5a759bf-6729-4325-b3cd-f1ff357d0538";
+
+/** The SQL with every comment line stripped — the statements, and nothing the prose says. */
+const STATEMENTS = SQL.split("\n")
+  .filter((line) => !line.trimStart().startsWith("--"))
+  .join("\n");
+
+function uuidsIn(text: string): Set<string> {
+  return new Set(text.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g) ?? []);
+}
+
+describe("the funnel of a brand that sells through several is UNKNOWN until its owner answers it", () => {
+  it("a goal that names no single funnel still resolves to NULL — the migration answers ONE pair, it does not weaken the rule", () => {
+    for (const goal of ["combinedSales", "websiteVisit", "positiveReply", "whatsappConversation"]) {
+      expect(funnelForGoal(goal)).toBeNull();
+      // Neither as the campaign's own goal nor inherited from its brand.
+      expect(resolveCampaignFunnelKey(goal, null)).toBeNull();
+      expect(resolveCampaignFunnelKey(null, goal)).toBeNull();
+    }
+  });
+
+  it("names exactly one (org, brand) pair — every other brand in the same unattributable state is untouched", () => {
+    const uuids = uuidsIn(STATEMENTS);
+    expect(uuids).toEqual(new Set([ORG_ID, BRAND_ID, LIVE_CAMPAIGN_ID]));
+  });
+
+  it("scopes to the sales-outreach feature family — a brand's PR / AI-visibility / VC campaigns run no sales funnel", () => {
+    for (const slug of SALES_OUTREACH_FEATURE_SLUGS) {
+      expect(STATEMENTS).toContain(`'${slug}'`);
+    }
+    const quotedFeatureSlugs = STATEMENTS.match(/'[a-z]+(?:-[a-z]+)+'/g) ?? [];
+    for (const quoted of quotedFeatureSlugs) {
+      expect(SALES_OUTREACH_FEATURE_SLUGS.has(quoted.slice(1, -1))).toBe(true);
+    }
+  });
+
+  it("writes only canonical funnel tokens, and gives the live campaign the meeting funnel", () => {
+    const written = STATEMENTS.match(/'(sales_meetings_from_\w+|website_purchases|form_magnet|reply_meeting|visit_\w+)'/g) ?? [];
+    expect(written.length).toBeGreaterThan(0);
+    for (const token of written) {
+      expect(SALES_FUNNEL_KEYS as readonly string[]).toContain(token.slice(1, -1));
+    }
+    expect(STATEMENTS).toMatch(
+      new RegExp(`'${LIVE_CAMPAIGN_ID}'[\\s\\S]{0,80}'sales_meetings_from_conversation'`),
+    );
+    // Everything else of the pair — its stopped history — states the funnel it ran before.
+    expect(STATEMENTS).toMatch(/ELSE\s+'website_purchases'/);
+  });
+
+  it("re-running it is a no-op: every write is guarded on the funnel still being NULL", () => {
+    // One INSERT of the decision rows, one UPDATE of the campaigns. Both guarded.
+    expect(STATEMENTS).toMatch(/ON CONFLICT \("campaign_id"\) DO NOTHING/);
+    const campaignUpdates = STATEMENTS.match(/UPDATE "campaigns"[\s\S]*?;/g) ?? [];
+    expect(campaignUpdates).toHaveLength(1);
+    for (const stmt of campaignUpdates) {
+      expect(stmt).toMatch(/"funnel_key" IS NULL/);
+    }
+    // The decision rows are selected on the same guard, so a second run records nothing new.
+    expect(STATEMENTS).toMatch(/INSERT INTO "campaign_funnel_owner_decisions"[\s\S]*?"funnel_key" IS NULL[\s\S]*?;/);
+  });
+
+  it("is reversible: it records the value it replaced, under a source tag an operator can undo by", () => {
+    expect(STATEMENTS).toMatch(/CREATE TABLE IF NOT EXISTS "campaign_funnel_owner_decisions"/);
+    expect(STATEMENTS).toContain('"previous_funnel_key"');
+    expect(STATEMENTS).toContain(`'${TAG}'`);
+    // The undo an operator runs is spelled out in the file itself.
+    expect(SQL).toMatch(/SET funnel_key = d\.previous_funnel_key/);
+  });
+
+  it("touches the funnel and nothing else — no status, schedule, budget, goal or deletion", () => {
+    expect(STATEMENTS).not.toMatch(/\bDELETE\b|\bTRUNCATE\b|\bDROP\b/i);
+    for (const column of ["status", "next_run_at", "goal", "daily_budget_cents", "brand_ids"]) {
+      expect(STATEMENTS).not.toMatch(new RegExp(`SET[\\s\\S]{0,200}"${column}"\\s*=`));
+    }
+    // Only `funnel_key` and the write stamp move on a campaign row.
+    expect(STATEMENTS).toMatch(/SET "funnel_key" = d\."funnel_key",\s*\n\s*"updated_at" = now\(\)/);
+  });
+
+  it("is registered in the migrations journal", () => {
+    const journal = JSON.parse(readFileSync(join(process.cwd(), "drizzle", "meta", "_journal.json"), "utf8"));
+    expect(journal.entries.some((e: { tag: string }) => e.tag === TAG)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

A campaign's funnel is a stored fact. A brand selling through several funnels under one `combinedSales` goal names none, so migration 0042 and the boot backfill both leave it NULL. That no-guess branch is correct and stays for every brand nobody has answered for.

For one (org, brand) pair the owner has now answered it — Kevin, 2026-08-02, org `f0420eb5` / brand `f4d73dab`. The brand optimized website purchases from the start and switched to sales meetings from conversation on 19 July, **without creating a new campaign**, so no campaign row marks the transition. A run-date split was declined: a campaign's history is not cut in two.

Migration `0045_owner_funnel_decision_f4d73dab` writes:

| rows | funnel |
|---|---|
| `d5a759bf-6729-4325-b3cd-f1ff357d0538` (live, created 15 June) | `sales_meetings_from_conversation` |
| its 51 stopped sales-cold-email campaigns | `website_purchases` |

Everything else of that brand keeps a NULL funnel: 82 PR / AI-visibility / VC campaigns (they run no sales funnel), and the campaigns three OTHER orgs hold on the same brand row (other customers).

## Accepted tradeoff, recorded so nobody "fixes" it later

33,229 of `d5a759bf`'s 54,809 runs predate the 19 July switch and sit under the meeting funnel. The distortion is one-directional — a meeting reads MORE expensive than it was, never less — and the owner chose it over splitting. Pinned in the migration header and in `CLAUDE.md`.

## Auditable, reversible, idempotent

Every write goes through a new `campaign_funnel_owner_decisions` table: one row per campaign, holding the value it replaced and the migration tag that wrote it. Nothing in the runtime reads it — the funnel lives on the campaign row like every other one.

```sql
-- what it wrote
SELECT * FROM campaign_funnel_owner_decisions WHERE source = '0045_owner_funnel_decision_f4d73dab';

-- undo
UPDATE campaigns c SET funnel_key = d.previous_funnel_key
FROM campaign_funnel_owner_decisions d
WHERE c.id::text = d.campaign_id
  AND d.source = '0045_owner_funnel_decision_f4d73dab'
  AND c.funnel_key = d.funnel_key;
```

Both statements are guarded on the funnel still being NULL, so a re-run (or a second replica booting at the same moment) is a no-op.

## Verified on a Neon branch forked from prod

| check | result |
|---|---|
| rows written | 1 `sales_meetings_from_conversation` + 51 `website_purchases` |
| the pair's non-sales campaigns | 82, still NULL |
| the same brand under other orgs | untouched, still NULL |
| second run | **0 rows changed**, decisions table still 52 |
| undo applied | all 134 rows back to NULL |

Branch deleted after verification. Prod itself is written by the boot migrator on deploy, and read back after (counts reported on the ship comment, not from a script log).

## Other brands in the same unattributable state — left NULL, deliberately

The sweep found three (org, brand) pairs with a LIVE sales campaign whose funnel is still NULL. Nobody has answered for them, so none is touched:

| org | brand | ongoing / total campaigns with a NULL funnel |
|---|---|---|
| `b645207b-d8e9-40b0-9391-072b777cd9a9` | `75d7e3e8-6926-4f85-a557-976895400666` | 1 / 46 |
| `5fefaf5a-8d50-4c5f-aa4b-3d35bcd1de93` | `a179bbd9-8eed-4dba-9338-78125922b0c6` | 1 / 1 |
| `d3367008-29cd-4dc5-a57e-d0d825bf1630` | `b97440f6-5822-43de-ad1d-9886723536d6` | 1 / 1 |

A funnel is a stored fact, never an inference. Answering one of these is a separate owner decision and a separate migration, and the table above is where it would be recorded.

## Not touched

`goal` (writing one would change what the runtime optimizes — that is not a labelling decision), status, schedule, budget, history, runs-service. No API shape change (`openapi.json` unchanged).

## Consequence worth flagging

Resolving the ambiguity means `ensureFundedFunnelCampaigns` no longer sees an unattributable incumbent for this brand. The brand funds two funnels in billing (`reply_meeting` $30/day, `visit_signup` $10/day, both set today), so the scheduler will now give `website_purchases` a campaign of its own — that is the per-funnel funding machinery doing its job on the customer's own current funding, not something this migration writes.

## Tests

301 unit (8 new, `tests/unit/funnel-owner-decision.test.ts`) + 184 integration, green. `tsc --noEmit` clean, build clean, from-scratch `db:migrate` on an empty database clean.

The new tests cover the case that motivated this: a goal naming no single funnel still resolves to NULL everywhere, and the migration names exactly one (org, brand) pair, writes only canonical funnel tokens, guards every write on NULL, records `previous_funnel_key`, and touches no status / schedule / goal / deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
