### PR TITLE
fix(channels): the feedback-request channel is named feedback-request-cold-email-outreach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ in-scope — never that a live set is fully covered by it. (Set 2026-08-18.)
 
 A sales funnel can be worked through more than one OFFER at once: the straight sales pitch
 (`sales-cold-email-outreach`) and the feedback request
-(`sales-feedback-request-cold-email-outreach`), which asks a buyer about the problem we solve
+(`feedback-request-cold-email-outreach`), which asks a buyer about the problem we solve
 instead of pitching. Same infrastructure, same measurement — only the offer differs, so a brand can
 work ONE funnel through BOTH, and each is a campaign of its own.
 

--- a/src/lib/campaign-identity.ts
+++ b/src/lib/campaign-identity.ts
@@ -38,7 +38,7 @@ const CHANNEL_BY_FEATURE: Readonly<Record<string, string>> = Object.freeze({
   // The feedback-request offer. Same medium as `cold_email` and deliberately NOT the same channel
   // token: a brand may work one funnel through both offers at once, and those are two campaigns,
   // so they must hold two identities or the unique index would let only one of them exist.
-  "sales-feedback-request-cold-email-outreach": "feedback_request_email",
+  "feedback-request-cold-email-outreach": "feedback_request_email",
 
   // Everything else. A sales funnel is not something these run — their funnel stays NULL — but
   // they still carry a channel so the identity key is enforceable for them too.

--- a/src/lib/sales-outreach-campaign.ts
+++ b/src/lib/sales-outreach-campaign.ts
@@ -10,7 +10,7 @@ export const SALES_CRM_FEATURE_SLUG = "sales-crm-email-outreach";
  * Which sales funnels this feature may be SOLD THROUGH is features-service's statement, read per
  * feature — never a matrix held here.
  */
-export const SALES_FEEDBACK_REQUEST_FEATURE_SLUG = "sales-feedback-request-cold-email-outreach";
+export const SALES_FEEDBACK_REQUEST_FEATURE_SLUG = "feedback-request-cold-email-outreach";
 
 // The sales-outreach feature family. Every feature here shares the SAME runtime behaviour in this
 // service — the funding hold, per-pair pacing, greedy workflow rotation + Thompson audience

--- a/tests/integration/funding-drives-eligibility.test.ts
+++ b/tests/integration/funding-drives-eligibility.test.ts
@@ -279,7 +279,7 @@ describe("funding brings back a brand that has nothing running", () => {
       "5000",
       [
         { funnelKey: "reply_meeting", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "3000" },
-        { funnelKey: "reply_meeting", featureSlug: "sales-feedback-request-cold-email-outreach", dailyBudgetCents: "2000" },
+        { funnelKey: "reply_meeting", featureSlug: "feedback-request-cold-email-outreach", dailyBudgetCents: "2000" },
       ],
     );
     const brandId = crypto.randomUUID();
@@ -294,13 +294,13 @@ describe("funding brings back a brand that has nothing running", () => {
     // is what the partial unique index on (org, brand, funnel, channel) polices.
     for (const c of ongoing) expect(c.funnelKey).toBe("sales_meetings_from_conversation");
     expect(ongoing.map((c) => c.featureSlug).sort()).toEqual([
+      "feedback-request-cold-email-outreach",
       "sales-cold-email-outreach",
-      "sales-feedback-request-cold-email-outreach",
     ]);
     expect(ongoing.map((c) => c.acquisitionChannel).sort()).toEqual(["cold_email", "feedback_request_email"]);
     // The second channel runs its OWN feature's workflow.
-    const feedback = ongoing.find((c) => c.featureSlug === "sales-feedback-request-cold-email-outreach")!;
-    expect(feedback.workflowSlug).toBe("sales-feedback-request-cold-email-outreach-seed");
+    const feedback = ongoing.find((c) => c.featureSlug === "feedback-request-cold-email-outreach")!;
+    expect(feedback.workflowSlug).toBe("feedback-request-cold-email-outreach-seed");
   });
 
   it("never provisions a funded pair the channel may not be sold through", async () => {
@@ -309,11 +309,11 @@ describe("funding brings back a brand that has nothing running", () => {
       "5000",
       [
         { funnelKey: "visit_signup", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "3000" },
-        { funnelKey: "visit_signup", featureSlug: "sales-feedback-request-cold-email-outreach", dailyBudgetCents: "2000" },
+        { funnelKey: "visit_signup", featureSlug: "feedback-request-cold-email-outreach", dailyBudgetCents: "2000" },
       ],
       // The feedback request buys a CONVERSATION; the website-purchase chain starts with a click it
       // has no way to sell.
-      { "sales-feedback-request-cold-email-outreach": ["sales_meetings_from_conversation"] },
+      { "feedback-request-cold-email-outreach": ["sales_meetings_from_conversation"] },
     );
     const brandId = crypto.randomUUID();
     await insertSalesCampaign(brandId, { status: "stopped", nextRunAt: null, funnelKey: null });

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -77,7 +77,7 @@ import {
 } from "../../src/lib/funnel-campaigns.js";
 
 const SALES = "sales-cold-email-outreach";
-const FEEDBACK = "sales-feedback-request-cold-email-outreach";
+const FEEDBACK = "feedback-request-cold-email-outreach";
 
 // The brand's alive campaigns, as the sales-scoped liveness check reads them.
 let aliveBrandCampaigns: Array<{ id: string; featureSlug: string | null }> = [];

--- a/tests/unit/funnel-channel-ceiling.test.ts
+++ b/tests/unit/funnel-channel-ceiling.test.ts
@@ -23,7 +23,7 @@ function read(
 }
 
 const SALES = "sales-cold-email-outreach";
-const FEEDBACK = "sales-feedback-request-cold-email-outreach";
+const FEEDBACK = "feedback-request-cold-email-outreach";
 
 describe("the ceiling that binds one (funnel, acquisition channel) pair", () => {
   it("answers 'no finer grain' when billing states no pair for the funnel", () => {

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -722,7 +722,7 @@ describe("Gate Check", () => {
         "3000",
         [
           { funnelKey: "reply_meeting", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "2000" },
-          { funnelKey: "reply_meeting", featureSlug: "sales-feedback-request-cold-email-outreach", dailyBudgetCents: "1000" },
+          { funnelKey: "reply_meeting", featureSlug: "feedback-request-cold-email-outreach", dailyBudgetCents: "1000" },
         ],
       );
       mockGetStatsBudget.mockResolvedValue(
@@ -742,7 +742,7 @@ describe("Gate Check", () => {
         "3000",
         [
           { funnelKey: "reply_meeting", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "2000" },
-          { funnelKey: "reply_meeting", featureSlug: "sales-feedback-request-cold-email-outreach", dailyBudgetCents: "1000" },
+          { funnelKey: "reply_meeting", featureSlug: "feedback-request-cold-email-outreach", dailyBudgetCents: "1000" },
         ],
       );
       mockGetStatsBudget.mockResolvedValue(
@@ -754,7 +754,7 @@ describe("Gate Check", () => {
         makeCampaign({
           brandIds: ["brand-1"],
           funnelKey: "sales_meetings_from_conversation",
-          featureSlug: "sales-feedback-request-cold-email-outreach",
+          featureSlug: "feedback-request-cold-email-outreach",
         }),
       );
       expect(result.allowed).toBe(true);
@@ -774,7 +774,7 @@ describe("Gate Check", () => {
         makeCampaign({
           brandIds: ["brand-1"],
           funnelKey: "sales_meetings_from_conversation",
-          featureSlug: "sales-feedback-request-cold-email-outreach",
+          featureSlug: "feedback-request-cold-email-outreach",
         }),
       );
       expect(result.allowed).toBe(false);


### PR DESCRIPTION
features-service renamed the feedback-request acquisition channel:

    sales-feedback-request-cold-email-outreach  ->  feedback-request-cold-email-outreach

This service keys the acquisition-channel token on the feature slug (`CHANNEL_BY_FEATURE` in `src/lib/campaign-identity.ts`). That map is total by construction: a slug it does not recognise falls through to `featureSlug.replace(/-/g, "_")`. Under the new name the campaign would have been stamped `feedback_request_cold_email_outreach` instead of `feedback_request_email` — silently, with no error, and the campaign filed under an identity nothing else uses.

One name, everywhere: the map key, `SALES_FEEDBACK_REQUEST_FEATURE_SLUG`, `CLAUDE.md`, and every fixture. No alias, no normalisation, no backward-compatible second spelling.

Nothing about the per-(funnel, channel) behaviour changes: one campaign per funded pair, each paced on its own pair's ceiling, a pair the feature may not sell still skipped, and a brand funding one channel per funnel behaving exactly as before.

One fixture assertion re-ordered — `.sort()` is alphabetical and `feedback-…` now sorts ahead of `sales-…`.

Suite: 554 passed (40 files). Build + OpenAPI regen clean (no spec drift).