### PR TITLE
feat(resume): a campaign that ran out of people to contact comes back on its own

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,37 @@ So `/end-run` REINTERPRETS `stopCampaign=true` as audience-scoped: it marks `req
 
 At that all-audiences-exhausted auto-stop point (and ONLY there) `/end-run` also fires a **fire-and-forget extend-audience lifecycle email** (`maybeSendExtendAudienceEmail`, `src/lib/transactional-email.ts`) nudging the user to extend an audience so outreach can resume. It sends via **transactional-email-service** (`POST /send`, eventType `audience_fully_contacted`; template registered at boot via `PUT /platform-templates`) ONLY when ALL hold: sales-cold-email-outreach feature, `campaign.createdByUserId` present (recipient), brand not paused, a daily budget `> 0` (campaign `dailyBudgetCents` else the brand's billing daily budget), and org `has_auto_topup` (billing `GET /internal/accounts/by-org/{orgId}/balance`, user-less). The **1×/month-per-brand cap is owned by transactional-email dedup** (its `audience_fully_contacted` monthly-per-brand cadence), NOT a local table. Every guard read is **fail-SAFE** (any error/absent field → treat as OFF → no email) and the whole call is fire-and-forget after the response, so it NEVER blocks or fails run finalization. When refactoring `/end-run`, keep this call at the exhausted-stop branch — do not drop it. (Set 2026-07-22, PR #292.)
 
+## EVERY `listRuns` states a status AND a bound — an unfiltered read costs more with every run the campaign has ever done
+
+runs-service serves `runs` as a VIEW over `run_lifecycle_events` (6.2M rows), so a `listRuns` with no
+bound replays the whole event log, LEFT JOINs a second view and GROUP BYs 19 columns — no index can
+help. The row count is the campaign's entire history, `workflow_context` JSONB included. Because
+gate-check is the FIRST node of EVERY run, that made each new run raise the price of every run after
+it: 83,064 calls / month at **21,216 rows per call** = 1.76 BILLION rows, essentially the whole Neon
+bill's public network transfer plus a large share of its compute, on a curve that had gone
+$139 → $204 → $337 → $476 → $701.
+
+The gate needs three things and each is now asked for on its own terms (`src/lib/gate-check.ts`):
+
+- **Stale cleanup + the one-run-at-a-time guard** read `status: "running"` with `RUNNING_RUNS_LIMIT`.
+  The invariant is ONE live run per campaign, so 200 is not a tuning knob — it exists so an
+  unbounded read can never come back. Rows arrive newest-first: past the bound the newest still
+  block the tick (guard correct) and the oldest are cleaned on a later pass.
+- **The `completed` count is a LIFETIME total** — `Math.max(leadStats.totalServed, completedRuns.length)`
+  is what enforces `maxLeads`, so a recency window would let a campaign run past its cap forever.
+  It is bounded by the CAP instead: the count is only ever compared `>= maxLeads`, so asking for at
+  most `maxLeads` rows answers that question EXACTLY (fewer back → exact count; exactly `maxLeads`
+  back → the cap is reached whatever the true total). Read only when a cap exists.
+
+runs-service exposes **no per-campaign run COUNT** (`GET /v1/runs` returns rows, `/public/stats/runs`
+is cross-tenant), which is why the lifetime total is still read as bounded rows rather than a scalar.
+Do not reconstruct a count locally — a counting/`total` capability is runs-service's to add.
+
+The other three call sites were already bounded (`scheduler.ts hasLiveRunForCampaign`,
+`funnel-campaigns.ts` ×2, all `limit: 1`); `/end-run` carries one too. A new `listRuns` without a
+status and a limit is a regression, and `tests/unit/gate-check.test.ts` fails on one.
+(Set 2026-08-07.)
+
 ## Scheduler in-flight guard — check ANY live run for the campaign, never the campaign-service marker
 
 The `campaign-service / <campaignId>` parent run (created by the workflow DAG's start-run) is an **ephemeral ~2s marker** — `start-run → end-run` within seconds — NOT an enclosing span. The genuinely-long work (lead-service `buffer/next`, observed up to **755s**) runs in a separate `lead-service / lead-serve` run that is **not linked** under the marker via `parent_run_id`. So `src/lib/scheduler.ts`'s "is a flow still alive?" check MUST query `listRuns` scoped to **`campaignId` + `status=running` + `startedAfter=freshnessCutoff`** (any service) via `hasLiveRunForCampaign()` — **never** `(serviceName="campaign-service", taskName=campaignId)`, which only sees the 2s corpse and re-fires mid-fill → `lead-service` `409 Concurrent buffer/next` storm. `STUCK_RUN_FRESHNESS_THRESHOLD_MS` must stay **strictly greater than** lead-service's max fill (`PULL_NEXT_TIMEOUT` 600s; observed 755s) — currently 15min. `reRunDueCampaigns` and `claimStuckCampaigns` MUST share the same helper. (Set 2026-06-13, v0.25.1 / DIS-277.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,57 @@ So `/end-run` REINTERPRETS `stopCampaign=true` as audience-scoped: it marks `req
 
 At that all-audiences-exhausted auto-stop point (and ONLY there) `/end-run` also fires a **fire-and-forget extend-audience lifecycle email** (`maybeSendExtendAudienceEmail`, `src/lib/transactional-email.ts`) nudging the user to extend an audience so outreach can resume. It sends via **transactional-email-service** (`POST /send`, eventType `audience_fully_contacted`; template registered at boot via `PUT /platform-templates`) ONLY when ALL hold: sales-cold-email-outreach feature, `campaign.createdByUserId` present (recipient), brand not paused, a daily budget `> 0` (campaign `dailyBudgetCents` else the brand's billing daily budget), and org `has_auto_topup` (billing `GET /internal/accounts/by-org/{orgId}/balance`, user-less). The **1×/month-per-brand cap is owned by transactional-email dedup** (its `audience_fully_contacted` monthly-per-brand cadence), NOT a local table. Every guard read is **fail-SAFE** (any error/absent field → treat as OFF → no email) and the whole call is fire-and-forget after the response, so it NEVER blocks or fails run finalization. When refactoring `/end-run`, keep this call at the exhausted-stop branch — do not drop it. (Set 2026-07-22, PR #292.)
 
+## A campaign that ran out of people to contact comes BACK on its own — the customer's action is the trigger, and they were told so
+
+The auto-stop above emails the customer asking them to extend or add an audience. Nothing closed
+that loop: they did exactly what the email asked and the campaign stayed stopped forever, because
+no path anywhere turned a stopped campaign back on. The dashboard made it worse — it lists only
+live campaigns, so the brand saw an empty table and no reason. Prod, brand
+`a179bbd9-8eed-4dba-9338-78125922b0c6`: auto-stopped 2026-08-05 for exhaustion, owner activated
+three fresh audiences 2026-08-10, five days of a funded and unpaused brand produced nothing.
+
+- **WHY a campaign stopped is a stored fact** — `campaigns.stop_reason` (migration 0046), written
+  at every one of the four places this service stops a campaign: `audience_exhausted` (/end-run,
+  all audiences exhausted), `max_leads_reached` (gate-check), `manual` (PATCH status=stop),
+  `org_teardown`. The vocabulary lives in ONE place, `src/lib/stop-reason.ts`. Without it the
+  campaign that ran out of people and the campaign a person switched off are the same row.
+- **ONLY `audience_exhausted` resumes. NULL never does.** Every row stopped before the column
+  existed keeps NULL and is invisible to the sweep — deliberately, and it is why there is no
+  backfill: a stop nobody wrote a reason for is not evidence of exhaustion, and a
+  timestamp-correlation guess would resurrect campaigns a person stopped on purpose. The loop
+  closes forward. The reason is CLEARED whenever a campaign becomes ongoing again (resume,
+  activate, brand un-pause), so the column always describes the CURRENT stop.
+- **The candidate population is the narrow one, never "every stopped campaign".** 682 stopped
+  rows against 17 ongoing — a stopped campaign is a large and mostly permanent population, so
+  `resumeServeableCampaigns` (`src/lib/campaign-resume.ts`) reads only `status='stopped' AND
+  stop_reason='audience_exhausted'`, served by a partial index. Nothing else is looked at.
+- **The signal is the audience owner's answer, not our guess.** features-service's projection
+  enumerates every ACTIVE audience of the brand, so a newly-activated audience appears the moment
+  the customer activates it. `serveableAudienceIdsForCampaign` (`src/lib/serveable-audience.ts`)
+  is the ONE definition of "has somebody to contact", shared by the leg that STOPS (/end-run) and
+  the leg that RESUMES. Two legs on two definitions is how a campaign gets stopped by one and
+  never picked up by the other.
+- **Own cadence, not the tick's.** `RESUME_SWEEP_INTERVAL_MS` = 10 min. A tick fires as often as
+  every 60s; asking features-service about every exhausted campaign at that rate would be a
+  per-minute fan-out for a state that changes when a customer edits their audiences. The
+  scheduler caps its idle sleep at that interval while anything is waiting
+  (`countResumableCampaigns`) — otherwise a brand whose ONLY campaign is stopped has an empty
+  ongoing snapshot, sleeps the full idle hour, and the sweep runs hourly however willing it is.
+- **Fail-CLOSED, unlike the scheduler's other reads.** Funding is checked on gate-check's exact
+  precedence (own `dailyBudgetCents` → funnel ceiling → brand daily budget) and an unreadable
+  budget, an unreadable audience set, a paused brand or a zero ceiling all leave the campaign
+  stopped. Turn-taking is fail-SOFT because it only reorders work already allowed; this decides
+  whether to START spending again, which is the gate's stance. **Every refusal is logged with its
+  reason** — a resume that cannot be decided safely is not a resume, and it says so.
+- **AT MOST one ongoing campaign per identity still holds.** The sweep checks for an incumbent on
+  (org, brand, funnel, channel) AND the write is conditional on the row still being
+  stopped-for-exhaustion; a `23505` from the partial unique index leaves it stopped. Belt and
+  braces on purpose: the index is the guarantee, the read is the reason we can explain.
+- The resumed campaign is `ongoing` with `nextRunAt=now`, i.e. exactly the state a live campaign
+  is in — the very next tick claims it like any other. Nothing about the auto-stop itself
+  changed: stopping when there is nobody left to contact is correct; never coming back was the bug.
+(Set 2026-08-10.)
+
 ## EVERY `listRuns` states a status AND a bound — an unfiltered read costs more with every run the campaign has ever done
 
 runs-service serves `runs` as a VIEW over `run_lifecycle_events` (6.2M rows), so a `listRuns` with no

--- a/drizzle/0046_campaign_stop_reason.sql
+++ b/drizzle/0046_campaign_stop_reason.sql
@@ -1,0 +1,28 @@
+-- Why a campaign stopped, recorded on the campaign itself.
+--
+-- A campaign whose every targeted audience ran dry is auto-stopped, and the customer is emailed
+-- asking them to extend or add an audience. Nothing closed that loop: the customer did exactly
+-- what the email asked and the campaign stayed stopped forever, because nothing anywhere turns a
+-- stopped campaign back on. Resuming it needs one thing the row never said — WHY it stopped.
+-- Without that, "resume the ones that ran out of people" is indistinguishable from "resume the
+-- ones a person deliberately switched off", and the second must never happen.
+--
+-- Four reasons are written, one per place this service stops a campaign:
+--   audience_exhausted  — /end-run, every targeted audience exhausted. The ONLY resumable one.
+--   max_leads_reached   — gate-check, the campaign's configured lead cap was reached.
+--   manual              — PATCH /campaigns/:id with status=stop. A person's decision; it stays.
+--   org_teardown        — DELETE /internal/campaigns/by-org/:orgId. The org is gone.
+--
+-- NULL means "not recorded" and is NEVER resumed. Every row stopped before this column existed
+-- keeps NULL, deliberately: a stop whose reason nobody wrote down is not evidence of exhaustion,
+-- and guessing one from a timestamp correlation would resurrect campaigns a person had stopped
+-- on purpose. The loop closes forward, for every campaign stopped from here on.
+
+ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "stop_reason" text;
+
+-- Serves the resume sweep's ONLY read: the stopped campaigns that ran out of people to contact.
+-- Partial, so it indexes that narrow population and not the 682-row stopped history beside it —
+-- the sweep must stay cheap however large the stopped population grows.
+CREATE INDEX IF NOT EXISTS "idx_campaigns_resumable"
+  ON "campaigns" ("stop_reason", "updated_at")
+  WHERE "status" = 'stopped' AND "stop_reason" IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1777000000000,
       "tag": "0045_owner_funnel_decision_f4d73dab",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1777100000000,
+      "tag": "0046_campaign_stop_reason",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -135,6 +135,10 @@
           "status": {
             "type": "string"
           },
+          "stopReason": {
+            "type": "string",
+            "nullable": true
+          },
           "nextRunAt": {
             "type": "string",
             "nullable": true
@@ -185,6 +189,7 @@
           "startDate",
           "endDate",
           "status",
+          "stopReason",
           "nextRunAt",
           "notifyFrequency",
           "notifyChannel",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -132,6 +132,21 @@ export const campaigns = pgTable(
 
     // Status: 'ongoing' or 'stopped'
     status: text("status").notNull().default("ongoing"),
+
+    // WHY this campaign stopped — see STOP_REASONS in src/lib/stop-reason.ts for the vocabulary.
+    //
+    // Load-bearing for exactly one decision: a campaign that stopped because it ran out of people
+    // to contact comes back on its own once the brand has somebody to contact again, and a
+    // campaign stopped for ANY other reason never does. Without a recorded reason those two are
+    // the same row, so "resume the exhausted ones" would also resurrect the ones a person
+    // switched off on purpose.
+    //
+    // NULL = not recorded (every row stopped before migration 0046, and every ongoing row). Never
+    // resumed: a stop nobody wrote a reason for is not evidence of exhaustion. Cleared back to
+    // NULL whenever a campaign becomes ongoing again, so the column always describes the CURRENT
+    // stop, never a previous one.
+    stopReason: text("stop_reason"),
+
     nextRunAt: timestamp("next_run_at", { withTimezone: true }),
 
     // Notifications (legacy - to be replaced by reportingFrequency)
@@ -146,6 +161,11 @@ export const campaigns = pgTable(
     index("idx_campaigns_org").on(table.orgId),
     uniqueIndex("uniq_campaigns_org_name").on(table.orgId, table.name),
     index("idx_campaigns_org_feature_funnel").on(table.orgId, table.featureSlug, table.funnelKey),
+    // Serves the resume sweep's only read — the stopped campaigns that ran out of people to
+    // contact. Partial so it covers that narrow population and not the whole stopped history.
+    index("idx_campaigns_resumable")
+      .on(table.stopReason, table.updatedAt)
+      .where(sql`${table.status} = 'stopped' and ${table.stopReason} is not null`),
     // A campaign is unique on (org, brand, sales funnel, acquisition channel) — see migration 0044.
     // Scoped to `ongoing`: a stopped row is history, not a competitor for the brand's turn.
     // `coalesce(funnel_key, '')` is load-bearing — Postgres treats NULLs as distinct, so without it

--- a/src/lib/campaign-resume.ts
+++ b/src/lib/campaign-resume.ts
@@ -1,0 +1,273 @@
+import { and, asc, eq } from "drizzle-orm";
+import type { IdentityHeaders } from "@distribute/runs-client";
+import { db } from "../db/index.js";
+import { campaigns } from "../db/schema.js";
+import { notPausedBrandClause } from "./brand-pause.js";
+import { STOP_REASONS } from "./stop-reason.js";
+import { serveableAudienceIdsForCampaign } from "./serveable-audience.js";
+import { fetchFunnelBudgets } from "./funnel-budget-client.js";
+import { toFunnelKey } from "./sales-funnel-vocabulary.js";
+import type { DownstreamIdentity } from "./downstream-headers.js";
+
+/**
+ * How often the sweep asks features-service about the stopped-for-exhaustion population.
+ *
+ * Its OWN cadence, not the scheduler's. A tick fires as often as every 60s to catch /end-run
+ * reschedules; asking the audience owner about every exhausted campaign at that rate would be a
+ * per-minute fan-out for a state that changes when a customer edits their audiences — hours or
+ * days apart. The customer was told their action is the trigger, so what they are owed is that
+ * it works without them, not that it works within the minute.
+ */
+export const RESUME_SWEEP_INTERVAL_MS = 10 * 60_000; // 10 min
+
+/**
+ * Most campaigns examined in one sweep. Not a silent cap: going over it is logged with the
+ * number left behind, and the sweep reads oldest-checked-first, so the remainder is picked up on
+ * the following sweep rather than starved.
+ */
+export const RESUME_SWEEP_MAX_CAMPAIGNS = 100;
+
+/** Why a candidate was NOT resumed, for the log line. */
+type SkipReason = string;
+
+/**
+ * How many campaigns are waiting on a resume decision. Read by the scheduler's cadence: while
+ * anything is waiting, the idle sleep is capped at the sweep interval, so a brand whose only
+ * campaign is stopped does not sit through the full idle hour before anyone looks at it.
+ */
+export async function countResumableCampaigns(): Promise<number> {
+  const rows = await db
+    .select({ id: campaigns.id })
+    .from(campaigns)
+    .where(
+      and(
+        eq(campaigns.status, "stopped"),
+        eq(campaigns.stopReason, STOP_REASONS.AUDIENCE_EXHAUSTED),
+        notPausedBrandClause(),
+      ),
+    )
+    .limit(1);
+  return rows.length;
+}
+
+let lastSweepAt = 0;
+
+/** Test seam: forget the throttle so a test can run consecutive sweeps. */
+export function resetResumeSweepThrottle(): void {
+  lastSweepAt = 0;
+}
+
+/**
+ * Bring back the campaigns that stopped because they ran out of people to contact and now have
+ * people to contact again.
+ *
+ * The customer's action IS the trigger: they were emailed asking them to extend or add an
+ * audience, they did it, and the new audience shows up in features-service's projection the
+ * moment it goes active. Nothing here polls the whole stopped population — the candidates are
+ * the campaigns that stated `audience_exhausted` when they stopped, which is a narrow and
+ * durable population, and every other stopped campaign is invisible to this code.
+ *
+ * A candidate comes back only when ALL of these hold, and each failure says which one:
+ *   - its brand is not paused,
+ *   - its funding still has a ceiling to spend against,
+ *   - features-service reports at least one serveable, non-exhausted audience,
+ *   - no ongoing campaign already holds its (org, brand, funnel, channel) identity.
+ * Anything unreadable leaves the campaign stopped and logs why. A resume that cannot be decided
+ * safely is not a resume.
+ *
+ * Returns how many campaigns were resumed.
+ */
+export async function resumeServeableCampaigns(now: Date = new Date()): Promise<number> {
+  if (now.getTime() - lastSweepAt < RESUME_SWEEP_INTERVAL_MS) return 0;
+  lastSweepAt = now.getTime();
+
+  const candidates = await db.query.campaigns.findMany({
+    where: and(
+      eq(campaigns.status, "stopped"),
+      eq(campaigns.stopReason, STOP_REASONS.AUDIENCE_EXHAUSTED),
+      // A paused brand is not resumed while it stays paused — same clause the scheduler holds
+      // ongoing campaigns with, so pause means the same thing on both sides of the line.
+      notPausedBrandClause(),
+    ),
+    // Oldest-touched first, so a population larger than one sweep rotates instead of starving.
+    orderBy: [asc(campaigns.updatedAt)],
+    limit: RESUME_SWEEP_MAX_CAMPAIGNS + 1,
+  });
+
+  const examined = candidates.slice(0, RESUME_SWEEP_MAX_CAMPAIGNS);
+  if (candidates.length > RESUME_SWEEP_MAX_CAMPAIGNS) {
+    console.log(
+      `[campaign-service] Resume sweep examining ${examined.length} of ${candidates.length}+ exhausted campaigns — the rest are examined on the next sweep (oldest first)`,
+    );
+  }
+  if (examined.length === 0) return 0;
+
+  let resumed = 0;
+  for (const campaign of examined) {
+    try {
+      if (await resumeOneCampaign(campaign, now)) resumed++;
+    } catch (err) {
+      // An unreadable answer is not a decision: leave the campaign stopped and say so.
+      console.warn(
+        `[campaign-service] Resume check failed for campaign ${campaign.id} — leaving it stopped:`,
+        err,
+      );
+    }
+  }
+
+  return resumed;
+}
+
+/**
+ * Decide and, when everything holds, perform the resume for ONE campaign.
+ * Returns true when the campaign came back.
+ */
+async function resumeOneCampaign(
+  campaign: typeof campaigns.$inferSelect,
+  now: Date,
+): Promise<boolean> {
+  const brandId = campaign.brandId ?? campaign.brandIds?.[0];
+  const featureSlug = campaign.featureSlug;
+  const userId = campaign.createdByUserId;
+
+  if (!brandId) return skip(campaign, "no brand on the campaign");
+  if (!featureSlug) return skip(campaign, "no feature slug on the campaign");
+  if (!userId) return skip(campaign, "no createdByUserId — nothing could run it");
+
+  // A fresh run id per check: the downstream reads are real, attributable calls, and a reused or
+  // absent one is rejected by the services that validate it as a UUID.
+  const runId = crypto.randomUUID();
+  const identity: DownstreamIdentity = {
+    orgId: campaign.orgId,
+    userId,
+    runId,
+    campaignId: campaign.id,
+    brandId,
+    workflowSlug: campaign.workflowSlug,
+    featureSlug,
+  };
+
+  const funding = await fundingCeiling(campaign, brandId, identity);
+  if (funding !== null) return skip(campaign, funding);
+
+  const serveableAudienceIds = await serveableAudienceIdsForCampaign(campaign, featureSlug, identity);
+  if (serveableAudienceIds.length === 0) {
+    // The expected state for most candidates on most sweeps: still nobody to contact. Not logged
+    // — it fires for every exhausted campaign of every client on every sweep, and it is already
+    // observable in the campaign staying stopped.
+    return false;
+  }
+
+  // At most one ongoing campaign per (org, brand, funnel, channel) — the partial unique index
+  // enforces it, and this read is what turns "the index rejected the write" into a decision we
+  // can explain. Both are needed: the index is the guarantee, this is the reason. Scoped to the
+  // rows the index actually covers (it is partial on a stated brand AND channel).
+  if (campaign.brandId && campaign.acquisitionChannel) {
+    const siblings = await db.query.campaigns.findMany({
+      where: and(
+        eq(campaigns.orgId, campaign.orgId),
+        eq(campaigns.status, "ongoing"),
+        eq(campaigns.brandId, campaign.brandId),
+        eq(campaigns.acquisitionChannel, campaign.acquisitionChannel),
+      ),
+      columns: { id: true, funnelKey: true },
+    });
+    const incumbent = siblings.find((s) => (s.funnelKey ?? "") === (campaign.funnelKey ?? ""));
+    if (incumbent) {
+      return skip(
+        campaign,
+        `campaign ${incumbent.id} is already ongoing for this brand, funnel and channel`,
+      );
+    }
+  }
+
+  // Conditional on the state we decided from, so two sweeps (or a sweep racing a human
+  // un-pause) cannot both bring the same campaign back, and a campaign a person stopped between
+  // the read and the write is not resumed.
+  let claimed: Array<{ id: string }>;
+  try {
+    claimed = await db
+      .update(campaigns)
+      .set({
+        status: "ongoing",
+        // The reason described a stop that is over. Clearing it keeps the column describing the
+        // CURRENT state and stops a second sweep treating an ongoing campaign as a candidate.
+        stopReason: null,
+        // Due immediately: the very next scheduler tick treats it like any other running campaign.
+        nextRunAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(campaigns.id, campaign.id),
+          eq(campaigns.status, "stopped"),
+          eq(campaigns.stopReason, STOP_REASONS.AUDIENCE_EXHAUSTED),
+        ),
+      )
+      .returning({ id: campaigns.id });
+  } catch (err) {
+    // The identity index refused the write — another campaign took this identity between the
+    // check above and here. That is the index doing its job; the campaign stays stopped.
+    if ((err as { code?: string } | null)?.code === "23505") {
+      return skip(campaign, "another campaign took this identity first (unique index)");
+    }
+    throw err;
+  }
+
+  if (claimed.length === 0) {
+    return skip(campaign, "no longer stopped-for-exhaustion when the resume was written");
+  }
+
+  console.log(
+    `[campaign-service] Resumed campaign ${campaign.id} (org ${campaign.orgId}, brand ${brandId}, funnel ${campaign.funnelKey ?? "none"}) — stopped for audience exhaustion, now serveable: ${serveableAudienceIds.join(", ")}`,
+  );
+  return true;
+}
+
+/**
+ * Is there still a ceiling to spend against? Returns null when funded, or the reason it is not.
+ *
+ * Mirrors gate-check's precedence exactly — the campaign's OWN daily budget, else its funnel's
+ * ceiling, else the brand's daily budget — because resuming a campaign the gate would refuse to
+ * let spend is a campaign that comes back only to be blocked on its first tick.
+ *
+ * Fail-CLOSED: an unreadable budget leaves the campaign stopped. The scheduler's turn-taking
+ * treats the same read as fail-SOFT because it only reorders work that is already allowed; here
+ * the read decides whether to START spending again, which is the gate's stance, not the
+ * scheduler's.
+ */
+async function fundingCeiling(
+  campaign: typeof campaigns.$inferSelect,
+  brandId: string,
+  identity: IdentityHeaders,
+): Promise<SkipReason | null> {
+  if (campaign.dailyBudgetCents !== null) {
+    return campaign.dailyBudgetCents > 0 ? null : "its own daily budget is zero";
+  }
+
+  const budgets = await fetchFunnelBudgets(brandId, identity);
+  if (!budgets.ok) return "billing did not answer the brand's budget";
+
+  if (campaign.funnelKey && budgets.funnels.length > 0) {
+    // Both sides canonicalised — billing still emits the pre-rename spellings, so comparing raw
+    // tokens would read a fully funded funnel as unfunded and never bring its campaign back.
+    const funnelKey = toFunnelKey(campaign.funnelKey);
+    const ceilingCents = funnelKey
+      ? budgets.funnels.find((f) => f.funnelKey === funnelKey)?.dailyBudgetCents ?? null
+      : null;
+    if (ceilingCents === null) return `funnel ${campaign.funnelKey} is not funded`;
+    return ceilingCents > 0 ? null : `funnel ${campaign.funnelKey} is funded at zero`;
+  }
+
+  // A brand with ONE pot — and a funnel campaign of a brand billing reports no per-funnel
+  // ceilings for, which paces on that same pot.
+  const brandCents = budgets.brandDailyBudgetCents;
+  if (brandCents === null) return "the brand has no daily budget set";
+  return brandCents > 0 ? null : "the brand's daily budget is zero";
+}
+
+/** Leave a campaign stopped and say why. Never silent: a refused resume is a decision. */
+function skip(campaign: { id: string }, reason: SkipReason): false {
+  console.log(`[campaign-service] Not resuming campaign ${campaign.id} — ${reason}`);
+  return false;
+}

--- a/src/lib/features-workflow-projection-client.ts
+++ b/src/lib/features-workflow-projection-client.ts
@@ -347,6 +347,19 @@ export function hasServeableAudienceInProjection(
   rows: ProjectionRow[],
   opts: { requiredAudienceIds?: string[]; excludedAudienceIds?: string[] } = {},
 ): boolean {
+  return serveableAudienceIdsInProjection(rows, opts).length > 0;
+}
+
+/**
+ * WHICH audiences are serveable — the same set hasServeableAudienceInProjection reduces to a
+ * boolean. Named separately because a resume has to SAY what made the campaign serveable again:
+ * "campaign X came back because audience Y is now reachable" is the only way the fleet number can
+ * be checked afterwards, and a boolean cannot say it. Sorted so the log line is stable.
+ */
+export function serveableAudienceIdsInProjection(
+  rows: ProjectionRow[],
+  opts: { requiredAudienceIds?: string[]; excludedAudienceIds?: string[] } = {},
+): string[] {
   let ids = new Set<string>();
   for (const r of rows) if (r.audienceId != null) ids.add(r.audienceId);
 
@@ -357,7 +370,7 @@ export function hasServeableAudienceInProjection(
   if (opts.excludedAudienceIds) {
     for (const e of opts.excludedAudienceIds) ids.delete(e);
   }
-  return ids.size > 0;
+  return [...ids].sort();
 }
 
 /**

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -6,6 +6,7 @@ import { anyBrandPaused } from "./brand-pause.js";
 import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
 import { fetchFunnelBudgets } from "./funnel-budget-client.js";
 import { toFunnelKey } from "./sales-funnel-vocabulary.js";
+import { STOP_REASONS } from "./stop-reason.js";
 
 const STALE_THRESHOLD_MS = 3 * 60 * 60 * 1000; // 3 hours
 
@@ -357,9 +358,12 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
 
 async function autoStopCampaign(campaignId: string): Promise<void> {
   await db.update(campaigns)
-    .set({ status: "stopped", updatedAt: new Date() })
+    // States WHY, so the resume sweep can tell this apart from a campaign that ran out of people
+    // to contact. A lead cap is a limit the campaign reached, not one it can grow out of: it
+    // never comes back on its own.
+    .set({ status: "stopped", stopReason: STOP_REASONS.MAX_LEADS_REACHED, updatedAt: new Date() })
     .where(eq(campaigns.id, campaignId));
-  console.log(`[campaign-service] Auto-stopped campaign ${campaignId}`);
+  console.log(`[campaign-service] Auto-stopped campaign ${campaignId} (max leads reached)`);
 }
 
 async function fetchLeadStats(

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -9,6 +9,14 @@ import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 
 const STALE_THRESHOLD_MS = 3 * 60 * 60 * 1000; // 3 hours
 
+// How many of the campaign's running rows the gate reads. The invariant is ONE run in flight per
+// campaign, and a row only stays `running` until its DAG ends or block 1 marks it stale, so this
+// is orders of magnitude above what a healthy campaign holds. It exists so an unbounded history
+// can never be pulled again — not as a tuning knob. Rows come back newest-first, so if a campaign
+// ever exceeded it the newest still block the tick (the guard stays correct) and the oldest are
+// cleaned on a later pass once the newer ones finish.
+const RUNNING_RUNS_LIMIT = 200;
+
 // The sales-outreach feature family (sales-cold-email-outreach + sales-crm-email-outreach) is
 // paced by the brand daily budget (billing-service brand_daily_budgets) and held on brand pause.
 // Every other feature is paced by the campaign's own budget windows and runs through a pause.
@@ -81,16 +89,24 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
     workflowSlug: campaign.workflowSlug,
   };
 
-  // Fetch all runs for this campaign (needed for stale cleanup, running check, consecutive failures)
-  const { runs } = await listRuns({
+  // The campaign's RUNNING rows — all this gate needs for stale cleanup (block 1) and the
+  // one-run-at-a-time guard (block 2). Asking for the campaign's whole history instead was the
+  // single most expensive query in the fleet: runs-service serves `runs` as a VIEW over its
+  // event log, so every gate check replayed ~21k rows (workflow_context JSONB included) for a
+  // campaign that only ever has one live run — and every new run made the next one dearer.
+  // Filter + bound at the source; the lifetime count block 4 needs is read separately, and only
+  // when a maxLeads cap actually exists.
+  const { runs: runningRuns } = await listRuns({
     orgId: campaign.orgId,
     serviceName: "campaign-service",
     taskName: campaign.campaignId,
+    status: "running",
+    limit: RUNNING_RUNS_LIMIT,
   });
 
   // 1. Stale run cleanup — mark runs running > 30 min as failed
   const now = Date.now();
-  for (const run of runs) {
+  for (const run of runningRuns) {
     if (run.status === "running" && (now - new Date(run.startedAt).getTime()) > STALE_THRESHOLD_MS) {
       try {
         await updateRun(run.id, "failed", identity);
@@ -102,7 +118,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   }
 
   // 2. Running run check — only 1 run at a time per campaign
-  if (runs.some((r: Run) => r.status === "running")) {
+  if (runningRuns.some((r: Run) => r.status === "running")) {
     return { allowed: false, reason: "A run is already in progress" };
   }
 
@@ -300,7 +316,24 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
 
   // 4. Volume check
   if (campaign.maxLeads != null) {
-    const completedRuns = runs.filter((r: Run) => r.status === "completed");
+    // The completed-run count is a LIFETIME total, and it is the fallback for totalServed — so
+    // it cannot be bounded by a recency window without letting a campaign run past its cap
+    // forever. It CAN be bounded by the cap itself: the only thing done with the number is
+    // `>= campaign.maxLeads`, so asking for at most maxLeads rows answers that question exactly.
+    // Fewer than maxLeads rows come back → the count is exact; exactly maxLeads come back → the
+    // cap is reached whatever the true total is. Same decision, bounded by a configured number
+    // (1–5 in every campaign that ever set one) instead of by the campaign's whole history.
+    //
+    // runs-service exposes no per-campaign run COUNT, so this is the cheapest honest read of a
+    // lifetime total from here. A counting endpoint there would make it a single scalar — filed
+    // as a feature request rather than reconstructed locally.
+    const { runs: completedRuns } = await listRuns({
+      orgId: campaign.orgId,
+      serviceName: "campaign-service",
+      taskName: campaign.campaignId,
+      status: "completed",
+      limit: campaign.maxLeads,
+    });
     let totalServed: number;
     try {
       const leadStats = await fetchLeadStats(campaign.orgId, campaign.campaignId, campaign.brandId, identity);

--- a/src/lib/sales-outreach-campaign.ts
+++ b/src/lib/sales-outreach-campaign.ts
@@ -100,7 +100,9 @@ export async function ensureRunnableSalesOutreachCampaign(
 
     const [campaign] = await store
       .update(campaigns)
-      .set({ status: "ongoing", nextRunAt: now, updatedAt: now })
+      // Clearing stopReason keeps the column describing the CURRENT state: the stop it described
+      // is over, and an ongoing campaign must never look like a resume candidate.
+      .set({ status: "ongoing", stopReason: null, nextRunAt: now, updatedAt: now })
       .where(and(
         eq(campaigns.id, stopped.id),
         eq(campaigns.orgId, orgId),

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -6,6 +6,11 @@ import { resolveWorkflowSlugForTrigger } from "./features-workflow-projection-cl
 import { listRuns } from "@distribute/runs-client";
 import { notPausedBrandClause } from "./brand-pause.js";
 import { planFunnelTurns } from "./funnel-campaigns.js";
+import {
+  countResumableCampaigns,
+  resumeServeableCampaigns,
+  RESUME_SWEEP_INTERVAL_MS,
+} from "./campaign-resume.js";
 
 // Cadence while a campaign is actively running (a run is in-flight). At this
 // rate the scheduler catches /end-run reschedules and stuck-run detection.
@@ -336,6 +341,11 @@ async function tick(): Promise<void> {
   isRunning = true;
   try {
     try {
+      // Bring back the campaigns that ran out of people to contact and now have people again,
+      // BEFORE the claim — a campaign resumed here is due immediately, so it takes its turn on
+      // this very tick instead of waiting for the next one. Throttled to its own cadence
+      // (RESUME_SWEEP_INTERVAL_MS), so a 60s tick does not turn into a 60s fan-out.
+      await resumeServeableCampaigns();
       await claimStuckCampaigns();
       await reRunDueCampaigns();
     } catch (err) {
@@ -345,6 +355,13 @@ async function tick(): Promise<void> {
     let delayMs = ACTIVE_INTERVAL_MS;
     try {
       delayMs = computeNextDelayMs(await loadOngoingSnapshot());
+      // A brand whose only campaign is stopped-for-exhaustion has an EMPTY ongoing snapshot, so
+      // the cadence above sleeps the full idle hour and the resume sweep would only run once an
+      // hour however often it is willing to run. While there is anything to bring back, sleep no
+      // longer than the sweep's own cadence.
+      if (delayMs > RESUME_SWEEP_INTERVAL_MS && (await countResumableCampaigns()) > 0) {
+        delayMs = RESUME_SWEEP_INTERVAL_MS;
+      }
     } catch (err) {
       console.error("[campaign-service] Scheduler delay computation error:", err);
     }

--- a/src/lib/serveable-audience.ts
+++ b/src/lib/serveable-audience.ts
@@ -1,0 +1,57 @@
+import type { Campaign } from "../db/schema.js";
+import type { DownstreamIdentity } from "./downstream-headers.js";
+import { fetchBrandRuntimeContext, type RuntimeGoal } from "./brand-runtime-client.js";
+import { getFreshExhaustedAudienceIds } from "./audience-exhaustion.js";
+import {
+  fetchWorkflowProjectionRows,
+  serveableAudienceIdsInProjection,
+} from "./features-workflow-projection-client.js";
+
+/** The campaign fields the serveable-audience read needs. */
+export type ServeableAudienceCampaign = Pick<
+  Campaign,
+  "id" | "orgId" | "goal" | "audienceIds"
+>;
+
+/**
+ * WHICH audiences this campaign could be served right now — the brand's active audiences,
+ * narrowed to the campaign's targeted subset, minus the ones currently marked exhausted.
+ *
+ * ONE definition, asked by the two legs that must agree on it:
+ *   /end-run     — none left → every targeted audience is exhausted → auto-stop.
+ *   resume sweep — at least one → the brand has somebody to contact again → come back.
+ * Two legs on two definitions is how a campaign gets stopped by one and never picked up by the
+ * other, so they read the same function rather than two copies of the same idea.
+ *
+ * The audience set comes from features-service, which owns it — this service never reaches into
+ * the service that owns audiences to decide whether a brand has somebody to contact.
+ *
+ * Deliberately does NOT arbitrate the goal, unlike /start-run. Audience MEMBERSHIP is
+ * goal-independent (features-service enumerates every active audience of the brand per dynasty
+ * whatever the goal; the goal only changes the cost metric attached to each row), so asking on
+ * the brand goal returns the same set. If that ever stopped holding this would see a SUPERSET,
+ * which is the safe direction for both callers: it can only keep a campaign alive or bring one
+ * back, never stop one wrongly.
+ *
+ * THROWS on any features/brand-service failure. Neither caller may treat an unreadable answer as
+ * a decision: /end-run must not stop on an infra hiccup, and the sweep must not resume on one.
+ */
+export async function serveableAudienceIdsForCampaign(
+  campaign: ServeableAudienceCampaign,
+  featureSlug: string,
+  identity: DownstreamIdentity,
+): Promise<string[]> {
+  const brandRuntimeContext = await fetchBrandRuntimeContext(identity.brandId, identity);
+  const runtimeGoal: RuntimeGoal = campaign.goal ?? brandRuntimeContext.currentGoal;
+  const excludedAudienceIds = await getFreshExhaustedAudienceIds(campaign.id);
+  const rows = await fetchWorkflowProjectionRows({
+    featureSlug,
+    brandId: identity.brandId,
+    goal: runtimeGoal,
+    identity,
+  });
+  return serveableAudienceIdsInProjection(rows, {
+    requiredAudienceIds: campaign.audienceIds ?? undefined,
+    excludedAudienceIds,
+  });
+}

--- a/src/lib/stop-reason.ts
+++ b/src/lib/stop-reason.ts
@@ -1,0 +1,33 @@
+/**
+ * WHY a campaign stopped — the vocabulary written to `campaigns.stop_reason`.
+ *
+ * One value per place this service stops a campaign. The distinction exists for a single
+ * decision: a campaign that stopped because it ran out of people to contact comes back by
+ * itself once the brand has somebody to contact again (the customer was emailed asking them to
+ * extend an audience — their action is the trigger, and they were told so). A campaign stopped
+ * for any OTHER reason stays stopped: switching a campaign off on purpose has to mean something.
+ */
+export const STOP_REASONS = {
+  /** /end-run: every targeted audience is exhausted. The ONLY reason a resume can act on. */
+  AUDIENCE_EXHAUSTED: "audience_exhausted",
+  /** gate-check: the campaign reached its configured maxLeads cap. */
+  MAX_LEADS_REACHED: "max_leads_reached",
+  /** PATCH /campaigns/:id with status=stop — a person's decision. */
+  MANUAL: "manual",
+  /** DELETE /internal/campaigns/by-org/:orgId — the org is being torn down. */
+  ORG_TEARDOWN: "org_teardown",
+} as const;
+
+export type StopReason = (typeof STOP_REASONS)[keyof typeof STOP_REASONS];
+
+/**
+ * Can a campaign stopped for this reason come back on its own?
+ *
+ * Only exhaustion. NULL — every row stopped before the reason was recorded, and anything a
+ * future code path stops without stating why — reads as NOT resumable: a stop whose reason
+ * nobody wrote down is not evidence that the campaign ran out of people, and guessing would
+ * resurrect campaigns a person deliberately switched off.
+ */
+export function isResumableStopReason(reason: string | null | undefined): boolean {
+  return reason === STOP_REASONS.AUDIENCE_EXHAUSTED;
+}

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -10,6 +10,7 @@ import { executeCampaignWorkflow, validateWorkflowInputs } from "../lib/workflow
 import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { campaignIdentityColumns } from "../lib/campaign-identity.js";
+import { STOP_REASONS } from "../lib/stop-reason.js";
 
 const router = Router();
 
@@ -381,6 +382,10 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
     const updates = { ...req.body, updatedAt: new Date() };
     if (updates.status) {
       updates.status = statusMap[updates.status] ?? updates.status;
+      // A person stopping a campaign is a decision, and it says so on the row: `manual` is not
+      // resumable, so nothing brings this campaign back on its own. Activating clears the reason
+      // — the stop it described is over.
+      updates.stopReason = req.body.status === "stop" ? STOP_REASONS.MANUAL : null;
     }
 
     const [updated] = await db

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -12,11 +12,12 @@ import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "../lib/brand-runtime-client.js";
 import { markAudienceExhausted, getFreshExhaustedAudienceIds } from "../lib/audience-exhaustion.js";
 import { maybeSendExtendAudienceEmail } from "../lib/transactional-email.js";
+import { serveableAudienceIdsForCampaign } from "../lib/serveable-audience.js";
+import { STOP_REASONS } from "../lib/stop-reason.js";
 import {
   fetchWorkflowProjectionRows,
   fetchGoalArbitration,
   selectAudienceFromProjection,
-  hasServeableAudienceInProjection,
   type ProjectionRow,
 } from "../lib/features-workflow-projection-client.js";
 import type { DownstreamIdentity } from "../lib/downstream-headers.js";
@@ -391,19 +392,11 @@ async function hasServeableAudience(
     workflowSlug: req.workflowSlug || campaign.workflowSlug,
     featureSlug,
   };
-  const brandRuntimeContext = await fetchBrandRuntimeContext(primaryBrandId, identity);
-  const runtimeGoal: RuntimeGoal = campaign.goal ?? brandRuntimeContext.currentGoal;
-  const excludedAudienceIds = await getFreshExhaustedAudienceIds(campaign.id);
-  const rows = await fetchWorkflowProjectionRows({
-    featureSlug,
-    brandId: primaryBrandId,
-    goal: runtimeGoal,
-    identity,
-  });
-  return hasServeableAudienceInProjection(rows, {
-    requiredAudienceIds: campaign.audienceIds ?? undefined,
-    excludedAudienceIds,
-  });
+  // Same definition the resume sweep reads. The two must agree: the leg that stops a campaign
+  // for having nobody left and the leg that brings it back once it has somebody cannot each
+  // carry their own idea of what "somebody" means.
+  const ids = await serveableAudienceIdsForCampaign(campaign, featureSlug, identity);
+  return ids.length > 0;
 }
 
 /**
@@ -512,9 +505,18 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
             void maybeSendExtendAudienceEmail(campaign, { runId: req.runId });
           }
           await db.update(campaigns)
-            .set({ status: "stopped", nextRunAt: null, updatedAt: new Date() })
+            // States WHY it stopped, and it is the ONE reason a campaign comes back by itself:
+            // the customer was just asked to extend an audience, so their doing it has to be
+            // enough to restart the campaign. Without the reason on the row, "resume the ones
+            // that ran out of people" could not be told from "resume the ones a person stopped".
+            .set({
+              status: "stopped",
+              stopReason: STOP_REASONS.AUDIENCE_EXHAUSTED,
+              nextRunAt: null,
+              updatedAt: new Date(),
+            })
             .where(and(eq(campaigns.id, campaignId), eq(campaigns.orgId, orgId)));
-          console.log(`[campaign-service] All targeted audiences exhausted — auto-stopped campaign ${campaignId}`);
+          console.log(`[campaign-service] All targeted audiences exhausted — auto-stopped campaign ${campaignId} (stopReason=${STOP_REASONS.AUDIENCE_EXHAUSTED}; resumes on its own once the brand has a serveable audience again)`);
           return;
         }
         // Serveable audiences remain → do NOT stop; fall through to the reschedule below.
@@ -646,7 +648,8 @@ router.delete("/internal/campaigns/by-org/:orgId", requireApiKey, async (req, re
     const result = await db.transaction(async (tx) => {
       const disabledCampaigns = await tx
         .update(campaigns)
-        .set({ status: "stopped", nextRunAt: null, updatedAt: new Date() })
+        // The org is gone. Stating it keeps these rows out of the resume sweep for good.
+        .set({ status: "stopped", stopReason: STOP_REASONS.ORG_TEARDOWN, nextRunAt: null, updatedAt: new Date() })
         .where(and(
           eq(campaigns.orgId, orgId),
           or(

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -462,6 +462,9 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
           taskName: campaignId,
           parentRunId: req.runId,
           status: "running",
+          // Already narrow — one marker row per parent run — but every listRuns in this service
+          // states a bound, so an unfiltered history read can never come back by accident.
+          limit: 10,
         });
         for (const run of runs) {
           await updateRun(run.id, status, identity);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -64,6 +64,11 @@ export const CampaignSchema = z.object({
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
   status: z.string(),
+  // WHY the campaign stopped: audience_exhausted | max_leads_reached | manual | org_teardown.
+  // Null on an ongoing campaign, and on every campaign stopped before the reason was recorded.
+  // A campaign that stopped because it ran out of people to contact (audience_exhausted) comes
+  // back by itself once the brand has somebody to contact again; no other reason does.
+  stopReason: z.string().nullable(),
   nextRunAt: z.string().nullable(),
   notifyFrequency: z.string().nullable(),
   notifyChannel: z.string().nullable(),

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -51,6 +51,15 @@ export async function insertTestCampaign(
     nextRunAt?: Date | null;
     createdByUserId?: string;
     parentRunId?: string;
+    // WHY it stopped — only `audience_exhausted` is resumable (src/lib/stop-reason.ts).
+    stopReason?: string | null;
+    funnelKey?: string | null;
+    // The two identity columns the partial unique index is built on. Written at creation by
+    // campaignIdentityColumns in the routes; stated explicitly here so a test can build the
+    // (org, brand, funnel, channel) collision the resume must refuse.
+    brandId?: string | null;
+    acquisitionChannel?: string | null;
+    updatedAt?: Date;
   } = {}
 ) {
   const [campaign] = await db
@@ -79,6 +88,11 @@ export async function insertTestCampaign(
       nextRunAt: data.nextRunAt ?? null,
       createdByUserId: data.createdByUserId || null,
       parentRunId: data.parentRunId || null,
+      stopReason: data.stopReason ?? null,
+      funnelKey: data.funnelKey ?? null,
+      brandId: data.brandId ?? null,
+      acquisitionChannel: data.acquisitionChannel ?? null,
+      ...(data.updatedAt ? { updatedAt: data.updatedAt } : {}),
     })
     .returning();
   return campaign;

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -242,6 +242,24 @@ describe("Campaign CRUD", () => {
         .expect(200);
 
       expect(activateRes.body.campaign.status).toBe("ongoing");
+      // The stop it described is over, so the reason goes with it.
+      expect(activateRes.body.campaign.stopReason).toBeNull();
+    });
+
+    it("records a hand stop as `manual`, so nothing ever brings it back on its own", async () => {
+      const createRes = await createCampaign().expect(201);
+      const campaignId = createRes.body.campaign.id;
+
+      const stopRes = await request(app)
+        .patch(`/campaigns/${campaignId}`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .send({ status: "stop" })
+        .expect(200);
+
+      expect(stopRes.body.campaign.status).toBe("stopped");
+      // `manual` is not resumable: stopping a campaign on purpose has to stay stopped.
+      expect(stopRes.body.campaign.stopReason).toBe("manual");
     });
 
     it("should update featureInputs", async () => {

--- a/tests/integration/campaign-resume.test.ts
+++ b/tests/integration/campaign-resume.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+
+// The two things the resume asks other services: does this brand have somebody to contact, and
+// is there still a ceiling to spend against. Both are HTTP reads owned elsewhere; here they are
+// stubbed so the test exercises the DECISION, against a real database.
+const { mockServeableAudienceIds, mockFetchFunnelBudgets } = vi.hoisted(() => ({
+  mockServeableAudienceIds: vi.fn(),
+  mockFetchFunnelBudgets: vi.fn(),
+}));
+
+vi.mock("../../src/lib/serveable-audience.js", () => ({
+  serveableAudienceIdsForCampaign: mockServeableAudienceIds,
+}));
+
+vi.mock("../../src/lib/funnel-budget-client.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/funnel-budget-client.js")>();
+  return { ...original, fetchFunnelBudgets: mockFetchFunnelBudgets };
+});
+
+import { eq } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import { campaigns } from "../../src/db/schema.js";
+import { cleanTestData, closeDb, insertTestCampaign, setBrandPause } from "../helpers/test-db.js";
+import {
+  resumeServeableCampaigns,
+  countResumableCampaigns,
+  resetResumeSweepThrottle,
+  RESUME_SWEEP_INTERVAL_MS,
+} from "../../src/lib/campaign-resume.js";
+import { STOP_REASONS } from "../../src/lib/stop-reason.js";
+import { SALES_OUTREACH_FEATURE_SLUG } from "../../src/lib/sales-outreach-campaign.js";
+
+const orgId = "resume-org";
+const FUNDED = { ok: true as const, brandDailyBudgetCents: 5_000, funnels: [] };
+
+/** A campaign in the exact state /end-run leaves behind when every audience ran dry. */
+async function insertExhaustedCampaign(over: Record<string, unknown> = {}) {
+  const brandId = crypto.randomUUID();
+  return insertTestCampaign(orgId, {
+    status: "stopped",
+    stopReason: STOP_REASONS.AUDIENCE_EXHAUSTED,
+    brandIds: [brandId],
+    brandId,
+    acquisitionChannel: "cold_email",
+    featureSlug: SALES_OUTREACH_FEATURE_SLUG,
+    createdByUserId: "user-resume",
+    nextRunAt: null,
+    ...over,
+  });
+}
+
+async function read(id: string) {
+  return db.query.campaigns.findFirst({ where: eq(campaigns.id, id) });
+}
+
+beforeEach(async () => {
+  await cleanTestData();
+  vi.clearAllMocks();
+  resetResumeSweepThrottle();
+  mockServeableAudienceIds.mockResolvedValue(["audience-fresh"]);
+  mockFetchFunnelBudgets.mockResolvedValue(FUNDED);
+});
+
+afterAll(async () => {
+  await cleanTestData();
+  await closeDb();
+});
+
+describe("resuming a campaign that ran out of people to contact", () => {
+  it("brings it back once the brand has a serveable audience again (AC1)", async () => {
+    const campaign = await insertExhaustedCampaign();
+
+    const resumed = await resumeServeableCampaigns();
+
+    expect(resumed).toBe(1);
+    const after = await read(campaign.id);
+    expect(after?.status).toBe("ongoing");
+  });
+
+  it("returns it to the same state a live campaign is in, due immediately (AC2)", async () => {
+    const campaign = await insertExhaustedCampaign();
+    const now = new Date();
+
+    await resumeServeableCampaigns(now);
+
+    const after = await read(campaign.id);
+    expect(after?.status).toBe("ongoing");
+    // Due now → the very next scheduler tick claims it like any other running campaign.
+    expect(after?.nextRunAt?.getTime()).toBe(now.getTime());
+    // The stop it described is over; an ongoing campaign is never a resume candidate.
+    expect(after?.stopReason).toBeNull();
+  });
+
+  it("leaves it stopped while the brand still has nobody to contact", async () => {
+    const campaign = await insertExhaustedCampaign();
+    mockServeableAudienceIds.mockResolvedValue([]);
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+  });
+
+  it("says which campaign came back and what made it serveable (AC6)", async () => {
+    const campaign = await insertExhaustedCampaign();
+    mockServeableAudienceIds.mockResolvedValue(["aud-a", "aud-b"]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await resumeServeableCampaigns();
+
+    const line = log.mock.calls.map((c) => String(c[0])).find((m) => m.includes("Resumed campaign"));
+    expect(line).toContain(campaign.id);
+    expect(line).toContain("aud-a");
+    expect(line).toContain("aud-b");
+    log.mockRestore();
+  });
+});
+
+describe("a campaign stopped for any other reason (AC3)", () => {
+  it("stays stopped when a person stopped it by hand", async () => {
+    const campaign = await insertExhaustedCampaign({ stopReason: STOP_REASONS.MANUAL });
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    const after = await read(campaign.id);
+    expect(after?.status).toBe("stopped");
+    expect(after?.stopReason).toBe(STOP_REASONS.MANUAL);
+    // It is not even a candidate — the audience owner is never asked about it.
+    expect(mockServeableAudienceIds).not.toHaveBeenCalled();
+  });
+
+  it("stays stopped when it reached its lead cap", async () => {
+    const campaign = await insertExhaustedCampaign({ stopReason: STOP_REASONS.MAX_LEADS_REACHED });
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+  });
+
+  it("stays stopped when its org was torn down", async () => {
+    const campaign = await insertExhaustedCampaign({ stopReason: STOP_REASONS.ORG_TEARDOWN });
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+  });
+
+  it("stays stopped when no reason was ever recorded", async () => {
+    // Every campaign stopped before the reason existed. A stop nobody wrote a reason for is not
+    // evidence of exhaustion, so the whole historical stopped population is invisible here.
+    const campaign = await insertExhaustedCampaign({ stopReason: null });
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+  });
+});
+
+describe("one live campaign per identity (AC4)", () => {
+  it("refuses to resume when an ongoing campaign already holds the identity", async () => {
+    const brandId = crypto.randomUUID();
+    const shared = {
+      brandIds: [brandId],
+      brandId,
+      acquisitionChannel: "cold_email",
+      funnelKey: "sales_meetings_from_conversation",
+    };
+    const incumbent = await insertTestCampaign(orgId, {
+      ...shared,
+      status: "ongoing",
+      featureSlug: SALES_OUTREACH_FEATURE_SLUG,
+      createdByUserId: "user-resume",
+    });
+    const exhausted = await insertExhaustedCampaign(shared);
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(exhausted.id))?.status).toBe("stopped");
+    expect((await read(incumbent.id))?.status).toBe("ongoing");
+
+    // Still exactly one live campaign for the identity.
+    const ongoing = await db.query.campaigns.findMany({
+      where: eq(campaigns.brandId, brandId),
+      columns: { id: true, status: true },
+    });
+    expect(ongoing.filter((c) => c.status === "ongoing")).toHaveLength(1);
+  });
+
+  it("resumes when the ongoing sibling works a DIFFERENT funnel", async () => {
+    const brandId = crypto.randomUUID();
+    await insertTestCampaign(orgId, {
+      brandIds: [brandId],
+      brandId,
+      acquisitionChannel: "cold_email",
+      funnelKey: "website_purchases",
+      status: "ongoing",
+      featureSlug: SALES_OUTREACH_FEATURE_SLUG,
+      createdByUserId: "user-resume",
+    });
+    const exhausted = await insertExhaustedCampaign({
+      brandIds: [brandId],
+      brandId,
+      acquisitionChannel: "cold_email",
+      funnelKey: "sales_meetings_from_conversation",
+    });
+    mockFetchFunnelBudgets.mockResolvedValue({
+      ok: true,
+      brandDailyBudgetCents: 5_000,
+      funnels: [{ funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 2_500 }],
+    });
+
+    expect(await resumeServeableCampaigns()).toBe(1);
+    expect((await read(exhausted.id))?.status).toBe("ongoing");
+  });
+
+  it("is idempotent — a second sweep over an already-resumed campaign does nothing", async () => {
+    const campaign = await insertExhaustedCampaign();
+
+    expect(await resumeServeableCampaigns()).toBe(1);
+    resetResumeSweepThrottle();
+    expect(await resumeServeableCampaigns()).toBe(0);
+
+    const rows = await db.query.campaigns.findMany({ where: eq(campaigns.id, campaign.id) });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("ongoing");
+  });
+});
+
+describe("a brand that is paused or has nothing funded (AC5)", () => {
+  it("does not resume a paused brand's campaign, and does once it un-pauses", async () => {
+    const brandId = crypto.randomUUID();
+    const campaign = await insertExhaustedCampaign({ brandIds: [brandId], brandId });
+    await setBrandPause(orgId, brandId, true);
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+
+    await setBrandPause(orgId, brandId, false);
+    resetResumeSweepThrottle();
+
+    expect(await resumeServeableCampaigns()).toBe(1);
+    expect((await read(campaign.id))?.status).toBe("ongoing");
+  });
+
+  it("does not resume when the brand's daily budget is zero", async () => {
+    const campaign = await insertExhaustedCampaign();
+    mockFetchFunnelBudgets.mockResolvedValue({ ok: true, brandDailyBudgetCents: 0, funnels: [] });
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+  });
+
+  it("does not resume when the brand has no daily budget set at all", async () => {
+    const campaign = await insertExhaustedCampaign();
+    mockFetchFunnelBudgets.mockResolvedValue({ ok: true, brandDailyBudgetCents: null, funnels: [] });
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+  });
+
+  it("does not resume a funnel campaign whose funnel is funded at zero", async () => {
+    const campaign = await insertExhaustedCampaign({ funnelKey: "sales_meetings_from_conversation" });
+    mockFetchFunnelBudgets.mockResolvedValue({
+      ok: true,
+      brandDailyBudgetCents: 5_000,
+      // The brand funds ANOTHER funnel. Falling back to the brand total would let this one spend
+      // the other funnel's money, so it stays stopped.
+      funnels: [{ funnelKey: "website_purchases", dailyBudgetCents: 5_000 }],
+    });
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+  });
+
+  it("resumes a funnel campaign on the pre-rename spelling billing still emits", async () => {
+    // billing names this funnel `reply_meeting`; the campaign states the canonical key. Comparing
+    // raw tokens would read a fully funded funnel as unfunded and never bring the campaign back.
+    const campaign = await insertExhaustedCampaign({ funnelKey: "sales_meetings_from_conversation" });
+    mockFetchFunnelBudgets.mockResolvedValue({
+      ok: true,
+      brandDailyBudgetCents: 5_000,
+      funnels: [{ funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 2_500 }],
+    });
+
+    expect(await resumeServeableCampaigns()).toBe(1);
+    expect((await read(campaign.id))?.status).toBe("ongoing");
+  });
+
+  it("resumes on the campaign's OWN daily budget without asking billing", async () => {
+    const campaign = await insertExhaustedCampaign({ dailyBudgetCents: 1_000 });
+
+    expect(await resumeServeableCampaigns()).toBe(1);
+    expect((await read(campaign.id))?.status).toBe("ongoing");
+    expect(mockFetchFunnelBudgets).not.toHaveBeenCalled();
+  });
+});
+
+describe("a resume that cannot be decided safely", () => {
+  it("leaves the campaign stopped when billing does not answer", async () => {
+    const campaign = await insertExhaustedCampaign();
+    mockFetchFunnelBudgets.mockResolvedValue({ ok: false });
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+  });
+
+  it("leaves the campaign stopped when the audience owner throws", async () => {
+    const campaign = await insertExhaustedCampaign();
+    mockServeableAudienceIds.mockRejectedValue(new Error("features-service down"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(await resumeServeableCampaigns()).toBe(0);
+    expect((await read(campaign.id))?.status).toBe("stopped");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("one undecidable campaign does not stop the next one from resuming", async () => {
+    const broken = await insertExhaustedCampaign({ updatedAt: new Date(Date.now() - 120_000) });
+    const fine = await insertExhaustedCampaign({ updatedAt: new Date(Date.now() - 60_000) });
+    mockServeableAudienceIds.mockImplementation(async (c: { id: string }) =>
+      c.id === broken.id ? Promise.reject(new Error("boom")) : ["audience-fresh"],
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(await resumeServeableCampaigns()).toBe(1);
+    expect((await read(broken.id))?.status).toBe("stopped");
+    expect((await read(fine.id))?.status).toBe("ongoing");
+    warn.mockRestore();
+  });
+});
+
+describe("the sweep's own cadence", () => {
+  it("does not re-ask the audience owner before its interval has passed", async () => {
+    await insertExhaustedCampaign();
+    mockServeableAudienceIds.mockResolvedValue([]);
+
+    await resumeServeableCampaigns();
+    expect(mockServeableAudienceIds).toHaveBeenCalledTimes(1);
+
+    // A scheduler tick a minute later must not turn into a second fan-out.
+    await resumeServeableCampaigns(new Date(Date.now() + 60_000));
+    expect(mockServeableAudienceIds).toHaveBeenCalledTimes(1);
+
+    await resumeServeableCampaigns(new Date(Date.now() + RESUME_SWEEP_INTERVAL_MS + 1_000));
+    expect(mockServeableAudienceIds).toHaveBeenCalledTimes(2);
+  });
+
+  it("counts what is waiting so the scheduler does not sleep an hour on it", async () => {
+    expect(await countResumableCampaigns()).toBe(0);
+    await insertExhaustedCampaign();
+    expect(await countResumableCampaigns()).toBe(1);
+  });
+});

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -1063,6 +1063,9 @@ describe("Pipeline routes", () => {
           status: "running",
         }),
       );
+      // Bounded like every other runs read in this service — one marker row per parent run, and
+      // no path can regress into pulling the campaign's history.
+      expect(mockListRuns.mock.calls[0][0].limit).toBeGreaterThan(0);
       expect(mockUpdateRun).toHaveBeenCalledTimes(1);
       expect(mockUpdateRun).toHaveBeenCalledWith("run-own", "failed", expect.objectContaining({ orgId }));
     });

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -1243,6 +1243,10 @@ describe("Pipeline routes", () => {
       });
       expect(updated!.status).toBe("stopped");
       expect(updated!.nextRunAt).toBeNull();
+      // And it says WHY. This is the one reason a campaign comes back on its own — the customer
+      // is emailed asking them to extend an audience, so their doing it has to restart it. A stop
+      // that does not record this reason is a campaign that stays stopped forever.
+      expect(updated!.stopReason).toBe("audience_exhausted");
     });
 
     it("should set nextRunAt and NOT fire-and-forget when stopCampaign is false", async () => {

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -96,6 +96,25 @@ function makeRun(overrides: Partial<{ id: string; status: string; startedAt: str
   };
 }
 
+/**
+ * The gate reads runs-service TWICE and each read states what it wants: the campaign's RUNNING
+ * rows (stale cleanup + the one-run-at-a-time guard) and — only under a maxLeads cap — its
+ * COMPLETED rows, bounded by that cap. Answer each call by the status it asked for, so a test
+ * that stages completed runs cannot accidentally also stage them as live.
+ */
+function mockRuns(
+  { running = [], completed = [] }: { running?: unknown[]; completed?: unknown[] } = {},
+) {
+  mockListRuns.mockImplementation(async (params: { status?: string; limit?: number }) => {
+    if (params.status === "running") return { runs: running };
+    if (params.status === "completed") {
+      // runs-service honours the bound; a caller asking for N never receives more than N.
+      return { runs: params.limit != null ? completed.slice(0, params.limit) : completed };
+    }
+    return { runs: [] };
+  });
+}
+
 function makeBudgetResponse(
   windows: Array<{
     label: string;
@@ -132,7 +151,7 @@ function makeBudgetResponse(
 describe("Gate Check", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockListRuns.mockResolvedValue({ runs: [] });
+    mockRuns();
     mockGetStatsBudget.mockResolvedValue({ windows: [] });
     mockUpdateRun.mockResolvedValue({});
     mockAnyBrandPaused.mockResolvedValue(false);
@@ -191,7 +210,7 @@ describe("Gate Check", () => {
         status: "running",
         startedAt: new Date(Date.now() - (3 * 60 + 1) * 60 * 1000).toISOString(),
       });
-      mockListRuns.mockResolvedValue({ runs: [staleRun] });
+      mockRuns({ running: [staleRun] });
 
       await runGateChecks(makeCampaign());
 
@@ -204,7 +223,7 @@ describe("Gate Check", () => {
         status: "running",
         startedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
       });
-      mockListRuns.mockResolvedValue({ runs: [recentRun] });
+      mockRuns({ running: [recentRun] });
 
       const result = await runGateChecks(makeCampaign());
 
@@ -220,7 +239,7 @@ describe("Gate Check", () => {
         status: "running",
         startedAt: new Date(Date.now() - 1000).toISOString(),
       });
-      mockListRuns.mockResolvedValue({ runs: [runningRun] });
+      mockRuns({ running: [runningRun] });
 
       const result = await runGateChecks(makeCampaign());
       expect(result.allowed).toBe(false);
@@ -403,14 +422,59 @@ describe("Gate Check", () => {
     });
   });
 
+  describe("Bounded runs reads", () => {
+    it("never asks runs-service for the campaign's whole history", async () => {
+      await runGateChecks(makeCampaign({ maxLeads: 3 }));
+
+      expect(mockListRuns).toHaveBeenCalled();
+      for (const [params] of mockListRuns.mock.calls) {
+        // Every read states the status it wants AND a bound. An unfiltered, unbounded read
+        // replayed ~21k rows per gate check — i.e. per campaign per tick, fleet-wide.
+        expect(params.status).toBeDefined();
+        expect(params.limit).toBeGreaterThan(0);
+      }
+    });
+
+    it("reads only the RUNNING rows for stale cleanup + the in-progress guard", async () => {
+      await runGateChecks(makeCampaign());
+
+      const statuses = mockListRuns.mock.calls.map(([p]: [{ status?: string }]) => p.status);
+      expect(statuses).toEqual(["running"]);
+      const [params] = mockListRuns.mock.calls[0];
+      expect(params).toMatchObject({
+        orgId: "org-1",
+        serviceName: "campaign-service",
+        taskName: "campaign-1",
+        status: "running",
+      });
+    });
+
+    it("does not read completed runs at all when the campaign has no maxLeads cap", async () => {
+      await runGateChecks(makeCampaign({ maxLeads: null }));
+
+      const statuses = mockListRuns.mock.calls.map(([p]: [{ status?: string }]) => p.status);
+      expect(statuses).not.toContain("completed");
+    });
+
+    it("bounds the completed-run read by the cap it is compared against", async () => {
+      await runGateChecks(makeCampaign({ maxLeads: 3 }));
+
+      const completedCall = mockListRuns.mock.calls
+        .map(([p]: [{ status?: string; limit?: number }]) => p)
+        .find(p => p.status === "completed");
+      expect(completedCall).toMatchObject({ status: "completed", limit: 3 });
+    });
+  });
+
   describe("Volume check", () => {
     it("should auto-stop when maxLeads is reached", async () => {
-      const runs = [
-        makeRun({ id: "r1", status: "completed" }),
-        makeRun({ id: "r2", status: "completed" }),
-        makeRun({ id: "r3", status: "completed" }),
-      ];
-      mockListRuns.mockResolvedValue({ runs });
+      mockRuns({
+        completed: [
+          makeRun({ id: "r1", status: "completed" }),
+          makeRun({ id: "r2", status: "completed" }),
+          makeRun({ id: "r3", status: "completed" }),
+        ],
+      });
 
       // Mock lead stats
       mockFetch.mockResolvedValueOnce({
@@ -425,8 +489,7 @@ describe("Gate Check", () => {
     });
 
     it("should allow when maxLeads is not reached", async () => {
-      const runs = [makeRun({ id: "r1", status: "completed" })];
-      mockListRuns.mockResolvedValue({ runs });
+      mockRuns({ completed: [makeRun({ id: "r1", status: "completed" })] });
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -438,11 +501,12 @@ describe("Gate Check", () => {
     });
 
     it("should fallback to completed run count on 404 from lead-service", async () => {
-      const runs = [
-        makeRun({ id: "r1", status: "completed" }),
-        makeRun({ id: "r2", status: "completed" }),
-      ];
-      mockListRuns.mockResolvedValue({ runs });
+      mockRuns({
+        completed: [
+          makeRun({ id: "r1", status: "completed" }),
+          makeRun({ id: "r2", status: "completed" }),
+        ],
+      });
 
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -453,8 +517,43 @@ describe("Gate Check", () => {
       expect(result.allowed).toBe(true); // 2 completed < 5 maxLeads
     });
 
+    it("still reaches maxLeads for a campaign whose history dwarfs the bound", async () => {
+      // 50 lifetime completed runs against a cap of 3. The gate only ever receives the first 3
+      // (that is the whole point of the bound) — a count capped at the cap must still satisfy
+      // `>= maxLeads`, or a long-running campaign would never stop.
+      mockRuns({
+        completed: Array.from({ length: 50 }, (_, i) =>
+          makeRun({ id: `r${i}`, status: "completed" }),
+        ),
+      });
+
+      // lead-service 404 → the completed-run count IS totalServed, no other source.
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+      const result = await runGateChecks(makeCampaign({ maxLeads: 3 }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Max leads reached");
+      expect(result.autoStopped).toBe(true);
+    });
+
+    it("still reaches maxLeads via the history when lead-service under-reports", async () => {
+      mockRuns({
+        completed: Array.from({ length: 50 }, (_, i) =>
+          makeRun({ id: `r${i}`, status: "completed" }),
+        ),
+      });
+
+      // lead-service answers below the cap; the run history is what carries the campaign over it.
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ totalServed: 1 }) });
+
+      const result = await runGateChecks(makeCampaign({ maxLeads: 5 }));
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Max leads reached");
+      expect(result.autoStopped).toBe(true);
+    });
+
     it("should block on non-404 lead-service error (fail-closed)", async () => {
-      mockListRuns.mockResolvedValue({ runs: [] });
+      mockRuns();
 
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/tests/unit/sales-outreach-campaign.test.ts
+++ b/tests/unit/sales-outreach-campaign.test.ts
@@ -107,7 +107,9 @@ describe("ensureRunnableSalesOutreachCampaign", () => {
       now,
     })).resolves.toEqual({ action: "resumed", campaign: resumed });
 
-    expect(mut.fns.set).toHaveBeenCalledWith({ status: "ongoing", nextRunAt: now, updatedAt: now });
+    // stopReason clears with the resume: the stop it described is over, and an ongoing campaign
+    // must never read as a resume candidate.
+    expect(mut.fns.set).toHaveBeenCalledWith({ status: "ongoing", stopReason: null, nextRunAt: now, updatedAt: now });
     expect(mut.insert).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -86,6 +86,14 @@ vi.mock("../../src/lib/funnel-campaigns.js", () => ({
   planFunnelTurns: vi.fn(async () => new Map()),
 }));
 
+// The resume sweep has its own suite (tests/integration/campaign-resume.test.ts) and needs a real
+// DB. Inert here so the narrowly-mocked db/schema/drizzle-orm above stay sufficient.
+vi.mock("../../src/lib/campaign-resume.js", () => ({
+  resumeServeableCampaigns: vi.fn(async () => 0),
+  countResumableCampaigns: vi.fn(async () => 0),
+  RESUME_SWEEP_INTERVAL_MS: 600_000,
+}));
+
 import {
   reRunDueCampaigns,
   claimStuckCampaigns,

--- a/tests/unit/stop-reason.test.ts
+++ b/tests/unit/stop-reason.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { STOP_REASONS, isResumableStopReason } from "../../src/lib/stop-reason.js";
+
+describe("stop reasons", () => {
+  it("names one reason per place a campaign is stopped", () => {
+    expect(STOP_REASONS).toEqual({
+      AUDIENCE_EXHAUSTED: "audience_exhausted",
+      MAX_LEADS_REACHED: "max_leads_reached",
+      MANUAL: "manual",
+      ORG_TEARDOWN: "org_teardown",
+    });
+  });
+
+  it("resumes ONLY a campaign that ran out of people to contact", () => {
+    expect(isResumableStopReason(STOP_REASONS.AUDIENCE_EXHAUSTED)).toBe(true);
+
+    // Stopping a campaign on purpose has to stay stopped, and a campaign that hit a limit it
+    // cannot grow out of never comes back on its own either.
+    expect(isResumableStopReason(STOP_REASONS.MANUAL)).toBe(false);
+    expect(isResumableStopReason(STOP_REASONS.MAX_LEADS_REACHED)).toBe(false);
+    expect(isResumableStopReason(STOP_REASONS.ORG_TEARDOWN)).toBe(false);
+  });
+
+  it("never resumes a stop whose reason nobody recorded", () => {
+    // Every row stopped before the reason column existed. Guessing one would resurrect the
+    // campaigns a person switched off on purpose.
+    expect(isResumableStopReason(null)).toBe(false);
+    expect(isResumableStopReason(undefined)).toBe(false);
+    expect(isResumableStopReason("")).toBe(false);
+    expect(isResumableStopReason("something-a-future-code-path-invented")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

A campaign whose every targeted audience is exhausted is auto-stopped, and an email goes out asking the customer to extend or add an audience. **Nothing closed that loop.** The customer does exactly what the email asked and their campaign stays stopped forever, because no path anywhere turns a stopped campaign back on. The dashboard makes it worse rather than explaining it: it lists only live campaigns, so the brand sees an empty table with no reason.

Prod, brand `a179bbd9-8eed-4dba-9338-78125922b0c6` (org `5fefaf5a`): auto-stopped for exhaustion on 2026-08-05, the owner activated three fresh audiences on 2026-08-10, and five days of a funded and unpaused brand produced nothing. It was resurrected by hand.

## Fix

**WHY a campaign stopped is now a stored fact** — `campaigns.stop_reason` (migration 0046), written at all four places this service stops a campaign:

| reason | written by | resumes? |
|---|---|---|
| `audience_exhausted` | `/end-run`, all targeted audiences exhausted | **yes** |
| `max_leads_reached` | gate-check | no |
| `manual` | `PATCH /campaigns/:id` status=stop | no |
| `org_teardown` | `DELETE /internal/campaigns/by-org/:orgId` | no |

`NULL` never resumes, so the entire historical stopped population is invisible to this — deliberately, and it is why there is **no backfill**: a stop nobody wrote a reason for is not evidence of exhaustion, and a timestamp-correlation guess would resurrect campaigns a person stopped on purpose. The loop closes forward. The reason is cleared whenever a campaign becomes ongoing again (resume, activate, brand un-pause), so the column always describes the *current* stop.

**The signal is the audience owner's answer, not a guess and not a poll over the stopped population.** 682 stopped rows against 17 ongoing, so the sweep reads only `status='stopped' AND stop_reason='audience_exhausted'` (partial index). For each, it asks features-service — which owns audiences — whether the brand has somebody to contact; a newly-activated audience appears there the moment the customer activates it. `serveableAudienceIdsForCampaign` is now the **one** definition of "has somebody to contact", shared by the leg that stops (`/end-run`) and the leg that resumes. Two legs on two definitions is how a campaign gets stopped by one and never picked up by the other.

**Own cadence** (`RESUME_SWEEP_INTERVAL_MS` = 10 min), not the scheduler tick's — a tick fires as often as every 60s and this state changes when a customer edits their audiences. The scheduler caps its idle sleep at that interval while anything is waiting, otherwise a brand whose only campaign is stopped has an empty ongoing snapshot, sleeps the full idle hour, and the sweep runs hourly however willing it is.

**Fail-CLOSED**, unlike the scheduler's other reads: funding is checked on gate-check's exact precedence (own `dailyBudgetCents` → funnel ceiling → brand daily budget), and a paused brand, a zero ceiling, an unreadable budget or an unreadable audience set all leave the campaign stopped. Every refusal is logged with its reason; every resume logs the campaign and the audiences that made it serveable.

**At most one ongoing campaign per (org, brand, funnel, channel) still holds**: the sweep checks for an incumbent, the write is conditional on the row still being stopped-for-exhaustion, and a `23505` from the partial unique index leaves it stopped.

The auto-stop itself is untouched. Stopping when there is nobody left to contact is correct; never coming back was the bug.

## Acceptance criteria

- **AC1** resumes once the brand has a serveable audience, no human step — `campaign-resume.test.ts`
- **AC2** resumes to `ongoing` + `nextRunAt=now`, so the very next tick claims it like any other
- **AC3** stopped for any other reason does NOT resume — manual / max-leads / teardown / unrecorded, each covered; the manual case never even asks the audience owner
- **AC4** idempotent, cannot produce two live campaigns for one identity — incumbent refusal + repeat-sweep no-op + different-funnel sibling still resumes
- **AC5** paused brand, zero brand budget, unset brand budget, funnel funded at zero — all stay stopped; un-pausing resumes
- **AC6** the resume names the campaign, its brand, its funnel and the audiences that made it serveable

## Tests

35 test files pass (unit + integration against a real Postgres). `tsc --noEmit` clean, build + openapi regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
