### PR TITLE
feat(campaigns): a campaign sells one offer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,6 +354,41 @@ read as one campaign.
   — their history lives in runs-service, keyed on `campaign_id`, and repointing it is runs-service's
   own ledger to move. Deleting them would orphan the history, which is the one thing never allowed.
 
+## The OFFER a campaign sells is brand-service's UUID, carried and never derived
+
+A new level sits between the brand and the campaign: **Org > Brand > Offer > Campaign**. An offer is
+one distinct thing a brand sells — its value proposition plus the sales funnels it sells through —
+so a brand selling a $200 self-serve plan and a $20k enterprise contract has two. A campaign sells
+exactly ONE, which makes a campaign **(offer × sales funnel × acquisition channel)**: it already
+stated the funnel (0041) and the channel (0044), and `campaigns.offer_id` (migration **0050**) is the
+missing third word. Without it, two campaigns of one brand on the same funnel through the same
+channel for two different offers are the same row to every reader — in the data, in the money
+attribution and on the customer's screen.
+
+- **brand-service OWNS the entity; this column carries its id.** No offer table, enum or vocabulary
+  exists here and none is to be introduced — the same posture this service holds for the goal and
+  the channel. It is not validated against brand-service on write, exactly as `funnelKey` and
+  `audienceIds` are not.
+- **NEVER derived.** Not from the funnel (several offers legitimately sell through one funnel, which
+  is the entire reason the dimension exists), not from the goal, not from the workflow. It is stated
+  by the creator or it is NULL.
+- **OPTIONAL on create, deliberately and temporarily.** Requiring it is a breaking request-contract
+  change, so a create that states no offer behaves EXACTLY as it did before the column existed and
+  callers state it as they migrate. It becomes required in a later wave, and only then. `PATCH` sets
+  or clears it, which is how a campaign created before it could state one says which offer it runs.
+- **It is NOT part of the identity key.** `uniq_campaigns_org_brand_funnel_channel` is untouched:
+  widening it while the field is optional would let one brand grow unlimited offer-less campaigns on
+  one (funnel, channel). Widening it is the same later wave that makes the field required.
+- **Nothing reads it** — no pacing, funding, selection, gate or provisioning decision. It is stored
+  and served, and `idx_campaigns_org_offer` serves the per-offer attribution read it exists for.
+- **The backfill is a SCRIPT, not the migration** (`scripts/backfill-campaign-offer.ts`): resolving a
+  campaign's brand to its offer is a brand-service READ and SQL cannot make one, so migration 0050
+  adds the column and backfills nothing. The script resolves once per (org, brand) pair, writes only
+  rows still NULL (so a re-run is a no-op and it can never overwrite an offer a live create just
+  stated), **dry-runs by default** (`--apply` writes), and LEAVES ALONE + reports any brand that does
+  not resolve to exactly one offer. Nothing is guessed for those. The previous value is NULL by
+  construction, so the undo is exactly the ids the run prints, which it emits as a statement.
+
 ## Nothing can be unattributable — so nothing holds a brand's provisioning back
 
 The rule that used to live here held a brand's per-funnel provisioning back while ANY alive campaign

--- a/drizzle/0050_campaign_offer_id.sql
+++ b/drizzle/0050_campaign_offer_id.sql
@@ -1,0 +1,30 @@
+-- The OFFER a campaign sells — a brand-service offer UUID.
+--
+-- A new granularity sits between the brand and the campaign: Org > Brand > OFFER > Campaign. An
+-- offer is one distinct thing a brand sells — its value proposition plus the sales funnels it
+-- sells through — so a brand selling a $200 self-serve plan and a $20k enterprise contract has
+-- two. A campaign sells exactly one, which makes a campaign (offer x sales funnel x acquisition
+-- channel); it already states the funnel (migration 0041) and the channel (0044), and this is the
+-- missing third word. Without it, two campaigns of one brand on the same funnel through the same
+-- channel for two DIFFERENT offers are the same row to every reader.
+--
+-- brand-service owns the entity; this column carries its id and nothing else. No offer vocabulary
+-- is introduced here, exactly as none is for the goal or the channel.
+--
+-- NOTHING IS BACKFILLED BY THIS MIGRATION, and that is deliberate: resolving a campaign's brand to
+-- its offer is a brand-service READ, and SQL cannot make one. The backfill is
+-- scripts/backfill-campaign-offer.ts, which resolves each brand to its single offer, writes only
+-- rows still NULL, and leaves alone (and reports) any brand that does not resolve to exactly one.
+--
+-- NULL = the campaign states no offer and behaves exactly as it did before this column existed:
+-- no pacing, funding, selection, identity or uniqueness decision reads it. Stating one is optional
+-- on create while callers migrate.
+--
+-- Idempotent (IF NOT EXISTS on both statements) so a partial-apply replay is safe.
+ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "offer_id" text;
+
+-- Serves "what did this offer buy" — the per-offer attribution read the column exists for.
+-- Partial: a campaign that states no offer is not part of any offer's answer.
+CREATE INDEX IF NOT EXISTS "idx_campaigns_org_offer"
+  ON "campaigns" USING btree ("org_id", "offer_id")
+  WHERE "offer_id" IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1777400000000,
       "tag": "0049_drop_brand_pause",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1777500000000,
+      "tag": "0050_campaign_offer_id",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -120,6 +120,10 @@
             "type": "string",
             "nullable": true
           },
+          "offerId": {
+            "type": "string",
+            "nullable": true
+          },
           "maxLeads": {
             "type": "integer",
             "nullable": true
@@ -185,6 +189,7 @@
           "maxBudgetTotalUsd",
           "dailyBudgetCents",
           "funnelKey",
+          "offerId",
           "maxLeads",
           "startDate",
           "endDate",
@@ -272,6 +277,11 @@
           "funnelKey": {
             "type": "string",
             "minLength": 1
+          },
+          "offerId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
           },
           "audienceIds": {
             "type": "array",
@@ -375,6 +385,11 @@
             "type": "string",
             "nullable": true,
             "minLength": 1
+          },
+          "offerId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
           },
           "audienceIds": {
             "type": "array",

--- a/scripts/backfill-campaign-offer.ts
+++ b/scripts/backfill-campaign-offer.ts
@@ -1,0 +1,225 @@
+/**
+ * One-shot backfill: every existing campaign states the OFFER it sells.
+ *
+ * A campaign is (offer x sales funnel x acquisition channel). Migration 0050 adds `offer_id` and
+ * backfills NOTHING, because resolving a campaign's brand to its offer is a brand-service READ and
+ * SQL cannot make one. This script makes it.
+ *
+ * Every brand has exactly one offer at the moment this runs — brand-service ships that migration
+ * in the same wave — so this is a RESOLUTION, not a guess. Where a brand does not resolve to
+ * exactly one offer, the campaign is LEFT ALONE and REPORTED. Nothing is ever inferred from the
+ * funnel, the goal or the workflow: several offers legitimately sell through one funnel, which is
+ * the whole reason the dimension exists, so picking one would invent an attribution.
+ *
+ * Idempotent: it only ever selects and writes rows whose `offer_id` is still NULL, and the UPDATE
+ * re-states that guard, so a second run writes nothing and a run racing a live create cannot
+ * overwrite an offer a caller just stated.
+ *
+ * Reversible: the previous value is NULL by construction (that is the guard), so the reverse of a
+ * run is exactly the ids it printed. The script emits the undo statement at the end.
+ *
+ * Dry run is the DEFAULT — it resolves and reports without writing. Pass --apply to write.
+ *
+ * Usage:
+ *   CAMPAIGN_SERVICE_DATABASE_URL=... BRAND_SERVICE_URL=... BRAND_SERVICE_API_KEY=... \
+ *     npx tsx scripts/backfill-campaign-offer.ts            # dry run, writes nothing
+ *   ... npx tsx scripts/backfill-campaign-offer.ts --apply  # writes
+ */
+
+import postgres from "postgres";
+
+/**
+ * What brand-service answers for one (org, brand) pair.
+ *
+ * `offerId` is set ONLY when the pair resolves to exactly one offer. Anything else — no offer,
+ * several offers, an unreadable answer — carries a `reason` and no id, and the caller leaves the
+ * campaign alone. There is deliberately no "pick the first" branch.
+ */
+export type OfferResolution =
+  | { offerId: string; reason?: undefined }
+  | { offerId: null; reason: string };
+
+export interface UnresolvedCampaign {
+  campaignId: string;
+  orgId: string;
+  brandId: string | null;
+  reason: string;
+}
+
+export interface BackfillResult {
+  /** Rows written (or, on a dry run, rows that WOULD be written). */
+  written: number;
+  /** The campaign ids behind `written` — the exact set an undo would target. */
+  writtenCampaignIds: string[];
+  /** Campaigns left untouched because their brand did not resolve to exactly one offer. */
+  unresolved: UnresolvedCampaign[];
+  dryRun: boolean;
+}
+
+/**
+ * Read the offer a brand sells, for ONE org's view of it.
+ *
+ * Contract (brand-service): GET /internal/brands/{brandId}/offers (x-api-key + x-org-id)
+ *   -> { offers: [{ id, active }] }
+ *
+ * `x-org-id` is load-bearing, not tracking: a `brands` row is a shared global identity that
+ * several orgs legitimately claim, and everything configured on top of it belongs to the (org,
+ * brand) pair. Naming the org is what stops brand-service answering for somebody else's offer.
+ *
+ * An inactive offer is not an answer — a brand's live offer is the one it still sells.
+ */
+export function makeOfferResolver(baseUrl: string, apiKey: string) {
+  return async function resolveBrandOffer(brandId: string, orgId: string): Promise<OfferResolution> {
+    const url = `${baseUrl.replace(/\/$/, "")}/internal/brands/${encodeURIComponent(brandId)}/offers`;
+    let res: Response;
+    try {
+      res = await fetch(url, { headers: { "x-api-key": apiKey, "x-org-id": orgId, "x-brand-id": brandId } });
+    } catch (err) {
+      return { offerId: null, reason: `brand-service unreachable: ${err instanceof Error ? err.message : String(err)}` };
+    }
+    if (!res.ok) {
+      return { offerId: null, reason: `brand-service returned ${res.status}` };
+    }
+
+    let data: { offers?: Array<{ id?: string; offerId?: string; active?: boolean }> };
+    try {
+      data = (await res.json()) as typeof data;
+    } catch {
+      return { offerId: null, reason: "brand-service answer is not JSON" };
+    }
+    if (!Array.isArray(data.offers)) {
+      return { offerId: null, reason: "brand-service answer carries no offers array" };
+    }
+
+    const ids = data.offers
+      .filter((o) => o?.active !== false)
+      .map((o) => o?.id ?? o?.offerId)
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+
+    if (ids.length === 1) return { offerId: ids[0] };
+    return {
+      offerId: null,
+      reason: ids.length === 0 ? "brand declares no active offer" : `brand declares ${ids.length} active offers`,
+    };
+  };
+}
+
+/**
+ * Write each campaign the offer its (org, brand) pair resolves to.
+ *
+ * One brand-service read per distinct pair, not per campaign — a brand with twenty campaigns is
+ * one question asked once.
+ */
+export async function backfillCampaignOffers(
+  querySql: postgres.Sql,
+  resolveBrandOffer: (brandId: string, orgId: string) => Promise<OfferResolution>,
+  options: { dryRun?: boolean } = {},
+): Promise<BackfillResult> {
+  const dryRun = options.dryRun !== false;
+
+  // `brand_id` is the stored half of the campaign identity (migration 0044); the historical
+  // multi-brand rows only carry the array, so fall back to its first element exactly as 0044 did.
+  const rows = (await querySql`
+    SELECT "id", "org_id", coalesce("brand_id", "brand_ids"[1]) AS "brand_id"
+    FROM "campaigns"
+    WHERE "offer_id" IS NULL
+    ORDER BY "created_at"
+  `) as unknown as Array<{ id: string; org_id: string; brand_id: string | null }>;
+
+  console.log(`Found ${rows.length} campaign(s) with no offer stated`);
+
+  const writtenCampaignIds: string[] = [];
+  const unresolved: UnresolvedCampaign[] = [];
+  const cache = new Map<string, OfferResolution>();
+
+  for (const row of rows) {
+    if (!row.brand_id) {
+      unresolved.push({
+        campaignId: row.id,
+        orgId: row.org_id,
+        brandId: null,
+        reason: "campaign states no brand",
+      });
+      continue;
+    }
+
+    const key = `${row.org_id}::${row.brand_id}`;
+    let resolution = cache.get(key);
+    if (!resolution) {
+      resolution = await resolveBrandOffer(row.brand_id, row.org_id);
+      cache.set(key, resolution);
+    }
+
+    if (!resolution.offerId) {
+      unresolved.push({
+        campaignId: row.id,
+        orgId: row.org_id,
+        brandId: row.brand_id,
+        reason: resolution.reason,
+      });
+      continue;
+    }
+
+    if (!dryRun) {
+      // The `offer_id IS NULL` guard is restated here, not just in the SELECT: it is what makes a
+      // re-run a no-op and what stops this overwriting an offer a live create stated meanwhile.
+      await querySql`
+        UPDATE "campaigns"
+        SET "offer_id" = ${resolution.offerId}, "updated_at" = now()
+        WHERE "id" = ${row.id} AND "offer_id" IS NULL
+      `;
+    }
+    console.log(`  ${dryRun ? "[dry-run] would set" : "set"} campaign ${row.id} offer → ${resolution.offerId}`);
+    writtenCampaignIds.push(row.id);
+  }
+
+  return { written: writtenCampaignIds.length, writtenCampaignIds, unresolved, dryRun };
+}
+
+async function main() {
+  const DATABASE_URL = process.env.CAMPAIGN_SERVICE_DATABASE_URL;
+  const BRAND_SERVICE_URL = process.env.BRAND_SERVICE_URL;
+  const BRAND_SERVICE_API_KEY = process.env.BRAND_SERVICE_API_KEY;
+
+  if (!DATABASE_URL || !BRAND_SERVICE_URL || !BRAND_SERVICE_API_KEY) {
+    console.error("Required: CAMPAIGN_SERVICE_DATABASE_URL, BRAND_SERVICE_URL, BRAND_SERVICE_API_KEY");
+    process.exit(1);
+  }
+
+  // Dry run unless --apply is stated. A backfill that writes by default is one nobody inspected.
+  const dryRun = !process.argv.includes("--apply");
+
+  const sql = postgres(DATABASE_URL);
+  console.log(`=== Backfilling campaign offers ${dryRun ? "(DRY RUN — nothing is written)" : "(APPLYING)"} ===\n`);
+
+  const result = await backfillCampaignOffers(sql, makeOfferResolver(BRAND_SERVICE_URL, BRAND_SERVICE_API_KEY), { dryRun });
+
+  console.log(`\n${result.written} campaign(s) ${dryRun ? "would be" : ""} written, ${result.unresolved.length} left alone`);
+
+  if (result.unresolved.length > 0) {
+    console.error("\nLEFT ALONE — their brand does not resolve to exactly one offer. No offer is invented for these:");
+    for (const u of result.unresolved) {
+      console.error(`  campaign ${u.campaignId} (org ${u.orgId}, brand ${u.brandId ?? "none"}): ${u.reason}`);
+    }
+  }
+
+  if (result.written > 0) {
+    const ids = result.writtenCampaignIds.map((id) => `'${id}'`).join(", ");
+    console.log(`\nUndo this run:\n  UPDATE "campaigns" SET "offer_id" = NULL WHERE "id" IN (${ids});`);
+  }
+
+  await sql.end();
+
+  // A campaign left alone is a real gap somebody must answer, so the run reports it as a failure
+  // — the writes that did land stay, and re-running after the gap is closed picks up only those.
+  if (result.unresolved.length > 0) process.exit(1);
+}
+
+// Only run main() when executed directly (not imported in tests)
+const isDirectRun = process.argv[1]?.includes("backfill-campaign-offer");
+if (isDirectRun) {
+  main().catch(async (err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -123,6 +123,28 @@ export const campaigns = pgTable(
     // resolves the pre-rename spellings, because billing-service emits them to this day.
     funnelKey: text("funnel_key"),
 
+    // The OFFER this campaign sells — a brand-service offer UUID.
+    //
+    // An offer is one distinct thing a brand sells: its value proposition plus the sales funnels
+    // it sells through. A brand selling a $200 self-serve plan and a $20k enterprise contract has
+    // two offers, and without this column its two campaigns — same funnel, same channel — are the
+    // same row to every reader, in the data, in the money attribution and on the customer's
+    // screen. It is the dimension that separates them.
+    //
+    // brand-service OWNS the entity; this column carries its id and nothing else. No offer
+    // vocabulary, table or enum exists here and none is to be introduced — the same posture this
+    // service holds for the goal and the acquisition channel.
+    //
+    // NEVER derived. A funnel does not name an offer (several offers legitimately sell through
+    // one funnel, which is the entire reason this dimension exists), and neither does the goal or
+    // the workflow. It is stated by the creator or it is NULL.
+    //
+    // NULL = the campaign states no offer, and behaves exactly as it did before this column
+    // existed: nothing reads it for pacing, funding, selection or identity. Stating an offer is
+    // optional on create while callers migrate; it becomes required in a later wave, and only
+    // then, because requiring it now would break every live caller.
+    offerId: text("offer_id"),
+
     // Volume limit (optional, total leads across all runs)
     maxLeads: integer("max_leads"),
 
@@ -161,6 +183,11 @@ export const campaigns = pgTable(
     index("idx_campaigns_org").on(table.orgId),
     uniqueIndex("uniq_campaigns_org_name").on(table.orgId, table.name),
     index("idx_campaigns_org_feature_funnel").on(table.orgId, table.featureSlug, table.funnelKey),
+    // Serves "what did this offer buy" — the per-offer attribution read the column exists for.
+    // Partial: a campaign that states no offer is not part of any offer's answer.
+    index("idx_campaigns_org_offer")
+      .on(table.orgId, table.offerId)
+      .where(sql`${table.offerId} is not null`),
     // Serves the resume sweep's only read — the stopped campaigns that ran out of people to
     // contact. Partial so it covers that narrow population and not the whole stopped history.
     index("idx_campaigns_resumable")

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -123,6 +123,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       brandProfileId,
       audienceId,
       funnelKey: bodyFunnelKey,
+      offerId,
       audienceIds,
       servicesOffered,
       clickDestinationUrl,
@@ -225,6 +226,10 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
           ...(activeGoalId !== undefined ? { activeGoalId } : {}),
           ...(brandProfileId !== undefined ? { brandProfileId } : {}),
           ...(audienceId !== undefined ? { audienceId } : {}),
+          // An incumbent campaign learns which offer it sells from a caller that now states one.
+          // Only when the caller actually sent it: a create that says nothing about the offer
+          // must not blank the one already on the row.
+          ...(offerId !== undefined ? { offerId } : {}),
           ...(audienceIds !== undefined ? { audienceIds } : {}),
           ...(servicesOffered !== undefined ? { servicesOffered } : {}),
           ...(clickDestinationUrl !== undefined ? { clickDestinationUrl } : {}),
@@ -287,6 +292,9 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         brandProfileId: brandProfileId ?? null,
         audienceId: audienceId ?? null,
         funnelKey,
+        // The offer this campaign sells, as STATED by its creator. Absent → NULL; nothing is
+        // inferred from the funnel, the goal or the workflow.
+        offerId: offerId ?? null,
         audienceIds: audienceIds ?? null,
         servicesOffered: servicesOffered ?? null,
         clickDestinationUrl: clickDestinationUrl ?? null,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -58,6 +58,14 @@ export const CampaignSchema = z.object({
   // unless billing holds no per-funnel ceilings for the brand at all, in which case the brand has
   // one pot and the campaign paces on the brand daily budget exactly as it always has.
   funnelKey: z.string().nullable(),
+  // The OFFER this campaign sells — a brand-service offer UUID. An offer is one distinct thing a
+  // brand sells, so a campaign is (offer x sales funnel x acquisition channel) and this is the
+  // word that separates two campaigns a brand runs on one funnel through one channel for two
+  // different offers. Never derived from the funnel, the goal or the workflow — several offers
+  // sell through one funnel, which is why the dimension exists. Null = the campaign states no
+  // offer, which is every campaign created before it could be stated and every caller that has
+  // not migrated yet; nothing reads it for pacing, funding, selection or identity.
+  offerId: z.string().nullable(),
   maxLeads: z.number().int().nullable(),
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
@@ -94,6 +102,16 @@ export const CreateCampaignBody = z.object({
   // (reply_meeting | visit_meeting | visit_signup | visit_form), stored canonical. Nothing is ever
   // inferred: a creator provisions per funded funnel, so it already knows the answer.
   funnelKey: z.string().min(1).optional(),
+  // The OFFER this campaign sells — a brand-service offer UUID.
+  //
+  // OPTIONAL, on purpose and for now: making it required is a breaking request-contract change,
+  // so callers state it as they migrate and a create without one behaves exactly as it did
+  // before the field existed. It becomes required in a later wave, once they have.
+  //
+  // Nothing is ever inferred when it is absent — not from the funnel (several offers sell through
+  // one funnel), not from the goal, not from the workflow. Absent means the campaign states no
+  // offer, and that is stored as NULL.
+  offerId: z.string().uuid("offerId must be a valid UUID").nullable().optional(),
   // Per-campaign OWN config (Campaign v2). Omit / null = inherit the brand. audienceIds is the
   // targeted SUBSET (one or more) of the brand's audiences; an empty array is rejected — use
   // null to clear back to inherit.
@@ -140,6 +158,10 @@ export const UpdateCampaignBody = z.object({
   activeGoalId: z.string().min(1).nullable().optional(),
   brandProfileId: z.string().min(1).nullable().optional(),
   audienceId: z.string().min(1).nullable().optional(),
+  // State (or clear) the OFFER this campaign sells — a brand-service offer UUID. Omit and it is
+  // untouched; null clears it back to "states no offer". This is how a caller that created a
+  // campaign before it could state an offer says which one it runs, without a second campaign.
+  offerId: z.string().uuid("offerId must be a valid UUID").nullable().optional(),
   // Set / clear this campaign's OWN config (Campaign v2). null clears a field → inherit the
   // brand. Updating these never touches the brand or any sibling campaign. audienceIds must be
   // non-empty when present; use null to clear back to inherit. `goal` is deliberately absent: it

--- a/tests/integration/campaign-offer.test.ts
+++ b/tests/integration/campaign-offer.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import app from "../../src/index.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+const ORG = "org_test_offer";
+
+/**
+ * A campaign sells exactly ONE offer — the third word of (offer x sales funnel x acquisition
+ * channel). These pin the two halves of the contract that matter while callers migrate:
+ * a campaign can STATE one and read it back, and a campaign that states NONE behaves exactly as
+ * it did before the field existed.
+ */
+describe("Campaign offer", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  function createCampaign(
+    body: Record<string, unknown>,
+    featureSlug = "sales-cold-email-v1",
+  ) {
+    return request(app)
+      .post("/campaigns")
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", ORG)
+      .set("x-user-id", "user_test_offer")
+      .set("x-run-id", crypto.randomUUID())
+      .set("x-feature-slug", featureSlug)
+      .send(body);
+  }
+
+  function read(id: string) {
+    return request(app)
+      .get(`/campaigns/${id}`)
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", ORG);
+  }
+
+  function baseBody(name: string) {
+    return {
+      name,
+      workflowSlug: "sales-email-cold-outreach",
+      orgId: ORG,
+      brandIds: [crypto.randomUUID()],
+    };
+  }
+
+  it("creates a campaign carrying an offer and reads it back", async () => {
+    const offerId = crypto.randomUUID();
+
+    const created = await createCampaign({ ...baseBody("Offer Campaign"), offerId }).expect(201);
+    expect(created.body.campaign.offerId).toBe(offerId);
+
+    const readBack = await read(created.body.campaign.id).expect(200);
+    expect(readBack.body.campaign.offerId).toBe(offerId);
+  });
+
+  it("a campaign created WITHOUT an offer states none — and nothing else about it changes", async () => {
+    const body = baseBody("Offerless Campaign");
+
+    const created = await createCampaign(body).expect(201);
+
+    expect(created.body.campaign.offerId).toBeNull();
+    // The rest of the row is exactly what it was before the field existed.
+    expect(created.body.campaign.name).toBe("Offerless Campaign");
+    expect(created.body.campaign.workflowSlug).toBe("sales-email-cold-outreach");
+    expect(created.body.campaign.brandIds).toEqual(body.brandIds);
+    expect(created.body.campaign.status).toBe("ongoing");
+
+    const readBack = await read(created.body.campaign.id).expect(200);
+    expect(readBack.body.campaign.offerId).toBeNull();
+  });
+
+  it("an explicit null states no offer, same as omitting it", async () => {
+    const created = await createCampaign({ ...baseBody("Null Offer"), offerId: null }).expect(201);
+    expect(created.body.campaign.offerId).toBeNull();
+  });
+
+  it("rejects an offerId that is not a UUID — brand-service owns the entity, we carry its id", async () => {
+    const res = await createCampaign({ ...baseBody("Bad Offer"), offerId: "not-a-uuid" }).expect(400);
+    expect(res.body.error).toContain("offerId");
+  });
+
+  it("PATCH states the offer of a campaign created before it could, and null clears it", async () => {
+    const offerId = crypto.randomUUID();
+    const created = await createCampaign(baseBody("Late Offer")).expect(201);
+    expect(created.body.campaign.offerId).toBeNull();
+
+    const patched = await request(app)
+      .patch(`/campaigns/${created.body.campaign.id}`)
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", ORG)
+      .send({ offerId })
+      .expect(200);
+    expect(patched.body.campaign.offerId).toBe(offerId);
+
+    const cleared = await request(app)
+      .patch(`/campaigns/${created.body.campaign.id}`)
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", ORG)
+      .send({ offerId: null })
+      .expect(200);
+    expect(cleared.body.campaign.offerId).toBeNull();
+  });
+
+  it("a re-create that says nothing about the offer does not blank the one already stated", async () => {
+    const offerId = crypto.randomUUID();
+    const body = baseBody("Incumbent Offer");
+
+    const created = await createCampaign({ ...body, offerId }).expect(201);
+    expect(created.body.campaign.offerId).toBe(offerId);
+
+    // Same (org, brand, funnel, channel) → the incumbent is updated, not duplicated.
+    const again = await createCampaign({ ...body, workflowSlug: "sales-email-cold-outreach-v2" }).expect(200);
+    expect(again.body.campaign.id).toBe(created.body.campaign.id);
+    expect(again.body.campaign.offerId).toBe(offerId);
+  });
+
+  it("a re-create that states a DIFFERENT offer moves the incumbent to it", async () => {
+    const first = crypto.randomUUID();
+    const second = crypto.randomUUID();
+    const body = baseBody("Moving Offer");
+
+    const created = await createCampaign({ ...body, offerId: first }).expect(201);
+    const again = await createCampaign({ ...body, offerId: second }).expect(200);
+
+    expect(again.body.campaign.id).toBe(created.body.campaign.id);
+    expect(again.body.campaign.offerId).toBe(second);
+  });
+});

--- a/tests/unit/campaign-offer-backfill.test.ts
+++ b/tests/unit/campaign-offer-backfill.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  backfillCampaignOffers,
+  makeOfferResolver,
+  type OfferResolution,
+} from "../../scripts/backfill-campaign-offer.js";
+
+const TAG = "0050_campaign_offer_id";
+const SQL = readFileSync(join(process.cwd(), "drizzle", `${TAG}.sql`), "utf8");
+
+/** The SQL with every comment line stripped — the statements, and nothing the prose says. */
+const STATEMENTS = SQL.split("\n")
+  .filter((line) => !line.trimStart().startsWith("--"))
+  .join("\n");
+
+/**
+ * Minimal tagged-template mock mimicking postgres `sql`: the first call is the SELECT and
+ * returns `rows`; every later call is an UPDATE and is recorded.
+ */
+function createMockSql(rows: Record<string, unknown>[]) {
+  let callCount = 0;
+  const updates: Array<{ offerId: unknown; campaignId: unknown }> = [];
+  const fn = async (_strings: TemplateStringsArray, ...values: unknown[]) => {
+    callCount++;
+    if (callCount === 1) return rows;
+    updates.push({ offerId: values[0], campaignId: values[1] });
+    return [];
+  };
+  return { sql: fn as unknown as Parameters<typeof backfillCampaignOffers>[0], updates };
+}
+
+function row(id: string, orgId = "org-1", brandId: string | null = "brand-1") {
+  return { id, org_id: orgId, brand_id: brandId };
+}
+
+function resolved(offerId: string): OfferResolution {
+  return { offerId };
+}
+
+describe("migration 0050 — the column, and nothing else", () => {
+  it("adds offer_id idempotently and creates its index idempotently", () => {
+    expect(STATEMENTS).toMatch(/ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "offer_id" text;/);
+    expect(STATEMENTS).toMatch(/CREATE INDEX IF NOT EXISTS "idx_campaigns_org_offer"/);
+  });
+
+  it("backfills NOTHING — resolving a brand to its offer is a brand-service read SQL cannot make", () => {
+    expect(STATEMENTS).not.toMatch(/\bUPDATE\b/i);
+    expect(STATEMENTS).not.toMatch(/\bINSERT\b/i);
+  });
+
+  it("touches no other column and deletes nothing", () => {
+    expect(STATEMENTS).not.toMatch(/\bDELETE\b|\bTRUNCATE\b|\bDROP\b/i);
+    for (const column of ["status", "next_run_at", "goal", "funnel_key", "daily_budget_cents", "brand_ids"]) {
+      expect(STATEMENTS).not.toMatch(new RegExp(`"${column}"\\s*=`));
+    }
+  });
+
+  it("is registered in the migrations journal", () => {
+    const journal = JSON.parse(readFileSync(join(process.cwd(), "drizzle", "meta", "_journal.json"), "utf8"));
+    expect(journal.entries.some((e: { tag: string }) => e.tag === TAG)).toBe(true);
+  });
+});
+
+describe("backfillCampaignOffers", () => {
+  it("writes each campaign the single offer its (org, brand) pair resolves to", async () => {
+    const { sql, updates } = createMockSql([row("c1"), row("c2")]);
+    const resolve = vi.fn().mockResolvedValue(resolved("offer-a"));
+
+    const result = await backfillCampaignOffers(sql, resolve, { dryRun: false });
+
+    expect(result.written).toBe(2);
+    expect(result.writtenCampaignIds).toEqual(["c1", "c2"]);
+    expect(result.unresolved).toEqual([]);
+    expect(updates).toEqual([
+      { offerId: "offer-a", campaignId: "c1" },
+      { offerId: "offer-a", campaignId: "c2" },
+    ]);
+  });
+
+  it("asks brand-service ONCE per (org, brand) pair, not once per campaign", async () => {
+    const { sql } = createMockSql([
+      row("c1", "org-1", "brand-1"),
+      row("c2", "org-1", "brand-1"),
+      row("c3", "org-2", "brand-1"),
+    ]);
+    const resolve = vi.fn().mockResolvedValue(resolved("offer-a"));
+
+    await backfillCampaignOffers(sql, resolve, { dryRun: false });
+
+    // Same brand under a DIFFERENT org is a different question — per-brand config is per pair.
+    expect(resolve).toHaveBeenCalledTimes(2);
+    expect(resolve).toHaveBeenCalledWith("brand-1", "org-1");
+    expect(resolve).toHaveBeenCalledWith("brand-1", "org-2");
+  });
+
+  it("leaves a campaign alone and REPORTS it when the brand does not resolve to exactly one offer", async () => {
+    const { sql, updates } = createMockSql([row("c1"), row("c2", "org-2", "brand-2")]);
+    const resolve = vi.fn(async (brandId: string) =>
+      brandId === "brand-1"
+        ? resolved("offer-a")
+        : ({ offerId: null, reason: "brand declares 2 active offers" } as OfferResolution),
+    );
+
+    const result = await backfillCampaignOffers(sql, resolve, { dryRun: false });
+
+    expect(result.written).toBe(1);
+    expect(updates).toEqual([{ offerId: "offer-a", campaignId: "c1" }]);
+    expect(result.unresolved).toEqual([
+      { campaignId: "c2", orgId: "org-2", brandId: "brand-2", reason: "brand declares 2 active offers" },
+    ]);
+  });
+
+  it("never invents an attribution for a campaign that states no brand", async () => {
+    const { sql, updates } = createMockSql([row("c1", "org-1", null)]);
+    const resolve = vi.fn();
+
+    const result = await backfillCampaignOffers(sql, resolve, { dryRun: false });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(updates).toEqual([]);
+    expect(result.unresolved).toEqual([
+      { campaignId: "c1", orgId: "org-1", brandId: null, reason: "campaign states no brand" },
+    ]);
+  });
+
+  it("re-running changes nothing: it selects and writes only rows whose offer is still NULL", async () => {
+    // Second run — every campaign now states an offer, so the SELECT returns nothing.
+    const { sql, updates } = createMockSql([]);
+    const resolve = vi.fn();
+
+    const result = await backfillCampaignOffers(sql, resolve, { dryRun: false });
+
+    expect(result).toMatchObject({ written: 0, writtenCampaignIds: [], unresolved: [] });
+    expect(updates).toEqual([]);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("guards BOTH the read and the write on offer_id IS NULL, so a live create is never overwritten", async () => {
+    const seen: string[] = [];
+    const sql = (async (strings: TemplateStringsArray) => {
+      const text = strings.join("?");
+      seen.push(text);
+      return seen.length === 1 ? [row("c1")] : [];
+    }) as unknown as Parameters<typeof backfillCampaignOffers>[0];
+
+    await backfillCampaignOffers(sql, async () => resolved("offer-a"), { dryRun: false });
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toMatch(/"offer_id" IS NULL/);
+    expect(seen[1]).toMatch(/UPDATE "campaigns"[\s\S]*"offer_id" IS NULL/);
+  });
+
+  it("dry run resolves and reports the exact same set, and writes nothing", async () => {
+    const { sql, updates } = createMockSql([row("c1"), row("c2")]);
+    const resolve = vi.fn().mockResolvedValue(resolved("offer-a"));
+
+    const result = await backfillCampaignOffers(sql, resolve, { dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.writtenCampaignIds).toEqual(["c1", "c2"]);
+    expect(updates).toEqual([]);
+  });
+
+  it("dry run is the DEFAULT — a backfill that writes unasked is one nobody inspected", async () => {
+    const { sql, updates } = createMockSql([row("c1")]);
+
+    const result = await backfillCampaignOffers(sql, async () => resolved("offer-a"));
+
+    expect(result.dryRun).toBe(true);
+    expect(updates).toEqual([]);
+  });
+});
+
+describe("makeOfferResolver", () => {
+  function withFetch(impl: () => Promise<unknown>) {
+    return vi.spyOn(globalThis, "fetch").mockImplementation(impl as never);
+  }
+
+  function jsonResponse(body: unknown, ok = true, status = 200) {
+    return Promise.resolve({ ok, status, json: async () => body } as Response);
+  }
+
+  it("resolves a brand declaring exactly one active offer, naming the org on the wire", async () => {
+    const spy = withFetch(() => jsonResponse({ offers: [{ id: "offer-a", active: true }] }));
+
+    const result = await makeOfferResolver("https://brand.test.local", "key")("brand-1", "org-1");
+
+    expect(result).toEqual({ offerId: "offer-a" });
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://brand.test.local/internal/brands/brand-1/offers");
+    // Per-brand configuration belongs to the (org, brand) pair — never let brand-service pick.
+    expect((init.headers as Record<string, string>)["x-org-id"]).toBe("org-1");
+    spy.mockRestore();
+  });
+
+  it("refuses to pick when a brand declares several — no offer is invented", async () => {
+    const spy = withFetch(() => jsonResponse({ offers: [{ id: "offer-a" }, { id: "offer-b" }] }));
+
+    const result = await makeOfferResolver("https://brand.test.local", "key")("brand-1", "org-1");
+
+    expect(result.offerId).toBeNull();
+    expect(result.reason).toContain("2 active offers");
+    spy.mockRestore();
+  });
+
+  it("ignores an inactive offer — a brand's live offer is the one it still sells", async () => {
+    const spy = withFetch(() =>
+      jsonResponse({ offers: [{ id: "offer-a", active: false }, { id: "offer-b", active: true }] }),
+    );
+
+    expect(await makeOfferResolver("https://brand.test.local", "key")("brand-1", "org-1")).toEqual({
+      offerId: "offer-b",
+    });
+    spy.mockRestore();
+  });
+
+  it("a brand declaring none, and an unreadable answer, are both left unresolved", async () => {
+    const resolver = makeOfferResolver("https://brand.test.local", "key");
+
+    let spy = withFetch(() => jsonResponse({ offers: [] }));
+    expect((await resolver("brand-1", "org-1")).offerId).toBeNull();
+    spy.mockRestore();
+
+    spy = withFetch(() => jsonResponse({ error: "boom" }, false, 500));
+    expect(await resolver("brand-1", "org-1")).toEqual({ offerId: null, reason: "brand-service returned 500" });
+    spy.mockRestore();
+
+    spy = withFetch(() => Promise.reject(new Error("ECONNRESET")));
+    expect((await resolver("brand-1", "org-1")).reason).toContain("unreachable");
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## What

A campaign records the OFFER it sells.

A new granularity sits between the brand and the campaign: **Org > Brand > Offer > Campaign**. An offer is one distinct thing a brand sells — its value proposition plus the sales funnels it sells through — so a brand selling a $200 self-serve plan and a $20k enterprise contract has two.

A campaign sells exactly one, which makes a campaign **(offer × sales funnel × acquisition channel)**. It already states the funnel (0041) and the channel (0044); this is the missing third word. Without it, two campaigns of one brand on the same funnel through the same channel for two different offers are the same row to every reader.

## Contract

| | |
|---|---|
| Field | `offerId` (column `offer_id`, nullable, UUID-validated at the API boundary) |
| On | create body, update body, and every campaign read |
| Migration | `drizzle/0050_campaign_offer_id.sql` — additive only, no `UPDATE`/`INSERT`/`DROP` (pinned by a test) |

## Optional on purpose

NULL behaves exactly as before the column existed: no pacing, funding, selection, identity or uniqueness decision reads it. Making it required is a breaking request-contract change and belongs to the wave where the callers migrate.

**The uniqueness key is deliberately NOT widened.** Adding the offer to `uniq_campaigns_org_brand_funnel_channel` while the field is optional would let a brand grow unlimited offer-less campaigns on one (funnel, channel). Same later wave.

Nothing validates the id cross-service — `funnelKey` and `audienceIds` are not validated either, so this follows the house rule rather than inventing one.

## The backfill is a script, not SQL

Resolving a campaign's brand to its offer is a brand-service READ, and SQL cannot make one. So `scripts/backfill-campaign-offer.ts` does it:

- **dry run is the default** — writes nothing, prints exactly what it would write
- idempotent twice over: the SELECT filters `offer_id IS NULL` and the UPDATE restates that guard, so a re-run writes nothing and it can never overwrite an offer a live create just stated
- reversible: the previous value is NULL by construction, and the run prints a ready-to-paste `UPDATE … SET offer_id = NULL WHERE id IN (…)`
- a brand that does not resolve to **exactly one** active offer — none, several, unreadable, or a campaign with no brand — is left untouched, reported, and the run exits non-zero. No offer is ever invented.

## ⚠️ Do not run the backfill yet

brand-service's offers endpoint does not exist at the time of this PR. The resolver targets a contract modelled on the existing `…/sales-funnels` sibling and tolerates either spelling of the id, but it is a **guess until brand-service ships**. It is one isolated injectable function (`makeOfferResolver`) so conforming it is a few lines, and the tests inject their own.

## Verified

`tsc --noEmit` clean · build succeeds · `check:migrations` OK · **577 tests pass across 42 files**. No existing test file modified.

## Follow-ups, not in scope

- `StartRunResponse` does not carry it — nothing downstream reads it yet.
- The internal funnel provisioner leaves it NULL — giving it an offer means a brand-service read on the provisioning tick, which is the callers-migrate wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
