### PR TITLE
hotfix: the gate reads what it needs, not the campaign's whole run history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,37 @@ So `/end-run` REINTERPRETS `stopCampaign=true` as audience-scoped: it marks `req
 
 At that all-audiences-exhausted auto-stop point (and ONLY there) `/end-run` also fires a **fire-and-forget extend-audience lifecycle email** (`maybeSendExtendAudienceEmail`, `src/lib/transactional-email.ts`) nudging the user to extend an audience so outreach can resume. It sends via **transactional-email-service** (`POST /send`, eventType `audience_fully_contacted`; template registered at boot via `PUT /platform-templates`) ONLY when ALL hold: sales-cold-email-outreach feature, `campaign.createdByUserId` present (recipient), brand not paused, a daily budget `> 0` (campaign `dailyBudgetCents` else the brand's billing daily budget), and org `has_auto_topup` (billing `GET /internal/accounts/by-org/{orgId}/balance`, user-less). The **1×/month-per-brand cap is owned by transactional-email dedup** (its `audience_fully_contacted` monthly-per-brand cadence), NOT a local table. Every guard read is **fail-SAFE** (any error/absent field → treat as OFF → no email) and the whole call is fire-and-forget after the response, so it NEVER blocks or fails run finalization. When refactoring `/end-run`, keep this call at the exhausted-stop branch — do not drop it. (Set 2026-07-22, PR #292.)
 
+## EVERY `listRuns` states a status AND a bound — an unfiltered read costs more with every run the campaign has ever done
+
+runs-service serves `runs` as a VIEW over `run_lifecycle_events` (6.2M rows), so a `listRuns` with no
+bound replays the whole event log, LEFT JOINs a second view and GROUP BYs 19 columns — no index can
+help. The row count is the campaign's entire history, `workflow_context` JSONB included. Because
+gate-check is the FIRST node of EVERY run, that made each new run raise the price of every run after
+it: 83,064 calls / month at **21,216 rows per call** = 1.76 BILLION rows, essentially the whole Neon
+bill's public network transfer plus a large share of its compute, on a curve that had gone
+$139 → $204 → $337 → $476 → $701.
+
+The gate needs three things and each is now asked for on its own terms (`src/lib/gate-check.ts`):
+
+- **Stale cleanup + the one-run-at-a-time guard** read `status: "running"` with `RUNNING_RUNS_LIMIT`.
+  The invariant is ONE live run per campaign, so 200 is not a tuning knob — it exists so an
+  unbounded read can never come back. Rows arrive newest-first: past the bound the newest still
+  block the tick (guard correct) and the oldest are cleaned on a later pass.
+- **The `completed` count is a LIFETIME total** — `Math.max(leadStats.totalServed, completedRuns.length)`
+  is what enforces `maxLeads`, so a recency window would let a campaign run past its cap forever.
+  It is bounded by the CAP instead: the count is only ever compared `>= maxLeads`, so asking for at
+  most `maxLeads` rows answers that question EXACTLY (fewer back → exact count; exactly `maxLeads`
+  back → the cap is reached whatever the true total). Read only when a cap exists.
+
+runs-service exposes **no per-campaign run COUNT** (`GET /v1/runs` returns rows, `/public/stats/runs`
+is cross-tenant), which is why the lifetime total is still read as bounded rows rather than a scalar.
+Do not reconstruct a count locally — a counting/`total` capability is runs-service's to add.
+
+The other three call sites were already bounded (`scheduler.ts hasLiveRunForCampaign`,
+`funnel-campaigns.ts` ×2, all `limit: 1`); `/end-run` carries one too. A new `listRuns` without a
+status and a limit is a regression, and `tests/unit/gate-check.test.ts` fails on one.
+(Set 2026-08-07.)
+
 ## Scheduler in-flight guard — check ANY live run for the campaign, never the campaign-service marker
 
 The `campaign-service / <campaignId>` parent run (created by the workflow DAG's start-run) is an **ephemeral ~2s marker** — `start-run → end-run` within seconds — NOT an enclosing span. The genuinely-long work (lead-service `buffer/next`, observed up to **755s**) runs in a separate `lead-service / lead-serve` run that is **not linked** under the marker via `parent_run_id`. So `src/lib/scheduler.ts`'s "is a flow still alive?" check MUST query `listRuns` scoped to **`campaignId` + `status=running` + `startedAfter=freshnessCutoff`** (any service) via `hasLiveRunForCampaign()` — **never** `(serviceName="campaign-service", taskName=campaignId)`, which only sees the 2s corpse and re-fires mid-fill → `lead-service` `409 Concurrent buffer/next` storm. `STUCK_RUN_FRESHNESS_THRESHOLD_MS` must stay **strictly greater than** lead-service's max fill (`PULL_NEXT_TIMEOUT` 600s; observed 755s) — currently 15min. `reRunDueCampaigns` and `claimStuckCampaigns` MUST share the same helper. (Set 2026-06-13, v0.25.1 / DIS-277.)

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -9,6 +9,14 @@ import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 
 const STALE_THRESHOLD_MS = 3 * 60 * 60 * 1000; // 3 hours
 
+// How many of the campaign's running rows the gate reads. The invariant is ONE run in flight per
+// campaign, and a row only stays `running` until its DAG ends or block 1 marks it stale, so this
+// is orders of magnitude above what a healthy campaign holds. It exists so an unbounded history
+// can never be pulled again — not as a tuning knob. Rows come back newest-first, so if a campaign
+// ever exceeded it the newest still block the tick (the guard stays correct) and the oldest are
+// cleaned on a later pass once the newer ones finish.
+const RUNNING_RUNS_LIMIT = 200;
+
 // The sales-outreach feature family (sales-cold-email-outreach + sales-crm-email-outreach) is
 // paced by the brand daily budget (billing-service brand_daily_budgets) and held on brand pause.
 // Every other feature is paced by the campaign's own budget windows and runs through a pause.
@@ -81,16 +89,24 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     workflowSlug: campaign.workflowSlug,
   };
 
-  // Fetch all runs for this campaign (needed for stale cleanup, running check, consecutive failures)
-  const { runs } = await listRuns({
+  // The campaign's RUNNING rows — all this gate needs for stale cleanup (block 1) and the
+  // one-run-at-a-time guard (block 2). Asking for the campaign's whole history instead was the
+  // single most expensive query in the fleet: runs-service serves `runs` as a VIEW over its
+  // event log, so every gate check replayed ~21k rows (workflow_context JSONB included) for a
+  // campaign that only ever has one live run — and every new run made the next one dearer.
+  // Filter + bound at the source; the lifetime count block 4 needs is read separately, and only
+  // when a maxLeads cap actually exists.
+  const { runs: runningRuns } = await listRuns({
     orgId: campaign.orgId,
     serviceName: "campaign-service",
     taskName: campaign.campaignId,
+    status: "running",
+    limit: RUNNING_RUNS_LIMIT,
   });
 
   // 1. Stale run cleanup — mark runs running > 30 min as failed
   const now = Date.now();
-  for (const run of runs) {
+  for (const run of runningRuns) {
     if (run.status === "running" && (now - new Date(run.startedAt).getTime()) > STALE_THRESHOLD_MS) {
       try {
         await updateRun(run.id, "failed", identity);
@@ -102,7 +118,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   }
 
   // 2. Running run check — only 1 run at a time per campaign
-  if (runs.some((r: Run) => r.status === "running")) {
+  if (runningRuns.some((r: Run) => r.status === "running")) {
     return { allowed: false, reason: "A run is already in progress" };
   }
 
@@ -300,7 +316,24 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
 
   // 4. Volume check
   if (campaign.maxLeads != null) {
-    const completedRuns = runs.filter((r: Run) => r.status === "completed");
+    // The completed-run count is a LIFETIME total, and it is the fallback for totalServed — so
+    // it cannot be bounded by a recency window without letting a campaign run past its cap
+    // forever. It CAN be bounded by the cap itself: the only thing done with the number is
+    // `>= campaign.maxLeads`, so asking for at most maxLeads rows answers that question exactly.
+    // Fewer than maxLeads rows come back → the count is exact; exactly maxLeads come back → the
+    // cap is reached whatever the true total is. Same decision, bounded by a configured number
+    // (1–5 in every campaign that ever set one) instead of by the campaign's whole history.
+    //
+    // runs-service exposes no per-campaign run COUNT, so this is the cheapest honest read of a
+    // lifetime total from here. A counting endpoint there would make it a single scalar — filed
+    // as a feature request rather than reconstructed locally.
+    const { runs: completedRuns } = await listRuns({
+      orgId: campaign.orgId,
+      serviceName: "campaign-service",
+      taskName: campaign.campaignId,
+      status: "completed",
+      limit: campaign.maxLeads,
+    });
     let totalServed: number;
     try {
       const leadStats = await fetchLeadStats(campaign.orgId, campaign.campaignId, campaign.brandId, identity);

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -462,6 +462,9 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
           taskName: campaignId,
           parentRunId: req.runId,
           status: "running",
+          // Already narrow — one marker row per parent run — but every listRuns in this service
+          // states a bound, so an unfiltered history read can never come back by accident.
+          limit: 10,
         });
         for (const run of runs) {
           await updateRun(run.id, status, identity);

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -1063,6 +1063,9 @@ describe("Pipeline routes", () => {
           status: "running",
         }),
       );
+      // Bounded like every other runs read in this service — one marker row per parent run, and
+      // no path can regress into pulling the campaign's history.
+      expect(mockListRuns.mock.calls[0][0].limit).toBeGreaterThan(0);
       expect(mockUpdateRun).toHaveBeenCalledTimes(1);
       expect(mockUpdateRun).toHaveBeenCalledWith("run-own", "failed", expect.objectContaining({ orgId }));
     });

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -96,6 +96,25 @@ function makeRun(overrides: Partial<{ id: string; status: string; startedAt: str
   };
 }
 
+/**
+ * The gate reads runs-service TWICE and each read states what it wants: the campaign's RUNNING
+ * rows (stale cleanup + the one-run-at-a-time guard) and — only under a maxLeads cap — its
+ * COMPLETED rows, bounded by that cap. Answer each call by the status it asked for, so a test
+ * that stages completed runs cannot accidentally also stage them as live.
+ */
+function mockRuns(
+  { running = [], completed = [] }: { running?: unknown[]; completed?: unknown[] } = {},
+) {
+  mockListRuns.mockImplementation(async (params: { status?: string; limit?: number }) => {
+    if (params.status === "running") return { runs: running };
+    if (params.status === "completed") {
+      // runs-service honours the bound; a caller asking for N never receives more than N.
+      return { runs: params.limit != null ? completed.slice(0, params.limit) : completed };
+    }
+    return { runs: [] };
+  });
+}
+
 function makeBudgetResponse(
   windows: Array<{
     label: string;
@@ -132,7 +151,7 @@ function makeBudgetResponse(
 describe("Gate Check", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockListRuns.mockResolvedValue({ runs: [] });
+    mockRuns();
     mockGetStatsBudget.mockResolvedValue({ windows: [] });
     mockUpdateRun.mockResolvedValue({});
     mockAnyBrandPaused.mockResolvedValue(false);
@@ -191,7 +210,7 @@ describe("Gate Check", () => {
         status: "running",
         startedAt: new Date(Date.now() - (3 * 60 + 1) * 60 * 1000).toISOString(),
       });
-      mockListRuns.mockResolvedValue({ runs: [staleRun] });
+      mockRuns({ running: [staleRun] });
 
       await runGateChecks(makeCampaign());
 
@@ -204,7 +223,7 @@ describe("Gate Check", () => {
         status: "running",
         startedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
       });
-      mockListRuns.mockResolvedValue({ runs: [recentRun] });
+      mockRuns({ running: [recentRun] });
 
       const result = await runGateChecks(makeCampaign());
 
@@ -220,7 +239,7 @@ describe("Gate Check", () => {
         status: "running",
         startedAt: new Date(Date.now() - 1000).toISOString(),
       });
-      mockListRuns.mockResolvedValue({ runs: [runningRun] });
+      mockRuns({ running: [runningRun] });
 
       const result = await runGateChecks(makeCampaign());
       expect(result.allowed).toBe(false);
@@ -403,14 +422,59 @@ describe("Gate Check", () => {
     });
   });
 
+  describe("Bounded runs reads", () => {
+    it("never asks runs-service for the campaign's whole history", async () => {
+      await runGateChecks(makeCampaign({ maxLeads: 3 }));
+
+      expect(mockListRuns).toHaveBeenCalled();
+      for (const [params] of mockListRuns.mock.calls) {
+        // Every read states the status it wants AND a bound. An unfiltered, unbounded read
+        // replayed ~21k rows per gate check — i.e. per campaign per tick, fleet-wide.
+        expect(params.status).toBeDefined();
+        expect(params.limit).toBeGreaterThan(0);
+      }
+    });
+
+    it("reads only the RUNNING rows for stale cleanup + the in-progress guard", async () => {
+      await runGateChecks(makeCampaign());
+
+      const statuses = mockListRuns.mock.calls.map(([p]: [{ status?: string }]) => p.status);
+      expect(statuses).toEqual(["running"]);
+      const [params] = mockListRuns.mock.calls[0];
+      expect(params).toMatchObject({
+        orgId: "org-1",
+        serviceName: "campaign-service",
+        taskName: "campaign-1",
+        status: "running",
+      });
+    });
+
+    it("does not read completed runs at all when the campaign has no maxLeads cap", async () => {
+      await runGateChecks(makeCampaign({ maxLeads: null }));
+
+      const statuses = mockListRuns.mock.calls.map(([p]: [{ status?: string }]) => p.status);
+      expect(statuses).not.toContain("completed");
+    });
+
+    it("bounds the completed-run read by the cap it is compared against", async () => {
+      await runGateChecks(makeCampaign({ maxLeads: 3 }));
+
+      const completedCall = mockListRuns.mock.calls
+        .map(([p]: [{ status?: string; limit?: number }]) => p)
+        .find(p => p.status === "completed");
+      expect(completedCall).toMatchObject({ status: "completed", limit: 3 });
+    });
+  });
+
   describe("Volume check", () => {
     it("should auto-stop when maxLeads is reached", async () => {
-      const runs = [
-        makeRun({ id: "r1", status: "completed" }),
-        makeRun({ id: "r2", status: "completed" }),
-        makeRun({ id: "r3", status: "completed" }),
-      ];
-      mockListRuns.mockResolvedValue({ runs });
+      mockRuns({
+        completed: [
+          makeRun({ id: "r1", status: "completed" }),
+          makeRun({ id: "r2", status: "completed" }),
+          makeRun({ id: "r3", status: "completed" }),
+        ],
+      });
 
       // Mock lead stats
       mockFetch.mockResolvedValueOnce({
@@ -425,8 +489,7 @@ describe("Gate Check", () => {
     });
 
     it("should allow when maxLeads is not reached", async () => {
-      const runs = [makeRun({ id: "r1", status: "completed" })];
-      mockListRuns.mockResolvedValue({ runs });
+      mockRuns({ completed: [makeRun({ id: "r1", status: "completed" })] });
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -438,11 +501,12 @@ describe("Gate Check", () => {
     });
 
     it("should fallback to completed run count on 404 from lead-service", async () => {
-      const runs = [
-        makeRun({ id: "r1", status: "completed" }),
-        makeRun({ id: "r2", status: "completed" }),
-      ];
-      mockListRuns.mockResolvedValue({ runs });
+      mockRuns({
+        completed: [
+          makeRun({ id: "r1", status: "completed" }),
+          makeRun({ id: "r2", status: "completed" }),
+        ],
+      });
 
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -453,8 +517,43 @@ describe("Gate Check", () => {
       expect(result.allowed).toBe(true); // 2 completed < 5 maxLeads
     });
 
+    it("still reaches maxLeads for a campaign whose history dwarfs the bound", async () => {
+      // 50 lifetime completed runs against a cap of 3. The gate only ever receives the first 3
+      // (that is the whole point of the bound) — a count capped at the cap must still satisfy
+      // `>= maxLeads`, or a long-running campaign would never stop.
+      mockRuns({
+        completed: Array.from({ length: 50 }, (_, i) =>
+          makeRun({ id: `r${i}`, status: "completed" }),
+        ),
+      });
+
+      // lead-service 404 → the completed-run count IS totalServed, no other source.
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+      const result = await runGateChecks(makeCampaign({ maxLeads: 3 }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Max leads reached");
+      expect(result.autoStopped).toBe(true);
+    });
+
+    it("still reaches maxLeads via the history when lead-service under-reports", async () => {
+      mockRuns({
+        completed: Array.from({ length: 50 }, (_, i) =>
+          makeRun({ id: `r${i}`, status: "completed" }),
+        ),
+      });
+
+      // lead-service answers below the cap; the run history is what carries the campaign over it.
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ totalServed: 1 }) });
+
+      const result = await runGateChecks(makeCampaign({ maxLeads: 5 }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Max leads reached");
+      expect(result.autoStopped).toBe(true);
+    });
+
     it("should block on non-404 lead-service error (fail-closed)", async () => {
-      mockListRuns.mockResolvedValue({ runs: [] });
+      mockRuns();
 
       mockFetch.mockResolvedValueOnce({
         ok: false,


### PR DESCRIPTION
## The problem

One query dominates the whole Neon bill. On runs-service, `pg_stat_statements`:

```
calls: 83 064   rows: 1 762 256 610   rows/call: 21 216   total_exec: 54 509 s   mean: 656 ms
```

1.76 billion rows in a month. That is essentially all of the 4,028 GB of public network transfer ($109.79) and a large share of the compute ($560.64).

The query is gate-check's `listRuns`, commented "Fetch all runs for this campaign". No limit, no date filter, so it pulled the campaign's entire run history — 21,216 rows on average, `workflow_context` JSONB included — and gate-check is the first node of **every** run.

Aggravating, on the runs-service side: `runs` and `runs_costs` are not tables but views over `run_lifecycle_events` (6.2M rows) and `cost_lifecycle_events` (2.1M rows). Every call replays the event log, LEFT JOINs a second view and GROUP BYs 19 columns, with no index possible.

So each new run made every later run more expensive. The bill follows a quadratic: $139 → $204 → $337 → $476 → $701 → $683.

## What the gate actually needs

Three things, now asked for on their own terms:

| Need | Read |
|---|---|
| Stale-run cleanup (`running` past STALE_THRESHOLD_MS) | `status: "running"`, `limit: RUNNING_RUNS_LIMIT` |
| One run in flight per campaign | same read |
| Lifetime `completed` count (maxLeads) | `status: "completed"`, `limit: campaign.maxLeads`, only when a cap exists |

**The running read.** The invariant is one live run per campaign, and a row only stays `running` until its DAG ends or block 1 marks it stale, so 200 is orders of magnitude above what a healthy campaign holds. It is not a tuning knob — it exists so an unbounded read can never come back. Rows arrive newest-first, so past the bound the newest still block the tick (the guard stays correct) and the oldest are cleaned on a later pass once the newer ones finish.

**The completed count — the trap called out in the brief.** It is a lifetime total and the fallback for `totalServed` (`Math.max(leadStats.totalServed, completedRuns.length)`, including the 404 branch), so a recency window would let a campaign outrun its `maxLeads` cap forever. It is bounded by the **cap** instead, not by a window: the number is only ever compared `>= campaign.maxLeads`, so asking for at most `maxLeads` rows answers that question exactly.

- Fewer than `maxLeads` rows come back → the count is exact.
- Exactly `maxLeads` come back → the cap is reached, whatever the true total is.

Same decision on every input, bounded by a configured number instead of by the campaign's whole history. In prod that number has only ever been 1–5, and **no ongoing campaign has a cap at all today** (18 ongoing, all `max_leads IS NULL`) — so the read is skipped entirely on the live fleet.

## Feature request for runs-service (not simulated here)

runs-service exposes **no per-campaign run COUNT**: `GET /v1/runs` returns rows, `/public/stats/runs` is cross-tenant and unfiltered. That is why the lifetime total is still read as bounded rows rather than a scalar. Reconstructing a count on this side would be inventing a number another service owns, so it was not done — a counting capability (a `total` on the list response, or a count endpoint) belongs in runs-service. Filing separately.

## Other call sites

`/end-run` (`src/routes/internal.ts`) already filtered on `parentRunId` + `status` and returns one row per call, so it was never the problem — it now carries a bound anyway, so no path in this service can regress into an unfiltered read. The other three (`scheduler.ts hasLiveRunForCampaign`, `funnel-campaigns.ts` ×2) were already at `limit: 1`.

## No behaviour change

Same decisions, same reasons, same `nextRunAt`. Nothing cached, nothing accumulated, no new table — this was a query to bound.

## Tests

- New `Bounded runs reads` block: every `listRuns` from the gate states a status **and** a bound; the running read is the only one made when no cap exists; the completed read is bounded by the cap.
- `still reaches maxLeads for a campaign whose history dwarfs the bound` — 50 lifetime completed runs against a cap of 3, lead-service 404 so the run count *is* `totalServed`: still auto-stops.
- `still reaches maxLeads via the history when lead-service under-reports` — same history, lead-service answers 1 against a cap of 5: still auto-stops.
- Stale cleanup and in-progress detection re-pointed at the status-filtered read and still assert the same outcomes; the test mock now answers each call by the status it asked for, so a test staging completed runs can no longer stage them as live by accident.
- `/end-run` bound asserted alongside its existing `parentRunId` assertion.

491 tests green (307 unit + 184 integration), build green.

## Verification after deploy

Re-read `pg_stat_statements` on runs-service and confirm this statement's `rows/call` has collapsed. Read-only; no artificial runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
