### PR TITLE
fix(offer-backfill): an offer belongs to the (org, brand) pair, and the backfill is re-runnable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,13 +381,37 @@ attribution and on the customer's screen.
   one (funnel, channel). Widening it is the same later wave that makes the field required.
 - **Nothing reads it** — no pacing, funding, selection, gate or provisioning decision. It is stored
   and served, and `idx_campaigns_org_offer` serves the per-offer attribution read it exists for.
+- **AN OFFER BELONGS TO THE (ORG, BRAND) PAIR, NOT TO THE BRAND** — the same rule as every other
+  per-brand configuration this service reads. brand-service's `brand_offers` is keyed on
+  `(org_id, brand_id, name)`, so a brand claimed by ten orgs carries TEN offers, one per claiming
+  org, frequently all named the same thing. "This brand has an offer" is therefore not a question
+  this service can act on: resolving a campaign's offer by brand alone would write ANOTHER org's
+  offer id onto this org's campaign, a cross-org attribution inside the very per-offer grouping the
+  column exists to make correct. `makeOfferResolver` names `x-org-id` for exactly that reason, and
+  it is load-bearing, not tracking.
+- **The 145 campaigns that state no offer in prod are not a backfill that missed them.** Re-run
+  2026-08-19 after brand-service finished creating its offers (last one 09:22Z): NOT ONE is
+  attributable. 38 name no brand at all. The other 107 name a brand that does have offers — but
+  their OWN org claims that brand in brand-service for none of them, and 143 of the 145 belong to
+  two orgs (`8c734aed`, `dff98ee0`) brand-service does not know at all: no claim, no offer, nobody
+  to ask. Every one of them is stopped, and no ongoing campaign is unattributed. So the offer grain
+  under-counting against the brand headline for those brands is a brand-service claim gap, not a
+  coverage gap here, and the honest answer stays NULL until their pair gets an offer.
 - **The backfill is a SCRIPT, not the migration** (`scripts/backfill-campaign-offer.ts`): resolving a
   campaign's brand to its offer is a brand-service READ and SQL cannot make one, so migration 0050
   adds the column and backfills nothing. The script resolves once per (org, brand) pair, writes only
   rows still NULL (so a re-run is a no-op and it can never overwrite an offer a live create just
-  stated), **dry-runs by default** (`--apply` writes), and LEAVES ALONE + reports any brand that does
+  stated), **dry-runs by default** (`--apply` writes), and LEAVES ALONE + reports any pair that does
   not resolve to exactly one offer. Nothing is guessed for those. The previous value is NULL by
   construction, so the undo is exactly the ids the run prints, which it emits as a statement.
+  It is **RE-RUNNABLE, not one-shot** — brand-service keeps creating offers, so a campaign
+  unattributable today becomes attributable the day its pair gets one, and the fix for that is to
+  run this again, never to widen what it is willing to guess. Two things it refuses to guess:
+  a campaign naming SEVERAL brands (the array fallback fires only when it names exactly one — a
+  bare `brand_ids[1]` reads a multi-brand campaign as a campaign of whichever brand sorted first),
+  and a pair with no single offer. Only the SECOND exits non-zero: a campaign that names no single
+  brand is the permanent honest answer and never changes, so failing the run on it would make this
+  job red forever and teach everyone to ignore its exit code.
 
 ## Nothing can be unattributable — so nothing holds a brand's provisioning back
 

--- a/scripts/backfill-campaign-offer.ts
+++ b/scripts/backfill-campaign-offer.ts
@@ -1,15 +1,32 @@
 /**
- * One-shot backfill: every existing campaign states the OFFER it sells.
+ * Backfill: every campaign that CAN be attributed states the OFFER it sells.
  *
  * A campaign is (offer x sales funnel x acquisition channel). Migration 0050 adds `offer_id` and
  * backfills NOTHING, because resolving a campaign's brand to its offer is a brand-service READ and
  * SQL cannot make one. This script makes it.
  *
- * Every brand has exactly one offer at the moment this runs — brand-service ships that migration
- * in the same wave — so this is a RESOLUTION, not a guess. Where a brand does not resolve to
- * exactly one offer, the campaign is LEFT ALONE and REPORTED. Nothing is ever inferred from the
- * funnel, the goal or the workflow: several offers legitimately sell through one funnel, which is
- * the whole reason the dimension exists, so picking one would invent an attribution.
+ * NOT one-shot, and that is the whole point. brand-service keeps creating offers, so a campaign
+ * that was unattributable when this last ran becomes attributable the moment its (org, brand) pair
+ * gets one. Coverage is therefore a thing to RE-RUN, not a thing to have done once: it resolves
+ * against whatever brand-service answers TODAY, writes only the rows still missing an offer, and
+ * can be run again tomorrow to pick up whatever became attributable in between.
+ *
+ * AN OFFER BELONGS TO THE (ORG, BRAND) PAIR, NOT TO THE BRAND, and that is what the remaining
+ * production gap turns out to be. Re-run 2026-08-19 after brand-service finished creating its
+ * offers: 145 campaigns state none, and NOT ONE of them is attributable. 38 name no brand. The
+ * other 107 name a brand that does have offers — but one per CLAIMING ORG (brand
+ * `f4d73dab` carries ten, one for each of its ten claiming orgs), and the campaign's own org
+ * claims that brand in brand-service for none of the 107. 143 of them belong to two orgs
+ * (`8c734aed`, `dff98ee0`) that brand-service does not know at all: no claim, no offer.
+ * So "the brand has exactly one offer" is not the question this can act on. Reading the brand's
+ * offer without naming the org would attribute one org's campaign to ANOTHER org's offer — a
+ * cross-org write into the very per-offer grouping this column exists to make correct. The 107
+ * stay unattributed until their own pair gets an offer, and a re-run picks them up when it does.
+ *
+ * Where a pair does not resolve to exactly one offer, the campaign is LEFT ALONE and REPORTED.
+ * Nothing is ever inferred from the funnel, the goal or the workflow: several offers legitimately
+ * sell through one funnel, which is the whole reason the dimension exists, so picking one would
+ * invent an attribution.
  *
  * Idempotent: it only ever selects and writes rows whose `offer_id` is still NULL, and the UPDATE
  * re-states that guard, so a second run writes nothing and a run racing a live create cannot
@@ -39,10 +56,23 @@ export type OfferResolution =
   | { offerId: string; reason?: undefined }
   | { offerId: null; reason: string };
 
+/**
+ * Why a campaign was left alone, and whether that is an ANSWER or a GAP.
+ *
+ * - `unattributable` — the campaign names no brand, or names several. There is nobody to ask, and
+ *   guessing is the one thing this must never do. Absence IS the honest answer, permanently: it
+ *   does not become attributable later, so a re-run reporting these is a re-run that worked.
+ * - `gap` — the campaign names exactly one brand and that brand did not resolve to exactly one
+ *   offer (none yet, several, or brand-service could not be read). Somebody must answer this, and
+ *   a later re-run may well pick it up on its own.
+ */
+export type UnresolvedKind = "unattributable" | "gap";
+
 export interface UnresolvedCampaign {
   campaignId: string;
   orgId: string;
   brandId: string | null;
+  kind: UnresolvedKind;
   reason: string;
 }
 
@@ -122,14 +152,30 @@ export async function backfillCampaignOffers(
 ): Promise<BackfillResult> {
   const dryRun = options.dryRun !== false;
 
-  // `brand_id` is the stored half of the campaign identity (migration 0044); the historical
-  // multi-brand rows only carry the array, so fall back to its first element exactly as 0044 did.
+  // `brand_id` is the stored half of the campaign identity (migration 0044); the historical rows
+  // only carry the array, so fall back to it — but ONLY when it names exactly ONE brand. Taking
+  // `brand_ids[1]` unconditionally reads a campaign of several brands as a campaign of its first,
+  // which is exactly the guess this script exists not to make: the offer written would be one
+  // brand's answer standing in for a question nobody asked. `brand_count` is what tells the two
+  // apart downstream, so "names no brand" and "names several" are reported as the different facts
+  // they are rather than both collapsing to a silent NULL.
   const rows = (await querySql`
-    SELECT "id", "org_id", coalesce("brand_id", "brand_ids"[1]) AS "brand_id"
+    SELECT
+      "id",
+      "org_id",
+      CASE
+        WHEN "brand_id" IS NOT NULL THEN "brand_id"
+        WHEN coalesce(array_length("brand_ids", 1), 0) = 1 THEN "brand_ids"[1]
+        ELSE NULL
+      END AS "brand_id",
+      CASE
+        WHEN "brand_id" IS NOT NULL THEN 1
+        ELSE coalesce(array_length("brand_ids", 1), 0)
+      END AS "brand_count"
     FROM "campaigns"
     WHERE "offer_id" IS NULL
     ORDER BY "created_at"
-  `) as unknown as Array<{ id: string; org_id: string; brand_id: string | null }>;
+  `) as unknown as Array<{ id: string; org_id: string; brand_id: string | null; brand_count: number }>;
 
   console.log(`Found ${rows.length} campaign(s) with no offer stated`);
 
@@ -143,7 +189,11 @@ export async function backfillCampaignOffers(
         campaignId: row.id,
         orgId: row.org_id,
         brandId: null,
-        reason: "campaign states no brand",
+        kind: "unattributable",
+        reason:
+          Number(row.brand_count) > 1
+            ? `campaign states ${row.brand_count} brands`
+            : "campaign states no brand",
       });
       continue;
     }
@@ -160,6 +210,7 @@ export async function backfillCampaignOffers(
         campaignId: row.id,
         orgId: row.org_id,
         brandId: row.brand_id,
+        kind: "gap",
         reason: resolution.reason,
       });
       continue;
@@ -201,10 +252,33 @@ async function main() {
 
   console.log(`\n${result.written} campaign(s) ${dryRun ? "would be" : ""} written, ${result.unresolved.length} left alone`);
 
-  if (result.unresolved.length > 0) {
-    console.error("\nLEFT ALONE — their brand does not resolve to exactly one offer. No offer is invented for these:");
-    for (const u of result.unresolved) {
-      console.error(`  campaign ${u.campaignId} (org ${u.orgId}, brand ${u.brandId ?? "none"}): ${u.reason}`);
+  const unattributable = result.unresolved.filter((u) => u.kind === "unattributable");
+  const gaps = result.unresolved.filter((u) => u.kind === "gap");
+
+  if (unattributable.length > 0) {
+    // Not a failure and not a to-do: there is no brand to ask, so no offer can honestly be stated.
+    // Reported as a count rather than a list — it is the same permanent set on every re-run.
+    console.log(
+      `\n${unattributable.length} campaign(s) name no single brand, so nothing can be asked for them — they stay unattributed, correctly.`,
+    );
+  }
+
+  if (gaps.length > 0) {
+    // Grouped by (org, brand): the reason is a property of the PAIR, not of each campaign, so one
+    // line per campaign prints the same sentence a hundred times and buries how many distinct
+    // things are actually unanswered. Six pairs is a report somebody reads; 107 lines is not.
+    const byPair = new Map<string, { orgId: string; brandId: string; reason: string; campaigns: number }>();
+    for (const u of gaps) {
+      const key = `${u.orgId}::${u.brandId}`;
+      const entry = byPair.get(key);
+      if (entry) entry.campaigns++;
+      else byPair.set(key, { orgId: u.orgId, brandId: u.brandId!, reason: u.reason, campaigns: 1 });
+    }
+    console.error(
+      `\nLEFT ALONE — ${gaps.length} campaign(s) across ${byPair.size} (org, brand) pair(s) whose brand does not resolve to exactly one offer. No offer is invented for these:`,
+    );
+    for (const p of byPair.values()) {
+      console.error(`  org ${p.orgId}, brand ${p.brandId} (${p.campaigns} campaign(s)): ${p.reason}`);
     }
   }
 
@@ -215,9 +289,11 @@ async function main() {
 
   await sql.end();
 
-  // A campaign left alone is a real gap somebody must answer, so the run reports it as a failure
-  // — the writes that did land stay, and re-running after the gap is closed picks up only those.
-  if (result.unresolved.length > 0) process.exit(1);
+  // A GAP is a real thing somebody must answer, so the run reports it as a failure — the writes
+  // that did land stay, and re-running after the gap is closed picks up only those. A campaign
+  // that names no single brand is NOT a gap: it is the honest answer and it never changes, so
+  // failing on it would make this job red forever and teach everyone to ignore its exit code.
+  if (gaps.length > 0) process.exit(1);
 }
 
 // Only run main() when executed directly (not imported in tests)

--- a/tests/unit/campaign-offer-backfill.test.ts
+++ b/tests/unit/campaign-offer-backfill.test.ts
@@ -31,8 +31,8 @@ function createMockSql(rows: Record<string, unknown>[]) {
   return { sql: fn as unknown as Parameters<typeof backfillCampaignOffers>[0], updates };
 }
 
-function row(id: string, orgId = "org-1", brandId: string | null = "brand-1") {
-  return { id, org_id: orgId, brand_id: brandId };
+function row(id: string, orgId = "org-1", brandId: string | null = "brand-1", brandCount = brandId ? 1 : 0) {
+  return { id, org_id: orgId, brand_id: brandId, brand_count: brandCount };
 }
 
 function resolved(offerId: string): OfferResolution {
@@ -108,7 +108,7 @@ describe("backfillCampaignOffers", () => {
     expect(result.written).toBe(1);
     expect(updates).toEqual([{ offerId: "offer-a", campaignId: "c1" }]);
     expect(result.unresolved).toEqual([
-      { campaignId: "c2", orgId: "org-2", brandId: "brand-2", reason: "brand declares 2 offers" },
+      { campaignId: "c2", orgId: "org-2", brandId: "brand-2", kind: "gap", reason: "brand declares 2 offers" },
     ]);
   });
 
@@ -121,8 +121,51 @@ describe("backfillCampaignOffers", () => {
     expect(resolve).not.toHaveBeenCalled();
     expect(updates).toEqual([]);
     expect(result.unresolved).toEqual([
-      { campaignId: "c1", orgId: "org-1", brandId: null, reason: "campaign states no brand" },
+      {
+        campaignId: "c1",
+        orgId: "org-1",
+        brandId: null,
+        kind: "unattributable",
+        reason: "campaign states no brand",
+      },
     ]);
+  });
+
+  // A campaign of several brands arrives with a NULL brand and a count > 1 (the SELECT refuses to
+  // hand back a first element). It must read as "names several", not as "names none": the two are
+  // different facts, and only the count can tell them apart once the id is gone.
+  it("never picks one of several brands, and says so", async () => {
+    const { sql, updates } = createMockSql([row("c1", "org-1", null, 3)]);
+    const resolve = vi.fn();
+
+    const result = await backfillCampaignOffers(sql, resolve, { dryRun: false });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(updates).toEqual([]);
+    expect(result.unresolved).toEqual([
+      {
+        campaignId: "c1",
+        orgId: "org-1",
+        brandId: null,
+        kind: "unattributable",
+        reason: "campaign states 3 brands",
+      },
+    ]);
+  });
+
+  // The SELECT is what protects the several-brand case, so it is asserted on the wire: a bare
+  // `brand_ids[1]` would silently attribute a multi-brand campaign to whichever brand sorted first.
+  it("only falls back to the brand array when it names exactly one brand", async () => {
+    const seen: string[] = [];
+    const sql = (async (strings: TemplateStringsArray) => {
+      seen.push(strings.join("?"));
+      return [];
+    }) as unknown as Parameters<typeof backfillCampaignOffers>[0];
+
+    await backfillCampaignOffers(sql, async () => resolved("offer-a"), { dryRun: false });
+
+    expect(seen[0]).toMatch(/array_length\("brand_ids", 1\), 0\) = 1 THEN "brand_ids"\[1\]/);
+    expect(seen[0]).toMatch(/ELSE NULL/);
   });
 
   it("re-running changes nothing: it selects and writes only rows whose offer is still NULL", async () => {


### PR DESCRIPTION
## What

The offer attribution left **145 campaigns unattributed**. The brief's premise was that 107 of them were attributable today and had merely been walked before brand-service finished creating production's offers (last one landed 09:22Z).

Re-run against production after that: **not one of the 145 is attributable**, and the reason is a grain the resolver was right about all along.

## Why they are not attributable

brand-service keys `brand_offers` on `(org_id, brand_id, name)`. **An offer belongs to the (org, brand) pair, not to the brand** — the same rule as every other per-brand configuration this service reads. Brand `f4d73dab` carries **ten** offers, one per claiming org, all named the same thing.

So "this brand has exactly one offer" is not a question this service can act on:

| | |
|---|---|
| 38 campaigns | name no brand at all — correctly unattributable, permanently |
| 107 campaigns | name a brand that has offers, but **their own org claims that brand for none of them** |
| 143 of the 145 | belong to two orgs (`8c734aed`, `dff98ee0`) brand-service does not know at all: no claim, no offer, nobody to ask |

Resolving by brand alone would write one org's offer id onto another org's campaign — a cross-org attribution inside the very per-offer grouping the column exists to make correct.

The offer grain under-counting against the brand headline for those brands is therefore a **brand-service claim gap, not a coverage gap here**. Every one of the 145 is `stopped`; **no ongoing campaign is unattributed**.

## What changes

The script, which is the thing that closes the gap when those pairs do get offers:

- **Re-runnable by intent, not by accident.** brand-service keeps creating offers, so a campaign unattributable today becomes attributable the day its pair gets one. The answer is to run this again, never to widen what it is willing to guess.
- **It no longer picks one of SEVERAL brands.** The brand-array fallback fired unconditionally on `brand_ids[1]`, reading a multi-brand campaign as a campaign of whichever brand sorted first — the exact guess this script exists not to make. It now falls back only when the array names exactly one brand, and reports `states N brands` as the distinct fact it is.
- **Only a real GAP fails the run.** A campaign naming no single brand is the permanent honest answer and never becomes attributable, so exiting non-zero on it would make this job red forever and teach everyone to ignore its exit code. A pair that does not resolve to one offer still fails — somebody must answer that.
- **The gap report groups by (org, brand).** The reason is a property of the pair, so one line per campaign printed the same sentence 107 times and buried how many distinct things are unanswered.

## Verified against production, read back from the database

Ran `--apply` in the prod container, then read the DB directly rather than the run's own log:

```
 no_offer | with_offer | total | no_brand | ongoing_unattributed
      145 |        555 |   700 |       38 |                    0
```

- Already-attributed campaigns untouched (555, unchanged).
- The 38 naming no brand are still unattributed.
- A second run writes nothing — both the SELECT and the UPDATE guard on `offer_id IS NULL`.

Positive control on the resolver, so "no offer" is brand-service's real answer and not a broken read:

```
org that HAS an offer     200 {"offers":[{"offerId":"2000036a-…","name":"Default Offer",…}]}
campaign's own org        200 {"offers":[]}
```

## Tests

351 unit tests pass. New coverage: never picks one of several brands, the SELECT's one-brand-only fallback asserted on the wire, and the `unattributable` / `gap` split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
