### PR TITLE
fix(offer-backfill): conform the resolver to brand-service's real contract

### DIFF
--- a/scripts/backfill-campaign-offer.ts
+++ b/scripts/backfill-campaign-offer.ts
@@ -59,14 +59,20 @@ export interface BackfillResult {
 /**
  * Read the offer a brand sells, for ONE org's view of it.
  *
- * Contract (brand-service): GET /internal/brands/{brandId}/offers (x-api-key + x-org-id)
- *   -> { offers: [{ id, active }] }
+ * Contract (brand-service, verified against the deployed route rather than assumed):
+ *   GET /internal/brands/{brandId}/offers  (x-api-key + x-org-id)
+ *   -> { offers: [{ offerId, brandId, name, createdAt, updatedAt }] }
  *
  * `x-org-id` is load-bearing, not tracking: a `brands` row is a shared global identity that
  * several orgs legitimately claim, and everything configured on top of it belongs to the (org,
  * brand) pair. Naming the org is what stops brand-service answering for somebody else's offer.
  *
- * An inactive offer is not an answer — a brand's live offer is the one it still sells.
+ * THERE IS NO `active` ON AN OFFER, and this used to filter on one. An offer is a proposition
+ * a brand states; it is the FUNNELS underneath it that are switched on and off, which is why
+ * brand-service's own funnel read is the one that says "active only". Filtering here on a field
+ * that is never sent read as a deliberate liveness check while doing nothing — the dangerous
+ * kind of dead code, because the day brand-service adds an unrelated `active` it would start
+ * silently dropping offers. An offer's existence IS the answer.
  */
 export function makeOfferResolver(baseUrl: string, apiKey: string) {
   return async function resolveBrandOffer(brandId: string, orgId: string): Promise<OfferResolution> {
@@ -81,7 +87,7 @@ export function makeOfferResolver(baseUrl: string, apiKey: string) {
       return { offerId: null, reason: `brand-service returned ${res.status}` };
     }
 
-    let data: { offers?: Array<{ id?: string; offerId?: string; active?: boolean }> };
+    let data: { offers?: Array<{ offerId?: string }> };
     try {
       data = (await res.json()) as typeof data;
     } catch {
@@ -92,14 +98,13 @@ export function makeOfferResolver(baseUrl: string, apiKey: string) {
     }
 
     const ids = data.offers
-      .filter((o) => o?.active !== false)
-      .map((o) => o?.id ?? o?.offerId)
+      .map((o) => o?.offerId)
       .filter((id): id is string => typeof id === "string" && id.length > 0);
 
     if (ids.length === 1) return { offerId: ids[0] };
     return {
       offerId: null,
-      reason: ids.length === 0 ? "brand declares no active offer" : `brand declares ${ids.length} active offers`,
+      reason: ids.length === 0 ? "brand declares no offer" : `brand declares ${ids.length} offers`,
     };
   };
 }

--- a/tests/unit/campaign-offer-backfill.test.ts
+++ b/tests/unit/campaign-offer-backfill.test.ts
@@ -100,7 +100,7 @@ describe("backfillCampaignOffers", () => {
     const resolve = vi.fn(async (brandId: string) =>
       brandId === "brand-1"
         ? resolved("offer-a")
-        : ({ offerId: null, reason: "brand declares 2 active offers" } as OfferResolution),
+        : ({ offerId: null, reason: "brand declares 2 offers" } as OfferResolution),
     );
 
     const result = await backfillCampaignOffers(sql, resolve, { dryRun: false });
@@ -108,7 +108,7 @@ describe("backfillCampaignOffers", () => {
     expect(result.written).toBe(1);
     expect(updates).toEqual([{ offerId: "offer-a", campaignId: "c1" }]);
     expect(result.unresolved).toEqual([
-      { campaignId: "c2", orgId: "org-2", brandId: "brand-2", reason: "brand declares 2 active offers" },
+      { campaignId: "c2", orgId: "org-2", brandId: "brand-2", reason: "brand declares 2 offers" },
     ]);
   });
 
@@ -182,8 +182,19 @@ describe("makeOfferResolver", () => {
     return Promise.resolve({ ok, status, json: async () => body } as Response);
   }
 
-  it("resolves a brand declaring exactly one active offer, naming the org on the wire", async () => {
-    const spy = withFetch(() => jsonResponse({ offers: [{ id: "offer-a", active: true }] }));
+  // The fixtures below carry brand-service's REAL wire shape, read off its deployed
+  // route: { offers: [{ offerId, brandId, name, createdAt, updatedAt }] }. They used
+  // to carry a guessed one ({ id, active }), written before that route existed.
+  const wireOffer = (offerId: string, name: string) => ({
+    offerId,
+    brandId: "brand-1",
+    name,
+    createdAt: "2026-08-19T00:00:00.000Z",
+    updatedAt: "2026-08-19T00:00:00.000Z",
+  });
+
+  it("resolves a brand declaring exactly one offer, naming the org on the wire", async () => {
+    const spy = withFetch(() => jsonResponse({ offers: [wireOffer("offer-a", "Starter")] }));
 
     const result = await makeOfferResolver("https://brand.test.local", "key")("brand-1", "org-1");
 
@@ -196,22 +207,27 @@ describe("makeOfferResolver", () => {
   });
 
   it("refuses to pick when a brand declares several — no offer is invented", async () => {
-    const spy = withFetch(() => jsonResponse({ offers: [{ id: "offer-a" }, { id: "offer-b" }] }));
+    const spy = withFetch(() =>
+      jsonResponse({ offers: [wireOffer("offer-a", "Starter"), wireOffer("offer-b", "Enterprise")] }),
+    );
 
     const result = await makeOfferResolver("https://brand.test.local", "key")("brand-1", "org-1");
 
     expect(result.offerId).toBeNull();
-    expect(result.reason).toContain("2 active offers");
+    expect(result.reason).toContain("2 offers");
     spy.mockRestore();
   });
 
-  it("ignores an inactive offer — a brand's live offer is the one it still sells", async () => {
+  // An offer has no liveness flag: it is the FUNNELS under it that switch on and off.
+  // A resolver that filtered on one would do nothing today and silently drop offers the
+  // day brand-service adds an unrelated field by that name.
+  it("does not filter on a liveness flag an offer does not have", async () => {
     const spy = withFetch(() =>
-      jsonResponse({ offers: [{ id: "offer-a", active: false }, { id: "offer-b", active: true }] }),
+      jsonResponse({ offers: [{ ...wireOffer("offer-a", "Starter"), active: false }] }),
     );
 
     expect(await makeOfferResolver("https://brand.test.local", "key")("brand-1", "org-1")).toEqual({
-      offerId: "offer-b",
+      offerId: "offer-a",
     });
     spy.mockRestore();
   });


### PR DESCRIPTION
## What

The offer resolver used by the campaign backfill was written **before** brand-service's offers route existed, so it targeted a guessed body:

```
{ offers: [{ id, active }] }        ← guessed
{ offers: [{ offerId, brandId, name, createdAt, updatedAt }] }   ← what actually ships
```

The path was right. The body was not.

## Why this matters even though it "worked"

It happened to work by tolerance — `o?.id ?? o?.offerId` fell through to the real field, and `active !== false` is true when the field is absent. That is the worst way for it to be wrong: **correct today, and documenting a contract nobody serves.**

## There is no `active` on an offer

An offer is a proposition a brand states. It is the **funnels underneath it** that switch on and off, which is why brand-service's funnel read is the one that says "active only".

So the filter read as a deliberate liveness check while doing nothing — and would start **silently dropping offers** the day brand-service adds an unrelated field by that name. An offer's existence is the answer.

## The fixtures agreed with the guess

They carried the guessed shape too, so they could not have caught it. They now carry the real one, read off the deployed route, plus a guard that pins the absence of the liveness filter:

```ts
it("does not filter on a liveness flag an offer does not have", async () => {
  const spy = withFetch(() =>
    jsonResponse({ offers: [{ ...wireOffer("offer-a", "Starter"), active: false }] }),
  );
  expect(await resolver("brand-1", "org-1")).toEqual({ offerId: "offer-a" });
});
```

## Timing

**No backfill has run.** This lands before the first one, which is exactly why the guess was isolated in one injectable function to begin with.

## Verified

`tsc --noEmit` clean (raw, not the wrapper's parse) · **349 unit tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
