### PR TITLE
docs: a test pinning frozen history against a growing constant fails when it grows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,55 @@ legacy `campaign.goal`, which nothing writes any more.
 
 **Arbitration now only decides for a brand with ONE pot.** A customer who funds each sales funnel separately has decided which funnels run — see the per-funnel section below. A funnel campaign carries the funnel's own goal, so it is a stated-goal campaign and is never arbitrated. (Set 2026-07-31, T4a; scoped 2026-08-02.)
 
+## Per (funnel, ACQUISITION CHANNEL) funding — a channel IS a feature slug, and every funded pair runs
+
+A sales funnel can be worked through more than one OFFER at once: the straight sales pitch
+(`sales-cold-email-outreach`) and the feedback request
+(`sales-feedback-request-cold-email-outreach`), which asks a buyer about the problem we solve
+instead of pitching. Same infrastructure, same measurement — only the offer differs, so a brand can
+work ONE funnel through BOTH, and each is a campaign of its own.
+
+- **A CHANNEL IS A FEATURES-SERVICE FEATURE SLUG.** There is no channel table, enum or vocabulary
+  in this service and none is to be introduced. Adding a further channel is one line in
+  `SALES_OUTREACH_FEATURE_SLUGS` (`src/lib/sales-outreach-campaign.ts`) plus its
+  `CHANNEL_BY_FEATURE` token — a second offer on the same medium needs its OWN channel token
+  (`feedback_request_email`, not `cold_email`), or the two campaigns of one funnel would collide on
+  the identity index and only one could exist.
+- **One campaign per funded (funnel, channel) PAIR.** billing serves the pair ceiling ADDITIVELY on
+  the same read (`channels: [{funnelKey, featureSlug, dailyBudgetCents}]`, `funnels` being its
+  per-funnel SUM), so nothing here adds anything up. `fundedPairs` provisions off `channels` when
+  billing states any and off `funnels` × the seed's channel when it does not — that fallback is
+  what keeps a brand funding one channel per funnel, i.e. every brand today, byte-identical.
+- **The ceiling that binds a campaign is its OWN pair's** (`channelCeilingCents`), inserted at one
+  place in gate-check's precedence and one in `campaign-funding`: own `dailyBudgetCents` → PAIR
+  ceiling → funnel ceiling → brand pot. Ranking two channels of one funnel against the funnel TOTAL
+  is how one offer spends the money the other was funded for, and it shows up in no log at all.
+  A funnel SPLIT across channels that does not fund this campaign's channel is UNFUNDED — never a
+  fallback to the funnel or brand figure.
+- **A funnel funded through exactly ONE channel binds whatever feature the campaign states.** That
+  mirrors billing's own rule for a write naming no channel, and it is load-bearing: billing's
+  migration attributed some brands' single ceiling to the DEFAULT channel while their campaign runs
+  another sales feature, and holding those would break a brand that has funded one channel per
+  funnel all along.
+- **Which funnels a channel may be SOLD THROUGH is features-service's statement, asked per feature**
+  (`GET /features/{slug}` → `salesFunnels`, `src/lib/feature-sales-funnels-client.ts`). The feedback
+  request states `sales_meetings_from_conversation` alone: its offer buys a CONVERSATION, and the
+  other three chains buy their first step with a website click it has no way to sell. A funded pair
+  the feature may not sell gets NO campaign, the same way a funnel billing funds but brand-service
+  does not declare gets none. An unreadable statement provisions nothing for that channel — a pair
+  is never guessed at. `tests/unit/no-legacy.test.ts` fails if a feature slug and a funnel key ever
+  appear on one line of code outside the client that ASKS: a local matrix is a second copy of one
+  product fact, drifting the day a channel gains or loses a chain.
+- **A workflow belongs to a FEATURE, so a new channel's campaign is given its own** (workflow-service
+  `GET /workflows?featureSlug=&status=active`). The seed campaign's slug is only right for the
+  seed's own channel; handing it to another offer runs the wrong DAG, and a slug of no feature at
+  all is refused by workflow-service — a campaign that stays ongoing and produces nothing forever.
+  A channel with NO active workflow is not provisioned (fail-closed); the next sweep stands it up
+  the moment the dynasty ships.
+- Everything below — the turn-taking, the fail-closed hold, the per-brand serialization, which
+  stopped campaigns funding may resume — is UNCHANGED and applies per campaign, so it applies per
+  pair without a special case. (Set 2026-08-18.)
+
 ## Per-funnel funding: every funded funnel runs, each paced on its OWN ceiling
 
 billing-service lets a customer fund each of a brand's SALES FUNNELS separately. Its brand-level

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,15 @@ legacy `campaign.goal`, which nothing writes any more.
 
 **Arbitration now only decides for a brand with ONE pot.** A customer who funds each sales funnel separately has decided which funnels run — see the per-funnel section below. A funnel campaign carries the funnel's own goal, so it is a stated-goal campaign and is never arbitrated. (Set 2026-07-31, T4a; scoped 2026-08-02.)
 
+## A test that pins FROZEN history against a GROWING constant fails the day the constant grows
+
+`tests/unit/funnel-owner-decision.test.ts` asserted both directions between a shipped migration's
+SQL and `SALES_OUTREACH_FEATURE_SLUGS`: every slug in the SQL is a sales one (true forever) AND
+every sales slug appears in the SQL (true only until the family grows). Adding the second
+acquisition channel failed it, on a migration that is correct and can never mention a feature that
+did not exist when it ran. Assert the direction that stays true — what the frozen file names is
+in-scope — never that a live set is fully covered by it. (Set 2026-08-18.)
+
 ## Per (funnel, ACQUISITION CHANNEL) funding — a channel IS a feature slug, and every funded pair runs
 
 A sales funnel can be worked through more than one OFFER at once: the straight sales pitch

--- a/src/lib/campaign-funding.ts
+++ b/src/lib/campaign-funding.ts
@@ -1,5 +1,5 @@
 import type { IdentityHeaders } from "@distribute/runs-client";
-import { fetchFunnelBudgets, type FunnelBudgetsRead } from "./funnel-budget-client.js";
+import { channelCeilingCents, fetchFunnelBudgets, type FunnelBudgetsRead } from "./funnel-budget-client.js";
 import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 
 /**
@@ -13,9 +13,10 @@ import { toFunnelKey } from "./sales-funnel-vocabulary.js";
  * never be claimed and had no API path back. Two representations of one fact is what produced
  * that, so there is one now, and it is billing's.
  *
- * The precedence is gate-check's, exactly — the campaign's OWN daily budget, else its funnel's
- * ceiling, else the brand's daily budget — because a campaign the gate would refuse to let spend
- * must not be handed a turn, and a campaign the gate WOULD let spend must not be held.
+ * The precedence is gate-check's, exactly — the campaign's OWN daily budget, else its own (funnel,
+ * acquisition channel) pair's ceiling, else its funnel's ceiling, else the brand's daily budget —
+ * because a campaign the gate would refuse to let spend must not be handed a turn, and a campaign
+ * the gate WOULD let spend must not be held.
  *
  * A ceiling that was never stated is NOT "unbounded", it is "unfunded". That is the one place
  * this differs from what the gate used to do: `brandDailyBudgetBlock` read a null brand budget as
@@ -32,7 +33,12 @@ export type FundingVerdict =
  * campaign of that brand without asking billing again per campaign.
  */
 export function fundingFromBudgets(
-  campaign: { dailyBudgetCents?: number | null; funnelKey?: string | null },
+  campaign: {
+    dailyBudgetCents?: number | null;
+    funnelKey?: string | null;
+    /** The acquisition CHANNEL this campaign works its funnel through — a feature slug. */
+    featureSlug?: string | null;
+  },
   budgets: Extract<FunnelBudgetsRead, { ok: true }>,
 ): FundingVerdict {
   // The campaign's own figure is a MIRROR of its funnel's ceiling (gate-check is the first node
@@ -48,6 +54,30 @@ export function fundingFromBudgets(
     // tokens would read a fully funded funnel as unfunded and hold a campaign the customer pays
     // for.
     const funnelKey = toFunnelKey(campaign.funnelKey);
+
+    // The ceiling that binds THIS campaign is its own (funnel, channel) pair's, whenever billing
+    // states one: a funnel worked through two offers funds each separately, and holding both
+    // against the funnel TOTAL would let one spend the other's money. A funnel billing states no
+    // pair for falls through to the funnel figure below — that is every brand funding one channel
+    // per funnel, unchanged.
+    if (funnelKey) {
+      const pair = channelCeilingCents(budgets, funnelKey, campaign.featureSlug);
+      if (pair.grain === "pair") {
+        if (pair.cents === null) {
+          return {
+            funded: false,
+            reason: `funnel ${campaign.funnelKey} is not funded for channel ${campaign.featureSlug ?? "none"}`,
+          };
+        }
+        return pair.cents > 0
+          ? { funded: true, ceilingCents: pair.cents }
+          : {
+              funded: false,
+              reason: `funnel ${campaign.funnelKey} is funded at zero for channel ${campaign.featureSlug ?? "none"}`,
+            };
+      }
+    }
+
     const ceilingCents = funnelKey
       ? budgets.funnels.find((f) => f.funnelKey === funnelKey)?.dailyBudgetCents ?? null
       : null;
@@ -75,7 +105,11 @@ export function fundingFromBudgets(
  * outage could only burn a run that the gate is about to refuse anyway.
  */
 export async function campaignFunding(
-  campaign: { dailyBudgetCents?: number | null; funnelKey?: string | null },
+  campaign: {
+    dailyBudgetCents?: number | null;
+    funnelKey?: string | null;
+    featureSlug?: string | null;
+  },
   brandId: string,
   identity: IdentityHeaders,
 ): Promise<FundingVerdict> {

--- a/src/lib/campaign-identity.ts
+++ b/src/lib/campaign-identity.ts
@@ -35,6 +35,10 @@ const CHANNEL_BY_FEATURE: Readonly<Record<string, string>> = Object.freeze({
   // through today; a brand may fund the same funnel on both, and those are two campaigns.
   "sales-cold-email-outreach": "cold_email",
   "sales-crm-email-outreach": "crm_email",
+  // The feedback-request offer. Same medium as `cold_email` and deliberately NOT the same channel
+  // token: a brand may work one funnel through both offers at once, and those are two campaigns,
+  // so they must hold two identities or the unique index would let only one of them exist.
+  "sales-feedback-request-cold-email-outreach": "feedback_request_email",
 
   // Everything else. A sales funnel is not something these run — their funnel stays NULL — but
   // they still carry a channel so the identity key is enforceable for them too.

--- a/src/lib/feature-sales-funnels-client.ts
+++ b/src/lib/feature-sales-funnels-client.ts
@@ -1,0 +1,65 @@
+import type { IdentityHeaders } from "@distribute/runs-client";
+import { toFunnelKey, type SalesFunnelKey } from "./sales-funnel-vocabulary.js";
+
+/**
+ * WHICH SALES FUNNELS AN ACQUISITION CHANNEL MAY BE SOLD THROUGH — features-service's statement,
+ * asked rather than held.
+ *
+ * Not every channel can sell every funnel: the feedback-request offer buys a CONVERSATION, while
+ * three of the four funnels start with a click onto the brand's website it has no way to sell. That
+ * is a product fact about the feature, and features-service owns it — it states `salesFunnels` on
+ * the feature row every consumer already reads. Hardcoding the matrix here would be a second copy
+ * of one fact, drifting the day a channel gains or loses a chain.
+ *
+ * Contract (features-service): GET /features/{slug} (x-api-key + identity)
+ *   -> { slug, ..., salesFunnels: string[] }
+ *
+ * ALWAYS PRESENT on the wire: a feature that sells through no sales funnel states `[]` and one that
+ * sells through every declared chain states all four keys. So an EMPTY list is a real answer —
+ * "this feature sells through no sales funnel" — and never means "all of them".
+ *
+ * Returns null when the statement could not be read (missing config, network error, non-2xx,
+ * unparseable payload, or the field absent because features-service predates it). The caller treats
+ * that exactly as it treats an unreadable brand funnel declaration: provision nothing rather than
+ * guess a pair a customer may not be able to sell through.
+ */
+export async function fetchFeatureSalesFunnels(
+  featureSlug: string,
+  identity: IdentityHeaders,
+): Promise<Set<SalesFunnelKey> | null> {
+  const baseUrl = process.env.FEATURES_SERVICE_URL;
+  const apiKey = process.env.FEATURES_SERVICE_API_KEY;
+  if (!baseUrl || !apiKey) return null;
+
+  const headers: Record<string, string> = {
+    "x-api-key": apiKey,
+    "x-org-id": identity.orgId,
+  };
+  if (identity.userId) headers["x-user-id"] = identity.userId;
+  if (identity.runId) headers["x-run-id"] = identity.runId;
+  if (identity.campaignId) headers["x-campaign-id"] = identity.campaignId;
+  if (identity.brandId) headers["x-brand-id"] = identity.brandId;
+  if (identity.workflowSlug) headers["x-workflow-slug"] = identity.workflowSlug;
+
+  try {
+    const res = await fetch(
+      `${baseUrl.replace(/\/$/, "")}/features/${encodeURIComponent(featureSlug)}`,
+      { headers },
+    );
+    if (!res.ok) return null;
+
+    const data = await res.json() as { salesFunnels?: unknown };
+    if (!Array.isArray(data.salesFunnels)) return null;
+
+    const keys = new Set<SalesFunnelKey>();
+    for (const raw of data.salesFunnels) {
+      // Any spelling in, one canonical token out — the same tolerance every other funnel read
+      // here has. A key no catalogue names is skipped rather than worked.
+      const key = typeof raw === "string" ? toFunnelKey(raw) : null;
+      if (key) keys.add(key);
+    }
+    return keys;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/feature-workflow-client.ts
+++ b/src/lib/feature-workflow-client.ts
@@ -1,0 +1,67 @@
+import type { IdentityHeaders } from "@distribute/runs-client";
+
+/**
+ * A workflow that can actually RUN a given acquisition channel.
+ *
+ * Provisioning used to copy the seed campaign's workflow slug, which was right while every campaign
+ * of a brand ran the same feature. It stops being right the moment a brand works one funnel through
+ * TWO channels: a workflow belongs to a feature, so handing the feedback-request campaign the sales
+ * pitch's DAG would run the wrong offer — and handing it a slug of no feature at all is refused by
+ * workflow-service, which is a campaign that stays ongoing and produces nothing forever.
+ *
+ * So the workflow is asked for, per feature, and a channel workflow-service has no ACTIVE workflow
+ * for is NOT provisioned. That is fail-closed on purpose: a campaign with no DAG to run is not a
+ * campaign, and the next sweep provisions it the moment the dynasty ships. The slug chosen here is
+ * only the seed — the greedy rotation re-picks one every run from that feature's own evidence.
+ *
+ * Contract (workflow-service): GET /workflows?featureSlug=&status=active
+ *   -> { workflows: [{ workflowSlug, workflowDynastySlug, featureSlug, createdAt, ... }] }
+ *
+ * Returns null on missing config, network error, non-2xx, an unparseable payload, or a feature with
+ * no active workflow.
+ */
+export async function fetchActiveWorkflowSlugForFeature(
+  featureSlug: string,
+  identity: IdentityHeaders,
+): Promise<string | null> {
+  const baseUrl = process.env.WORKFLOW_SERVICE_URL;
+  const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
+  if (!baseUrl || !apiKey) return null;
+
+  const headers: Record<string, string> = {
+    "x-api-key": apiKey,
+    "x-org-id": identity.orgId,
+  };
+  if (identity.userId) headers["x-user-id"] = identity.userId;
+  if (identity.runId) headers["x-run-id"] = identity.runId;
+  if (identity.brandId) headers["x-brand-id"] = identity.brandId;
+
+  try {
+    const url = new URL(`${baseUrl.replace(/\/$/, "")}/workflows`);
+    url.searchParams.set("featureSlug", featureSlug);
+    url.searchParams.set("status", "active");
+
+    const res = await fetch(url, { headers });
+    if (!res.ok) return null;
+
+    const data = await res.json() as {
+      workflows?: Array<{ workflowSlug?: string; featureSlug?: string; createdAt?: string }>;
+    };
+    if (!Array.isArray(data.workflows)) return null;
+
+    // Filtered again on the feature: the seed must belong to the channel it is provisioned for,
+    // whatever the query returned.
+    const candidates = data.workflows.filter(
+      (w) => typeof w?.workflowSlug === "string" && w.workflowSlug.length > 0
+        && (w.featureSlug === undefined || w.featureSlug === featureSlug),
+    );
+    if (candidates.length === 0) return null;
+
+    // Newest first, so a brand-new campaign starts on the channel's current workflow rather than
+    // its oldest one. Ties (or an absent createdAt) fall back to the listed order, which is stable.
+    candidates.sort((a, b) => String(b.createdAt ?? "").localeCompare(String(a.createdAt ?? "")));
+    return candidates[0]!.workflowSlug!;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/features-workflow-projection-client.ts
+++ b/src/lib/features-workflow-projection-client.ts
@@ -397,11 +397,12 @@ export function serveableAudienceIdsInProjection(
  * Whether the greedy workflow rotation applies to a given feature. When false, the
  * trigger keeps the campaign's configured workflowSlug (no features-service call).
  *
- * Scoped to the sales-outreach feature family (sales-cold-email-outreach +
- * sales-crm-email-outreach) — those vary their workflow across runs. Every other feature
+ * Scoped to the sales-outreach feature family (every acquisition CHANNEL that sells a sales
+ * funnel) — those vary their workflow across runs. Every other feature
  * always runs its campaign's configured workflowSlug, run after run, with no
  * features-service call and no rotation. (Product decision 2026-07-07: rotation is a
- * sales-outreach lever; extended to sales-crm-email-outreach 2026-07-24 for full parity.)
+ * sales-outreach lever; extended to sales-crm-email-outreach 2026-07-24 and to every sales
+ * channel since — a second channel is a second feature, and it rotates like the first.)
  */
 export function isWorkflowRotationEnabled(featureSlug: string): boolean {
   return isSalesOutreachFeature(featureSlug);

--- a/src/lib/funnel-budget-client.ts
+++ b/src/lib/funnel-budget-client.ts
@@ -26,8 +26,42 @@ export interface FunnelBudget {
   dailyBudgetCents: number;
 }
 
+/**
+ * One (sales funnel, ACQUISITION-CHANNEL feature) ceiling — the finer grain billing serves
+ * ALONGSIDE the per-funnel figure above.
+ *
+ * A funnel can be worked through two offers at once (a straight sales pitch and a feedback-request
+ * pitch). Each is a campaign of its own, measured and funded on its own, so each must be paced on
+ * its own money: ranking both against the funnel TOTAL lets one consume what the other was funded
+ * for. `funnels` above is the per-funnel SUM of these, so nothing here is ever added up by a
+ * consumer.
+ *
+ * A CHANNEL IS A FEATURE SLUG. There is no channel table, enum or vocabulary in this service and
+ * none should be introduced — billing stores whatever feature slug the customer funds, and which
+ * feature may be sold through which funnel is features-service's statement, read per feature.
+ */
+export interface FunnelChannelBudget {
+  /** Canonical funnel key, same canonicalisation as `FunnelBudget.funnelKey`. */
+  funnelKey: SalesFunnelKey;
+  /** The acquisition channel this ceiling funds, as a features-service feature slug. */
+  featureSlug: string;
+  /** This PAIR's own daily ceiling, in CENTS. */
+  dailyBudgetCents: number;
+}
+
 export type FunnelBudgetsRead =
-  | { ok: true; brandDailyBudgetCents: number | null; funnels: FunnelBudget[] }
+  | {
+      ok: true;
+      brandDailyBudgetCents: number | null;
+      funnels: FunnelBudget[];
+      /**
+       * ADDITIVE grain. Empty for a brand that has never set per-funnel ceilings — and also for a
+       * billing deploy that predates the pair grain, which is why an ABSENT `channels` field is
+       * read as "no finer grain" rather than as "nothing is funded": every consumer then falls
+       * through to the funnel figure and behaves exactly as it did before.
+       */
+      channels: FunnelChannelBudget[];
+    }
   | { ok: false };
 
 /**
@@ -69,6 +103,7 @@ export async function fetchFunnelBudgets(
     const data = await res.json() as {
       dailyBudgetCents?: string | null;
       funnels?: Array<{ funnelKey?: string; dailyBudgetCents?: string }>;
+      channels?: Array<{ funnelKey?: string; featureSlug?: string; dailyBudgetCents?: string }>;
     };
 
     let brandDailyBudgetCents: number | null = null;
@@ -95,10 +130,60 @@ export async function fetchFunnelBudgets(
       funnels.push({ funnelKey, dailyBudgetCents: cents });
     }
 
-    return { ok: true, brandDailyBudgetCents, funnels };
+    // The pair grain is ADDITIVE and arrived after this consumer: an absent field is a billing
+    // deploy that does not serve it yet, which is "no finer grain", NOT "nothing is funded". A
+    // present-but-unparseable one is refused like the funnel figures — a ceiling we cannot read
+    // must never be read as no ceiling.
+    const channels: FunnelChannelBudget[] = [];
+    if (data.channels !== undefined) {
+      if (!Array.isArray(data.channels)) return { ok: false };
+      for (const raw of data.channels) {
+        if (!raw?.funnelKey || !raw?.featureSlug) return { ok: false };
+        const cents = parseFloat(raw.dailyBudgetCents ?? "");
+        if (!Number.isFinite(cents)) return { ok: false };
+        const funnelKey = toFunnelKey(raw.funnelKey);
+        if (!funnelKey) continue; // a funnel no catalogue names — same treatment as above
+        channels.push({ funnelKey, featureSlug: raw.featureSlug, dailyBudgetCents: cents });
+      }
+    }
+
+    return { ok: true, brandDailyBudgetCents, funnels, channels };
   } catch {
     return { ok: false };
   }
+}
+
+/**
+ * The ceiling that binds ONE (funnel, acquisition-channel feature) pair.
+ *
+ * Three answers, and the distinction between the last two is what keeps a single-channel brand
+ * behaving exactly as it did:
+ *
+ *   - `grain: "none"` — billing states no pair for this funnel at all (an older deploy, or a brand
+ *     that funds nothing per funnel). The caller falls through to the funnel figure, i.e. today's
+ *     behaviour, byte for byte.
+ *   - `cents` — this pair is funded at that amount.
+ *   - `cents: null` — the funnel IS split across channels and this campaign's channel is not one of
+ *     them, so it is unfunded. Never a fallback to the funnel total: that is precisely how one
+ *     offer would spend the money the other was funded for.
+ *
+ * A funnel funded through exactly ONE channel answers with that channel's ceiling WHATEVER feature
+ * the campaign states. That mirrors billing's own rule for a write that names no channel ("the
+ * funnel's single channel when it funds one"), and it is what guarantees that a brand funding one
+ * channel per funnel is unaffected — including the brands whose single ceiling billing's migration
+ * attributed to the default channel while their campaign runs another sales feature.
+ */
+export function channelCeilingCents(
+  read: Extract<FunnelBudgetsRead, { ok: true }>,
+  funnelKey: SalesFunnelKey,
+  featureSlug: string | null | undefined,
+): { grain: "none" } | { grain: "pair"; cents: number | null } {
+  // Same reading as on the wire: no pair stated is "no finer grain", never "nothing is funded".
+  const rows = (read.channels ?? []).filter((c) => c.funnelKey === funnelKey);
+  if (rows.length === 0) return { grain: "none" };
+  if (rows.length === 1) return { grain: "pair", cents: rows[0]!.dailyBudgetCents };
+  const match = featureSlug ? rows.find((c) => c.featureSlug === featureSlug) : undefined;
+  return { grain: "pair", cents: match ? match.dailyBudgetCents : null };
 }
 
 /**
@@ -108,4 +193,14 @@ export async function fetchFunnelBudgets(
  */
 export function fundedFunnels(read: Extract<FunnelBudgetsRead, { ok: true }>): FunnelBudget[] {
   return read.funnels.filter((f) => f.dailyBudgetCents > 0);
+}
+
+/**
+ * The (funnel, acquisition-channel feature) pairs this org actually FUNDS for the brand — the unit
+ * one campaign is provisioned per. A ceiling of zero is a deliberate "do not work this pair".
+ */
+export function fundedChannelPairs(
+  read: Extract<FunnelBudgetsRead, { ok: true }>,
+): FunnelChannelBudget[] {
+  return (read.channels ?? []).filter((c) => c.dailyBudgetCents > 0);
 }

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -2,7 +2,15 @@ import { and, arrayContains, desc, eq, inArray, isNull, sql } from "drizzle-orm"
 import { getStatsBudget, listRuns, type IdentityHeaders } from "@distribute/runs-client";
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
-import { fetchFunnelBudgets, fundedFunnels, type FunnelBudget } from "./funnel-budget-client.js";
+import {
+  fetchFunnelBudgets,
+  fundedChannelPairs,
+  fundedFunnels,
+  type FunnelBudgetsRead,
+} from "./funnel-budget-client.js";
+import { fetchFeatureSalesFunnels } from "./feature-sales-funnels-client.js";
+import { fetchActiveWorkflowSlugForFeature } from "./feature-workflow-client.js";
+import type { SalesFunnelKey } from "./sales-funnel-vocabulary.js";
 import { fetchDeclaredSalesFunnels, type DeclaredSalesFunnel } from "./brand-sales-funnels-client.js";
 import { isSalesOutreachFeature, SALES_OUTREACH_FEATURE_SLUGS } from "./sales-outreach-campaign.js";
 import { toFunnelKey } from "./sales-funnel-vocabulary.js";
@@ -176,10 +184,10 @@ async function planOneBrand(
     return;
   }
 
-  const funded = fundedFunnels(budgets);
+  const funded = fundedPairs(budgets, featureSlug);
   if (funded.length > 0) {
     const declared = await fetchDeclaredSalesFunnels(brandId, identity);
-    await ensureFundedFunnelCampaigns({ seed, brandId, featureSlug, funded, declared, now });
+    await ensureFundedFunnelCampaigns({ seed, brandId, funded, declared, identity, now });
   }
 
   // (0) The hold. A campaign the customer funds nothing for waits for money, not for a turn — so
@@ -230,7 +238,41 @@ async function planOneBrand(
 }
 
 /**
- * Make sure every funded funnel of the brand HAS a campaign.
+ * One funded (sales funnel, acquisition-channel feature) pair — the unit ONE campaign is
+ * provisioned per.
+ */
+interface FundedPair {
+  funnelKey: SalesFunnelKey;
+  /** The acquisition channel, as a features-service feature slug. A channel IS a feature slug. */
+  featureSlug: string;
+}
+
+/**
+ * What the customer funds, at the grain a campaign is provisioned per.
+ *
+ * billing states the pair grain ADDITIVELY, so both shapes are live at once and the fallback is
+ * what keeps every brand funding one channel per funnel untouched:
+ *
+ *   - pairs stated → one campaign per funded pair, each on its own channel.
+ *   - no pairs (an older billing deploy, or a brand that funds nothing per funnel) → one campaign
+ *     per funded FUNNEL on the seed's channel, i.e. exactly what this did before.
+ */
+function fundedPairs(
+  budgets: Extract<FunnelBudgetsRead, { ok: true }>,
+  seedFeatureSlug: string,
+): FundedPair[] {
+  const pairs = fundedChannelPairs(budgets);
+  if (pairs.length > 0) {
+    return pairs.map((p) => ({ funnelKey: p.funnelKey, featureSlug: p.featureSlug }));
+  }
+  return fundedFunnels(budgets).map((f) => ({
+    funnelKey: f.funnelKey,
+    featureSlug: seedFeatureSlug,
+  }));
+}
+
+/**
+ * Make sure every funded (funnel, channel) pair of the brand HAS a campaign.
  *
  * The campaign STATES its funnel, and that statement is the whole vocabulary for what it sells.
  * Nothing here reads a goal to work out which funnel an existing campaign is on: every campaign
@@ -240,7 +282,13 @@ async function planOneBrand(
  * back any more.
  *
  * A funnel billing funds but brand-service does not declare (or declares inactive) is skipped: a
- * switched-off funnel must never be worked, whatever ceiling billing still holds for it.
+ * switched-off funnel must never be worked, whatever ceiling billing still holds for it. A PAIR the
+ * channel may not sell through is skipped the same way, and for the same reason — the feedback
+ * request buys a conversation, so it cannot sell the three chains that start with a website click.
+ * That statement is features-service's and is asked per channel; no matrix is held here.
+ *
+ * A channel workflow-service has no ACTIVE workflow for is also skipped: a campaign with no DAG to
+ * run would stay ongoing and produce nothing.
  *
  * Funding brings back the campaign that was HELD, never the campaign that stopped for a reason of
  * its own. A row carrying `audience_exhausted`, `max_leads_reached`, `manual` or `org_teardown`
@@ -253,16 +301,16 @@ async function planOneBrand(
 async function ensureFundedFunnelCampaigns({
   seed,
   brandId,
-  featureSlug,
   funded,
   declared,
+  identity,
   now,
 }: {
   seed: ClaimedFunnelCampaign;
   brandId: string;
-  featureSlug: string;
-  funded: FunnelBudget[];
+  funded: FundedPair[];
   declared: DeclaredSalesFunnel[] | null;
+  identity: IdentityHeaders;
   now: Date;
 }): Promise<void> {
   // No readable funnel declaration → nothing says the brand still sells through these funnels.
@@ -271,9 +319,30 @@ async function ensureFundedFunnelCampaigns({
   if (!seed.createdByUserId) return; // no recipient/owner to attribute a new campaign to
 
   const declaredKeys = new Set(declared.map((f) => f.funnelKey));
+  // One read per CHANNEL, not per pair: a brand funding both of a channel's funnels asks once.
+  const sellableByFeature = new Map<string, Set<SalesFunnelKey> | null>();
+  const workflowByFeature = new Map<string, string | null>();
 
   for (const f of funded) {
     if (!declaredKeys.has(f.funnelKey)) continue;
+    const featureSlug = f.featureSlug;
+
+    if (!sellableByFeature.has(featureSlug)) {
+      sellableByFeature.set(featureSlug, await fetchFeatureSalesFunnels(featureSlug, identity));
+    }
+    const sellable = sellableByFeature.get(featureSlug)!;
+    // Unreadable → provision nothing for this channel, exactly as an unreadable brand declaration
+    // provisions nothing for the brand. A pair is not guessed at.
+    if (!sellable) continue;
+    if (!sellable.has(f.funnelKey)) {
+      // A pair nobody can run: the customer funds it, but this channel has no way to sell that
+      // chain. Logged once per sweep rather than silently dropped — the money is real and the
+      // customer is owed an answer about it eventually.
+      console.log(
+        `[campaign-service] Not provisioning ${featureSlug} for funnel ${f.funnelKey} (brand ${brandId}) — features-service does not state that pair`,
+      );
+      continue;
+    }
 
     const existing = await db.query.campaigns.findFirst({
       where: and(
@@ -308,9 +377,30 @@ async function ensureFundedFunnelCampaigns({
       continue;
     }
 
+    // A workflow belongs to a FEATURE, so the seed's slug is only right for the seed's own
+    // channel. Every other channel is asked for its own; a channel with no active workflow is not
+    // provisioned, because a campaign with no DAG to run would sit ongoing and produce nothing.
+    let workflowSlug: string | null = seed.workflowSlug;
+    if (featureSlug !== seed.featureSlug) {
+      if (!workflowByFeature.has(featureSlug)) {
+        workflowByFeature.set(
+          featureSlug,
+          await fetchActiveWorkflowSlugForFeature(featureSlug, identity),
+        );
+      }
+      workflowSlug = workflowByFeature.get(featureSlug)!;
+    }
+    if (!workflowSlug) {
+      console.log(
+        `[campaign-service] Not provisioning ${featureSlug} for funnel ${f.funnelKey} (brand ${brandId}) — workflow-service states no active workflow for that channel`,
+      );
+      continue;
+    }
+
     // Deterministic name: uniq_campaigns_org_name is the only uniqueness Postgres can enforce
     // here (brand_ids is a text[], so no unique index can span it), which makes a duplicate
-    // provision a constraint violation rather than a second campaign for the same funnel.
+    // provision a constraint violation rather than a second campaign for the same pair. The name
+    // already carries the channel, so two channels of one funnel never collide on it.
     const name = funnelCampaignName(featureSlug, brandId, f.funnelKey);
 
     try {
@@ -318,7 +408,7 @@ async function ensureFundedFunnelCampaigns({
         orgId: seed.orgId,
         createdByUserId: seed.createdByUserId,
         name,
-        workflowSlug: seed.workflowSlug,
+        workflowSlug,
         brandIds: [brandId],
         ...campaignIdentityColumns({ brandIds: [brandId], featureSlug }),
         featureSlug,
@@ -446,7 +536,7 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
 
       const budgets = await fetchFunnelBudgets(row.brand_id, identity);
       if (!budgets.ok) continue;
-      const funded = fundedFunnels(budgets);
+      const funded = fundedPairs(budgets, row.feature_slug);
       // The expected state for most brands on most sweeps: still funding nothing. Not logged — it
       // fires for every idle brand of every client on every sweep, and it is already observable in
       // the brand having no ongoing campaign.
@@ -466,9 +556,9 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
           dailyBudgetCents: null,
         },
         brandId: row.brand_id,
-        featureSlug: row.feature_slug,
         funded,
         declared,
+        identity,
         now,
       });
       const after = await countOngoingSalesCampaigns(row.org_id, row.brand_id);

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -3,7 +3,7 @@ import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
-import { fetchFunnelBudgets } from "./funnel-budget-client.js";
+import { channelCeilingCents, fetchFunnelBudgets } from "./funnel-budget-client.js";
 import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 import { STOP_REASONS } from "./stop-reason.js";
 
@@ -17,7 +17,7 @@ const STALE_THRESHOLD_MS = 3 * 60 * 60 * 1000; // 3 hours
 // cleaned on a later pass once the newer ones finish.
 const RUNNING_RUNS_LIMIT = 200;
 
-// The sales-outreach feature family (sales-cold-email-outreach + sales-crm-email-outreach) is
+// The sales-outreach feature family (every acquisition channel that sells a sales funnel) is
 // paced by the brand daily budget (billing-service brand_daily_budgets) and held on brand pause.
 // Every other feature is paced by the campaign's own budget windows and runs through a pause.
 // See isSalesOutreachFeature (sales-outreach-campaign.ts) for membership.
@@ -267,6 +267,29 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
         // a campaign row written before migration 0043 does too, so comparing raw tokens would
         // find no ceiling for a funnel that is fully funded and block it as unfunded.
         const funnelKey = toFunnelKey(campaign.funnelKey);
+
+        // (a2') A funnel can be worked through two ACQUISITION CHANNELS at once — the straight
+        // sales pitch and the feedback-request pitch — and each is funded separately. So the
+        // ceiling that binds this campaign is its own (funnel, channel) pair's whenever billing
+        // states one, never the funnel total: pacing both campaigns on the total is exactly how
+        // one offer spends the money the other was funded for. A funnel billing states no pair for
+        // falls through to the funnel figure below, which is every brand funding one channel per
+        // funnel — unchanged.
+        if (funnelKey) {
+          const pair = channelCeilingCents(budgets, funnelKey, campaign.featureSlug);
+          if (pair.grain === "pair") {
+            // Funded through OTHER channels but not this one, or funded at zero: a deliberate
+            // customer decision, so never a fallback to the funnel or brand total.
+            if (pair.cents === null || pair.cents <= 0) {
+              return { allowed: false, reason: "Funnel not funded for this channel" };
+            }
+            if (spentCents >= pair.cents) {
+              return { allowed: false, reason: "Funnel daily budget reached" };
+            }
+            continue;
+          }
+        }
+
         const ceilingCents = funnelKey
           ? budgets.funnels.find(f => f.funnelKey === funnelKey)?.dailyBudgetCents ?? null
           : null;

--- a/src/lib/sales-outreach-campaign.ts
+++ b/src/lib/sales-outreach-campaign.ts
@@ -1,14 +1,26 @@
 export const SALES_OUTREACH_FEATURE_SLUG = "sales-cold-email-outreach";
 export const SALES_CRM_FEATURE_SLUG = "sales-crm-email-outreach";
+/**
+ * The second cold-email ACQUISITION CHANNEL: the same medium and the same measurement as
+ * `sales-cold-email-outreach`, differing only in the OFFER — it asks a buyer for feedback on the
+ * problem we solve instead of pitching, and the conversation that opens becomes the meeting.
+ *
+ * A channel IS a feature slug in this fleet's vocabulary, so a second channel is a second feature
+ * and nothing else: no channel table, enum or vocabulary exists here or should be introduced.
+ * Which sales funnels this feature may be SOLD THROUGH is features-service's statement, read per
+ * feature — never a matrix held here.
+ */
+export const SALES_FEEDBACK_REQUEST_FEATURE_SLUG = "sales-feedback-request-cold-email-outreach";
 
-// The sales-outreach feature family. Both features share the SAME runtime behaviour in this
-// service — the funding hold, brand-daily-budget pacing, greedy workflow rotation + Thompson
-// audience selection, and the extend-audience lifecycle email. Any per-feature gate keyed on
-// "is this a sales-outreach campaign?" MUST test membership here, not a single slug, so the two
-// features stay byte-identical. (Adding a third sales feature = one line here.)
+// The sales-outreach feature family. Every feature here shares the SAME runtime behaviour in this
+// service — the funding hold, per-pair pacing, greedy workflow rotation + Thompson audience
+// selection, brand serialization, and the extend-audience lifecycle email. Any per-feature gate
+// keyed on "is this a sales-outreach campaign?" MUST test membership here, not a single slug, so
+// the features stay byte-identical. (Adding a further sales channel = one line here.)
 export const SALES_OUTREACH_FEATURE_SLUGS: ReadonlySet<string> = new Set([
   SALES_OUTREACH_FEATURE_SLUG,
   SALES_CRM_FEATURE_SLUG,
+  SALES_FEEDBACK_REQUEST_FEATURE_SLUG,
 ]);
 
 export function isSalesOutreachFeature(slug?: string | null): boolean {

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -12,7 +12,7 @@ import { SALES_OUTREACH_FEATURE_SLUGS } from "../lib/sales-outreach-campaign.js"
 
 // The daily budget is a sales-outreach pacing lever (the ONLY feature family the sales gate
 // enforces it for), so the brand-page propagation targets that family's campaigns
-// (sales-cold-email-outreach + sales-crm-email-outreach).
+// (every acquisition channel that sells a sales funnel).
 const SALES_FEATURE_SLUGS = [...SALES_OUTREACH_FEATURE_SLUGS];
 
 const router = Router();
@@ -68,7 +68,7 @@ router.get("/brands/:brandId/pause", requireApiKey, serviceAuth, async (req: Aut
  * pacing enforces it immediately. Org-scoped (only this org's campaigns for the brand are
  * touched). dailyBudgetCents:null clears each campaign's own budget → they fall back to the
  * brand daily budget again. Scoped to the sales-outreach feature family
- * (sales-cold-email-outreach + sales-crm-email-outreach) — the only features the daily budget paces.
+ * (every acquisition channel that sells a sales funnel) — the only features the daily budget paces.
  */
 router.patch("/brands/:brandId/daily-budget", requireApiKey, serviceAuth, validateBody(SetBrandCampaignsDailyBudgetBody), async (req: AuthenticatedRequest, res) => {
   try {

--- a/tests/integration/funding-drives-eligibility.test.ts
+++ b/tests/integration/funding-drives-eligibility.test.ts
@@ -56,6 +56,12 @@ vi.stubGlobal("fetch", mockFetch);
 function billingAnswers(
   funnels: Array<{ funnelKey: string; dailyBudgetCents: string }>,
   brandDailyBudgetCents: string | null,
+  // The ADDITIVE (funnel, acquisition-channel feature) grain. Omitted = a billing deploy that does
+  // not serve it, which is what every case that does not pass it relies on.
+  channels?: Array<{ funnelKey: string; featureSlug: string; dailyBudgetCents: string }>,
+  // Which sales funnels each channel may be SOLD THROUGH, as features-service states it. Default:
+  // every channel sells every chain.
+  sellableByFeature?: Record<string, string[]>,
 ) {
   mockFetch.mockImplementation(async (url: string) => {
     if (String(url).includes("/funnel-budgets")) {
@@ -65,6 +71,34 @@ function billingAnswers(
           brandId: "b",
           dailyBudgetCents: brandDailyBudgetCents,
           funnels: funnels.map((f) => ({ ...f, updatedAt: null })),
+          ...(channels ? { channels: channels.map((c) => ({ ...c, updatedAt: null })) } : {}),
+        }),
+      };
+    }
+    // workflow-service: which workflow can RUN a channel. A workflow belongs to a feature, so a
+    // second channel never inherits the first one's.
+    if (String(url).includes("/workflows")) {
+      const featureSlug = new URL(String(url)).searchParams.get("featureSlug");
+      return {
+        ok: true,
+        json: async () => ({
+          workflows: [{ workflowSlug: `${featureSlug}-seed`, featureSlug, createdAt: "2026-08-18T00:00:00.000Z" }],
+        }),
+      };
+    }
+    // features-service's per-channel statement: which sales funnels this acquisition channel may
+    // be SOLD THROUGH. The cold-email pitch sells every chain.
+    if (String(url).includes("/features/")) {
+      const slug = decodeURIComponent(String(url).split("/features/")[1]!);
+      return {
+        ok: true,
+        json: async () => ({
+          salesFunnels: sellableByFeature?.[slug] ?? [
+            "sales_meetings_from_conversation",
+            "sales_meetings_from_website",
+            "website_purchases",
+            "form_magnet",
+          ],
         }),
       };
     }
@@ -122,6 +156,8 @@ beforeEach(async () => {
   resetFundingSweepThrottle();
   process.env.BILLING_SERVICE_URL = "https://billing.test.local";
   process.env.BILLING_SERVICE_API_KEY = "test-billing-key";
+  process.env.FEATURES_SERVICE_URL = "https://features.test.local";
+  process.env.FEATURES_SERVICE_API_KEY = "test-features-key";
 });
 
 describe("the scheduler holds what the customer funds nothing for", () => {
@@ -235,6 +271,60 @@ describe("funding brings back a brand that has nothing running", () => {
     });
     expect(ongoing).toHaveLength(1);
     expect(ongoing[0].funnelKey).toBe("sales_meetings_from_conversation");
+  });
+
+  it("gives a funnel funded through TWO channels one campaign per channel", async () => {
+    billingAnswers(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }],
+      "5000",
+      [
+        { funnelKey: "reply_meeting", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "3000" },
+        { funnelKey: "reply_meeting", featureSlug: "sales-feedback-request-cold-email-outreach", dailyBudgetCents: "2000" },
+      ],
+    );
+    const brandId = crypto.randomUUID();
+    await insertSalesCampaign(brandId, { status: "stopped", nextRunAt: null, funnelKey: null });
+
+    const { provisionFundedFunnelsForIdleBrands } = await import("../../src/lib/funnel-campaigns.js");
+    expect(await provisionFundedFunnelsForIdleBrands()).toBe(2);
+
+    const ongoing = await db.query.campaigns.findMany({ where: eq(campaigns.status, "ongoing") });
+    expect(ongoing).toHaveLength(2);
+    // Same funnel, one campaign per acquisition channel — and each holds its own identity, which
+    // is what the partial unique index on (org, brand, funnel, channel) polices.
+    for (const c of ongoing) expect(c.funnelKey).toBe("sales_meetings_from_conversation");
+    expect(ongoing.map((c) => c.featureSlug).sort()).toEqual([
+      "sales-cold-email-outreach",
+      "sales-feedback-request-cold-email-outreach",
+    ]);
+    expect(ongoing.map((c) => c.acquisitionChannel).sort()).toEqual(["cold_email", "feedback_request_email"]);
+    // The second channel runs its OWN feature's workflow.
+    const feedback = ongoing.find((c) => c.featureSlug === "sales-feedback-request-cold-email-outreach")!;
+    expect(feedback.workflowSlug).toBe("sales-feedback-request-cold-email-outreach-seed");
+  });
+
+  it("never provisions a funded pair the channel may not be sold through", async () => {
+    billingAnswers(
+      [{ funnelKey: "visit_signup", dailyBudgetCents: "5000" }],
+      "5000",
+      [
+        { funnelKey: "visit_signup", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "3000" },
+        { funnelKey: "visit_signup", featureSlug: "sales-feedback-request-cold-email-outreach", dailyBudgetCents: "2000" },
+      ],
+      // The feedback request buys a CONVERSATION; the website-purchase chain starts with a click it
+      // has no way to sell.
+      { "sales-feedback-request-cold-email-outreach": ["sales_meetings_from_conversation"] },
+    );
+    const brandId = crypto.randomUUID();
+    await insertSalesCampaign(brandId, { status: "stopped", nextRunAt: null, funnelKey: null });
+
+    const { provisionFundedFunnelsForIdleBrands } = await import("../../src/lib/funnel-campaigns.js");
+    expect(await provisionFundedFunnelsForIdleBrands()).toBe(1);
+
+    const ongoing = await db.query.campaigns.findMany({ where: eq(campaigns.status, "ongoing") });
+    expect(ongoing).toHaveLength(1);
+    expect(ongoing[0].featureSlug).toBe("sales-cold-email-outreach");
+    expect(ongoing[0].funnelKey).toBe("website_purchases");
   });
 
   it("does NOT resume a campaign that stopped for a reason of its own — money answers none of them", async () => {

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -66,6 +66,7 @@ vi.mock("drizzle-orm", () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+import { SALES_FUNNEL_KEYS } from "../../src/lib/sales-funnel-vocabulary.js";
 import {
   planFunnelTurns,
   selectLowestFillRatio,
@@ -76,6 +77,7 @@ import {
 } from "../../src/lib/funnel-campaigns.js";
 
 const SALES = "sales-cold-email-outreach";
+const FEEDBACK = "sales-feedback-request-cold-email-outreach";
 
 // The brand's alive campaigns, as the sales-scoped liveness check reads them.
 let aliveBrandCampaigns: Array<{ id: string; featureSlug: string | null }> = [];
@@ -101,6 +103,10 @@ function mockFunnelBudgets(
   // What billing answers as the brand-level pot. Defaults to the sum, which is what it derives
   // when the brand funds per funnel; pass it explicitly for a brand with ONE pot (funnels: []).
   brandDailyBudgetCents?: string | null,
+  // The finer, ADDITIVE grain: one entry per (funnel, acquisition-channel feature). Omitted = a
+  // billing deploy that does not serve it, which every test below relies on to prove the
+  // per-funnel behaviour is untouched.
+  channels?: Array<{ funnelKey: string; featureSlug: string; dailyBudgetCents: string }>,
 ) {
   mockFetch.mockResolvedValueOnce({
     ok: true,
@@ -111,6 +117,7 @@ function mockFunnelBudgets(
           ? String(funnels.reduce((s, f) => s + Number(f.dailyBudgetCents), 0))
           : brandDailyBudgetCents,
       funnels: funnels.map(f => ({ ...f, updatedAt: null })),
+      ...(channels ? { channels: channels.map(c => ({ ...c, updatedAt: null })) } : {}),
     }),
   });
 }
@@ -203,6 +210,29 @@ describe("planFunnelTurns", () => {
     process.env.BILLING_SERVICE_API_KEY = "billing-key";
     process.env.BRAND_SERVICE_URL = "https://brand.test.local";
     process.env.BRAND_SERVICE_API_KEY = "brand-key";
+    process.env.FEATURES_SERVICE_URL = "https://features.test.local";
+    process.env.FEATURES_SERVICE_API_KEY = "features-key";
+    process.env.WORKFLOW_SERVICE_URL = "https://workflow.test.local";
+    process.env.WORKFLOW_SERVICE_API_KEY = "workflow-key";
+    // The reads that are ASKED PER CHANNEL rather than per brand: which funnels a channel may be
+    // sold through (features-service) and which workflow can run it (workflow-service). Answered by
+    // URL rather than by queue position, so every ordered `mockResolvedValueOnce` below — which
+    // takes precedence — keeps describing the billing/brand sequence it always did.
+    mockFetch.mockImplementation(async (input: URL | string) => {
+      const url = String(input);
+      if (url.includes("/features/")) {
+        return { ok: true, json: async () => ({ salesFunnels: [...SALES_FUNNEL_KEYS] }) };
+      }
+      if (url.includes("/workflows")) {
+        return {
+          ok: true,
+          json: async () => ({
+            workflows: [{ workflowSlug: `${new URL(url).searchParams.get("featureSlug")}-seed`, createdAt: "2026-08-18T00:00:00.000Z" }],
+          }),
+        };
+      }
+      throw new Error(`unexpected fetch in test: ${url}`);
+    });
     mockListRuns.mockResolvedValue({ runs: [] });
     mockFindFirst.mockResolvedValue({ id: "existing", name: "custom name", status: "ongoing" });
     // The only findMany left is the sales-scoped liveness check ({ id, featureSlug }). Default the
@@ -283,6 +313,187 @@ describe("planFunnelTurns", () => {
     // is not written any more, because it cannot tell the two meeting funnels apart.
     for (const values of inserted) expect(values.goal).toBeUndefined();
     expect(inserted[0].name).toBe(funnelCampaignName(SALES, "brand-1", inserted[0].funnelKey));
+  });
+
+  it("gives a funnel funded through TWO channels one campaign per channel", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+      "3000",
+      [
+        { funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "2000" },
+        { funnelKey: "reply_meeting", featureSlug: FEEDBACK, dailyBudgetCents: "1000" },
+      ],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    const inserted = mockInsertValues.mock.calls.map(c => c[0]);
+    expect(inserted).toHaveLength(2);
+    // One campaign per PAIR: each states the same funnel and its OWN channel, so neither can be
+    // mistaken for the other and each is paced on the ceiling that binds it.
+    expect(inserted.map(v => v.featureSlug).sort()).toEqual([SALES, FEEDBACK].sort());
+    for (const values of inserted) {
+      expect(values.funnelKey).toBe("sales_meetings_from_conversation");
+      expect(values.name).toBe(funnelCampaignName(values.featureSlug, "brand-1", values.funnelKey));
+    }
+    // The second channel runs its OWN feature's workflow — never the seed campaign's, which
+    // belongs to another offer and which workflow-service would refuse for this feature.
+    const feedback = inserted.find(v => v.featureSlug === FEEDBACK)!;
+    expect(feedback.workflowSlug).toBe(`${FEEDBACK}-seed`);
+  });
+
+  it("never provisions a pair the channel may not be sold through", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "visit_signup", featureSlug: FEEDBACK, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+    // features-service states the feedback request sells the CONVERSATION chain alone: it buys a
+    // conversation and has no website step to sell.
+    mockFetch.mockImplementationOnce(async () => ({
+      ok: true,
+      json: async () => ({ salesFunnels: ["sales_meetings_from_conversation"] }),
+    }));
+
+    await planFunnelTurns([claimed({ funnelKey: "website_purchases" })]);
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("provisions nothing for a channel whose funnel statement cannot be read", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "2000" }],
+      "2000",
+      [{ funnelKey: "reply_meeting", featureSlug: FEEDBACK, dailyBudgetCents: "2000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+    mockFetch.mockImplementationOnce(async () => ({ ok: false, status: 500, json: async () => ({}) }));
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    // A pair is never guessed at — the same stance an unreadable brand declaration takes.
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("provisions nothing for a channel with no active workflow to run it", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "2000" }],
+      "2000",
+      [{ funnelKey: "reply_meeting", featureSlug: FEEDBACK, dailyBudgetCents: "2000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+    mockFetch.mockImplementation(async (input: URL | string) => {
+      const url = String(input);
+      if (url.includes("/features/")) {
+        return { ok: true, json: async () => ({ salesFunnels: [...SALES_FUNNEL_KEYS] }) };
+      }
+      return { ok: true, json: async () => ({ workflows: [] }) };
+    });
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    // A campaign with no DAG to run would sit ongoing and produce nothing forever.
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("paces each channel on its OWN ceiling, so one cannot consume the other's money", async () => {
+    // Both campaigns work the same funnel; the sales pitch has already spent its whole $20 while
+    // the feedback request has spent nothing of its $10. Ranked on the FUNNEL total ($30) the
+    // spent-out one would still look 66% empty and keep taking turns.
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+      "3000",
+      [
+        { funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "2000" },
+        { funnelKey: "reply_meeting", featureSlug: FEEDBACK, dailyBudgetCents: "1000" },
+      ],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "x", status: "ongoing", stopReason: null });
+    mockSpend("2000"); // the sales pitch, at its own ceiling
+    mockSpend("0");    // the feedback request, untouched
+
+    aliveBrandCampaigns = [
+      { id: "c-sales", featureSlug: SALES },
+      { id: "c-feedback", featureSlug: FEEDBACK },
+    ];
+    const now = new Date("2026-08-18T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-sales", funnelKey: "sales_meetings_from_conversation", featureSlug: SALES }),
+        claimed({ id: "c-feedback", funnelKey: "sales_meetings_from_conversation", featureSlug: FEEDBACK }),
+      ],
+      now,
+    );
+
+    // The full channel yields; the empty one takes the turn.
+    expect(deferred.has("c-feedback")).toBe(false);
+    expect(deferred.get("c-sales")).toBeDefined();
+  });
+
+  it("HOLDS a campaign whose funnel is funded through OTHER channels only", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+      "3000",
+      [
+        { funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "2000" },
+        { funnelKey: "reply_meeting", featureSlug: "sales-crm-email-outreach", dailyBudgetCents: "1000" },
+      ],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "x", status: "ongoing", stopReason: null });
+    mockSpend("0");
+    mockSpend("0");
+
+    aliveBrandCampaigns = [{ id: "c-sales", featureSlug: SALES }];
+    const now = new Date("2026-08-18T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-sales", funnelKey: "sales_meetings_from_conversation", featureSlug: SALES }),
+        claimed({ id: "c-crm", funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-crm-email-outreach" }),
+        claimed({ id: "c-feedback", funnelKey: "sales_meetings_from_conversation", featureSlug: FEEDBACK }),
+      ],
+      now,
+    );
+
+    // The funnel is SPLIT across two channels and neither is the feedback request's: falling back
+    // to the funnel total would be spending the other two offers' money. It waits for money, not
+    // for a turn, so it is re-checked on the funding cadence.
+    expect(deferred.get("c-feedback")?.getTime()).toBe(now.getTime() + FUNDING_RECHECK_MS);
+    // The two funded channels are in the running as usual — one takes the turn, the other waits it.
+    expect(deferred.get("c-sales")?.getTime() ?? now.getTime() + FUNNEL_TURN_DEFER_MS)
+      .toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
+  });
+
+  it("a funnel funded through exactly ONE channel binds whatever feature the campaign states", async () => {
+    // billing's migration attributed some brands' single ceiling to the DEFAULT channel while their
+    // campaign runs another sales feature. Holding those would be a regression on a brand that has
+    // funded one channel per funnel all along, which is every brand today.
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "2000" }],
+      "2000",
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "2000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "x", status: "ongoing", stopReason: null });
+    mockSpend("0");
+
+    aliveBrandCampaigns = [{ id: "c-crm", featureSlug: "sales-crm-email-outreach" }];
+    const deferred = await planFunnelTurns([
+      claimed({
+        id: "c-crm",
+        funnelKey: "sales_meetings_from_conversation",
+        featureSlug: "sales-crm-email-outreach",
+      }),
+    ]);
+
+    expect(deferred.size).toBe(0);
   });
 
   it("never provisions a funnel billing funds but brand-service does not declare active", async () => {

--- a/tests/unit/funnel-channel-ceiling.test.ts
+++ b/tests/unit/funnel-channel-ceiling.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  channelCeilingCents,
+  fetchFunnelBudgets,
+  fundedChannelPairs,
+  type FunnelBudgetsRead,
+} from "../../src/lib/funnel-budget-client.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const IDENTITY = { orgId: "org-1", userId: "user-1" };
+
+function read(
+  channels: Array<{ funnelKey: string; featureSlug: string; dailyBudgetCents: number }>,
+): Extract<FunnelBudgetsRead, { ok: true }> {
+  return {
+    ok: true,
+    brandDailyBudgetCents: 3000,
+    funnels: [{ funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 3000 }],
+    channels: channels as never,
+  };
+}
+
+const SALES = "sales-cold-email-outreach";
+const FEEDBACK = "sales-feedback-request-cold-email-outreach";
+
+describe("the ceiling that binds one (funnel, acquisition channel) pair", () => {
+  it("answers 'no finer grain' when billing states no pair for the funnel", () => {
+    // An older billing deploy, or a brand that funds nothing per funnel. The caller falls through
+    // to the funnel figure, i.e. today's behaviour — never to 'unfunded'.
+    expect(channelCeilingCents(read([]), "sales_meetings_from_conversation", SALES)).toEqual({
+      grain: "none",
+    });
+  });
+
+  it("gives each channel of a split funnel its OWN ceiling", () => {
+    const budgets = read([
+      { funnelKey: "sales_meetings_from_conversation", featureSlug: SALES, dailyBudgetCents: 2000 },
+      { funnelKey: "sales_meetings_from_conversation", featureSlug: FEEDBACK, dailyBudgetCents: 1000 },
+    ]);
+    expect(channelCeilingCents(budgets, "sales_meetings_from_conversation", SALES)).toEqual({
+      grain: "pair",
+      cents: 2000,
+    });
+    expect(channelCeilingCents(budgets, "sales_meetings_from_conversation", FEEDBACK)).toEqual({
+      grain: "pair",
+      cents: 1000,
+    });
+  });
+
+  it("is UNFUNDED — never the funnel total — for a channel a split funnel does not fund", () => {
+    const budgets = read([
+      { funnelKey: "sales_meetings_from_conversation", featureSlug: SALES, dailyBudgetCents: 2000 },
+      { funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-crm-email-outreach", dailyBudgetCents: 1000 },
+    ]);
+    // Falling back would be one offer spending the money the other was funded for.
+    expect(channelCeilingCents(budgets, "sales_meetings_from_conversation", FEEDBACK)).toEqual({
+      grain: "pair",
+      cents: null,
+    });
+  });
+
+  it("binds whatever feature the campaign states when the funnel funds exactly ONE channel", () => {
+    // billing's own rule for a write naming no channel, and what keeps every brand funding one
+    // channel per funnel — including those whose single ceiling was attributed to the default
+    // channel while their campaign runs another sales feature — behaving exactly as before.
+    const budgets = read([
+      { funnelKey: "sales_meetings_from_conversation", featureSlug: SALES, dailyBudgetCents: 2000 },
+    ]);
+    expect(channelCeilingCents(budgets, "sales_meetings_from_conversation", "sales-crm-email-outreach")).toEqual({
+      grain: "pair",
+      cents: 2000,
+    });
+  });
+
+  it("counts a pair funded at zero as funded-at-zero, not as absent", () => {
+    const budgets = read([
+      { funnelKey: "sales_meetings_from_conversation", featureSlug: SALES, dailyBudgetCents: 0 },
+      { funnelKey: "sales_meetings_from_conversation", featureSlug: FEEDBACK, dailyBudgetCents: 1000 },
+    ]);
+    expect(channelCeilingCents(budgets, "sales_meetings_from_conversation", SALES)).toEqual({
+      grain: "pair",
+      cents: 0,
+    });
+    expect(fundedChannelPairs(budgets).map((p) => p.featureSlug)).toEqual([FEEDBACK]);
+  });
+});
+
+describe("reading the pair grain off billing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+    process.env.BILLING_SERVICE_API_KEY = "billing-key";
+  });
+
+  function billingSays(body: unknown) {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => body });
+  }
+
+  it("reads an ABSENT channels field as no finer grain, not as nothing funded", async () => {
+    billingSays({
+      brandId: "brand-1",
+      dailyBudgetCents: "3000",
+      funnels: [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000", updatedAt: null }],
+    });
+    const result = await fetchFunnelBudgets("brand-1", IDENTITY);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.channels).toEqual([]);
+    expect(result.funnels).toHaveLength(1);
+  });
+
+  it("canonicalises the funnel of a pair, because billing still emits the pre-rename spelling", async () => {
+    billingSays({
+      brandId: "brand-1",
+      dailyBudgetCents: "3000",
+      funnels: [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000", updatedAt: null }],
+      channels: [
+        { funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "2000", updatedAt: null },
+        { funnelKey: "reply_meeting", featureSlug: FEEDBACK, dailyBudgetCents: "1000", updatedAt: null },
+      ],
+    });
+    const result = await fetchFunnelBudgets("brand-1", IDENTITY);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.channels.map((c) => c.funnelKey)).toEqual([
+      "sales_meetings_from_conversation",
+      "sales_meetings_from_conversation",
+    ]);
+  });
+
+  it("refuses the whole read on an unparseable pair ceiling", async () => {
+    // A ceiling we cannot read must never be read as no ceiling — the same stance the per-funnel
+    // figures take.
+    billingSays({
+      brandId: "brand-1",
+      dailyBudgetCents: "3000",
+      funnels: [],
+      channels: [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "not-a-number" }],
+    });
+    expect(await fetchFunnelBudgets("brand-1", IDENTITY)).toEqual({ ok: false });
+  });
+});

--- a/tests/unit/funnel-owner-decision.test.ts
+++ b/tests/unit/funnel-owner-decision.test.ts
@@ -28,10 +28,11 @@ describe("the funnel of a brand that sells through several is UNKNOWN until its 
   });
 
   it("scopes to the sales-outreach feature family — a brand's PR / AI-visibility / VC campaigns run no sales funnel", () => {
-    for (const slug of SALES_OUTREACH_FEATURE_SLUGS) {
-      expect(STATEMENTS).toContain(`'${slug}'`);
-    }
+    // Every feature slug the migration names is a sales-outreach one. The converse is NOT asserted:
+    // this file is frozen history, so a sales channel shipped after it (the feedback request) can
+    // never appear in it, and demanding that it does would fail the day the family grows.
     const quotedFeatureSlugs = STATEMENTS.match(/'[a-z]+(?:-[a-z]+)+'/g) ?? [];
+    expect(quotedFeatureSlugs.length).toBeGreaterThan(0);
     for (const quoted of quotedFeatureSlugs) {
       expect(SALES_OUTREACH_FEATURE_SLUGS.has(quoted.slice(1, -1))).toBe(true);
     }

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -627,6 +627,9 @@ describe("Gate Check", () => {
     function mockFunnelBudgets(
       funnels: Array<{ funnelKey: string; dailyBudgetCents: string }>,
       dailyBudgetCents: string | null = "3000",
+      // The ADDITIVE (funnel, acquisition-channel feature) grain. Omitted = a billing deploy that
+      // does not serve it, which is what every case above relies on to pace on the funnel figure.
+      channels?: Array<{ funnelKey: string; featureSlug: string; dailyBudgetCents: string }>,
     ) {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -634,6 +637,7 @@ describe("Gate Check", () => {
           brandId: "brand-1",
           dailyBudgetCents,
           funnels: funnels.map(f => ({ ...f, updatedAt: null })),
+          ...(channels ? { channels: channels.map(c => ({ ...c, updatedAt: null })) } : {}),
         }),
       });
     }
@@ -707,6 +711,98 @@ describe("Gate Check", () => {
       const result = await runGateChecks(funnelCampaign());
       expect(result.allowed).toBe(false);
       expect(result.reason).toBe("Funnel not funded");
+    });
+
+    it("paces on THIS (funnel, channel) pair's own ceiling, not the funnel total", async () => {
+      // One funnel worked through two offers. The sales pitch has spent its whole $20; under the
+      // funnel total ($30) it would still read as having room and keep spending the feedback
+      // request's money.
+      mockFunnelBudgets(
+        [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+        "3000",
+        [
+          { funnelKey: "reply_meeting", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "2000" },
+          { funnelKey: "reply_meeting", featureSlug: "sales-feedback-request-cold-email-outreach", dailyBudgetCents: "1000" },
+        ],
+      );
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "2000" }]),
+      );
+
+      const result = await runGateChecks(
+        makeCampaign({ brandIds: ["brand-1"], funnelKey: "sales_meetings_from_conversation" }),
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Funnel daily budget reached");
+    });
+
+    it("allows the other channel of the same funnel while it is under ITS ceiling", async () => {
+      mockFunnelBudgets(
+        [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+        "3000",
+        [
+          { funnelKey: "reply_meeting", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "2000" },
+          { funnelKey: "reply_meeting", featureSlug: "sales-feedback-request-cold-email-outreach", dailyBudgetCents: "1000" },
+        ],
+      );
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "500" }]),
+      );
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ affordable: true }) });
+
+      const result = await runGateChecks(
+        makeCampaign({
+          brandIds: ["brand-1"],
+          funnelKey: "sales_meetings_from_conversation",
+          featureSlug: "sales-feedback-request-cold-email-outreach",
+        }),
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("never falls back to the funnel total for a channel the funnel does not fund", async () => {
+      mockFunnelBudgets(
+        [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+        "3000",
+        [
+          { funnelKey: "reply_meeting", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "2000" },
+          { funnelKey: "reply_meeting", featureSlug: "sales-crm-email-outreach", dailyBudgetCents: "1000" },
+        ],
+      );
+
+      const result = await runGateChecks(
+        makeCampaign({
+          brandIds: ["brand-1"],
+          funnelKey: "sales_meetings_from_conversation",
+          featureSlug: "sales-feedback-request-cold-email-outreach",
+        }),
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Funnel not funded for this channel");
+    });
+
+    it("a funnel funded through exactly ONE channel binds whatever feature the campaign states", async () => {
+      // billing attributed some brands' single ceiling to the default channel while their campaign
+      // runs another sales feature. Blocking those would break a brand that has funded one channel
+      // per funnel all along — which is every brand today.
+      mockFunnelBudgets(
+        [{ funnelKey: "reply_meeting", dailyBudgetCents: "2000" }],
+        "2000",
+        [{ funnelKey: "reply_meeting", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "2000" }],
+      );
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "10" }]),
+      );
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ affordable: true }) });
+
+      const result = await runGateChecks(
+        makeCampaign({
+          brandIds: ["brand-1"],
+          funnelKey: "sales_meetings_from_conversation",
+          featureSlug: "sales-crm-email-outreach",
+        }),
+      );
+      expect(result.allowed).toBe(true);
     });
 
     it("a brand that funds no funnel separately paces on its brand budget, funnel or not", async () => {

--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -347,4 +347,32 @@ describe('No Legacy Patterns - CRITICAL', () => {
     }
     expect(violations, `No route may write a brand pause state:\n${violations.join('\n')}`).toHaveLength(0);
   });
+
+  it('should NOT hold which acquisition channel sells which sales funnel', () => {
+    // A channel IS a feature slug, and which funnels a feature may be SOLD THROUGH is
+    // features-service's product statement — asked per feature, never copied here. A second copy
+    // drifts the day a channel gains or loses a chain, and the customer's money is on the outcome.
+    // The one file allowed to name a funnel beside a feature slug is the one that ASKS.
+    const files = getAllTsFiles(srcDir);
+    const violations: { file: string; line: number; code: string }[] = [];
+
+    for (const file of files) {
+      const relative = path.relative(srcDir, file);
+      if (relative === 'lib/feature-sales-funnels-client.ts') continue;
+      const content = fs.readFileSync(file, 'utf-8');
+      content.split('\n').forEach((line, index) => {
+        const code = line.replace(/\/\/.*$/, '').replace(/^\s*\*.*$/, '');
+        // A feature slug and a funnel key on the same line of CODE is a matrix being written down.
+        if (/["'][a-z-]*sales-[a-z-]+["']/.test(code)
+          && /["'](sales_meetings_from_\w+|website_purchases|form_magnet|reply_meeting|visit_\w+)["']/.test(code)) {
+          violations.push({ file: relative, line: index + 1, code: line.trim().substring(0, 100) });
+        }
+      });
+    }
+
+    expect(
+      violations,
+      `Which feature sells through which funnel is features-service's statement — ask it:\n${violations.map(v => `  ${v.file}:${v.line}\n    ${v.code}`).join('\n')}`,
+    ).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Retro from #357: the owner-decision migration test required every current sales-outreach slug to appear in a shipped SQL file. That direction only holds until the family grows, and it broke on the second acquisition channel — on a migration that is correct and could never name a feature that did not exist when it ran. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)