### PR TITLE
feat(offers): ask brand-service for the funnels of the OFFER, not of the brand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,8 +379,11 @@ attribution and on the customer's screen.
 - **It is NOT part of the identity key.** `uniq_campaigns_org_brand_funnel_channel` is untouched:
   widening it while the field is optional would let one brand grow unlimited offer-less campaigns on
   one (funnel, channel). Widening it is the same later wave that makes the field required.
-- **Nothing reads it** — no pacing, funding, selection, gate or provisioning decision. It is stored
-  and served, and `idx_campaigns_org_offer` serves the per-offer attribution read it exists for.
+- **It decides no MONEY question** — no pacing, funding, gate or ranking decision reads it, and
+  `idx_campaigns_org_offer` serves the per-offer attribution read it exists for. Since 2026-08-19 it
+  decides exactly ONE thing: WHICH QUESTION this service asks brand-service about the funnels sold
+  here (next section). That is a grain, not a lever — no campaign runs, stops, or spends differently
+  because of the value.
 - **AN OFFER BELONGS TO THE (ORG, BRAND) PAIR, NOT TO THE BRAND** — the same rule as every other
   per-brand configuration this service reads. brand-service's `brand_offers` is keyed on
   `(org_id, brand_id, name)`, so a brand claimed by ten orgs carries TEN offers, one per claiming
@@ -412,6 +415,43 @@ attribution and on the customer's screen.
   and a pair with no single offer. Only the SECOND exits non-zero: a campaign that names no single
   brand is the permanent honest answer and never changes, so failing the run on it would make this
   job red forever and teach everyone to ignore its exit code.
+
+## "Which funnels are sold here?" is asked of the OFFER — the only grain with ONE answer
+
+An offer owns its own value proposition AND its own declared sales funnels with their own
+economics, so "the funnels of brand X" stopped having one answer the day a brand could sell
+several. brand-service says so itself: it REFUSES a brand-keyed
+`GET /internal/brands/:id/sales-funnels` on a brand holding more than one offer rather than guessing
+which one the caller meant. A campaign already STATES the offer it sells, so the unambiguous
+question is `GET /internal/offers/:offerId/sales-funnels` — keyed on the offer alone, one answer per
+offer, ten answers on the brand ten orgs claim.
+
+- **Three outcomes, never one `null`.** `SalesFunnelsRead`
+  (`src/lib/brand-sales-funnels-client.ts`) is `{ok, funnels}` | `{ok:false, reason:
+  "ambiguous" | "unavailable" | "unknown_offer"}`. Collapsing them is what made the offer level
+  SILENT rather than merely broken: any non-2xx read as "declares nothing", so the day a customer
+  creates their second offer the brand's campaigns simply stop being provisioned, with nothing
+  crashing and nothing logged about an offer anywhere. An EMPTY list stays a truthful answer and is
+  NOT logged (it is the routine state of a brand that has declared nothing); a REFUSAL warns that it
+  is a refusal, in those words. `tests/unit/no-legacy.test.ts` fails on a nullable return here.
+- **`ambiguous` is matched on the STATUS and on the CODE.** 409 is enough on its own, and
+  `OFFER_REQUIRED` / `MULTIPLE_OFFERS` / `AMBIGUOUS_OFFER` / `ORG_REQUIRED` are matched whatever
+  status they arrive dressed in — a refusal read as an empty set is the whole failure mode, so it
+  must not depend on brand-service keeping one status forever.
+- **Asked over the WHOLE claimed group, once per distinct offer.** `resolveDeclaredFunnels`
+  (`funnel-campaigns.ts`) reads one offer at a time and unions the answers, keeping which offer
+  declared each funnel. The brand-keyed read is made ONLY when a campaign of the group states no
+  offer — so a campaign that states none behaves exactly as it did before offers existed, and a
+  brand whose campaigns all state one never makes the read that would be refused.
+- **A funnel SEVERAL offers of one brand declare is provisioned for NEITHER, loudly.** They are
+  equals and none outranks another, so there is no offer to file a new campaign under; picking one
+  would rank it on another product's economics. It waits for a caller that says which offer it
+  means. Same rule, same reason, as never resolving a brand to one of its offers.
+- **A campaign provisioned from an offer's declaration CARRIES that offer** (`offerId` on the
+  insert). Still carried, never derived: the value comes from the campaign whose declaration put the
+  funnel in scope, not from the funnel, the goal or the workflow.
+- The idle-brand funding sweep asks the same way, off its seed row's `offer_id`.
+(Set 2026-08-19.)
 
 ## Nothing can be unattributable — so nothing holds a brand's provisioning back
 

--- a/src/lib/brand-sales-funnels-client.ts
+++ b/src/lib/brand-sales-funnels-client.ts
@@ -25,64 +25,172 @@ export interface DeclaredSalesFunnel {
 }
 
 /**
- * Read the funnels a brand has declared it sells through.
+ * The answer to "which funnels are sold through here?", with the three outcomes kept apart.
  *
- * Contract (brand-service): GET /internal/brands/{brandId}/sales-funnels (x-api-key [+ x-org-id])
- *   -> { funnels: [{ funnelKey, active, name, steps, rates, ... }] }
+ * They used to be one `null`, and that is what made the offer level dangerous: brand-service
+ * REFUSES a brand-keyed read on a brand holding several offers rather than guessing which one the
+ * caller meant, and a refusal collapsed onto `null` is indistinguishable from the service being
+ * unreachable and from the org having declared nothing at all. The consequence was silent — the
+ * day a customer creates their second offer, the brand simply looks like it declares no funnels
+ * and its campaigns stop being provisioned, with nothing logged about an offer anywhere.
  *
- * Returns null when the set could not be read (missing config, network error, non-2xx,
- * unparseable payload). Callers treat that as "no funnel information this tick" and leave the
- * brand exactly as it is — provisioning a campaign is not worth guessing a funnel for.
- *
- * An EMPTY list is a real answer, not a failure: the org has declared nothing yet. Per
- * brand-service's own contract we never substitute a plausible set for it.
- *
- * Only ACTIVE funnels are returned to the caller — a funnel the org switched off must never be
- * worked, whatever billing still holds a ceiling for.
+ *  - `ok` + funnels — a truthful answer. An EMPTY list is one of them: the org has declared
+ *    nothing yet, and per brand-service's own contract we never substitute a plausible set for it.
+ *  - `ambiguous` — brand-service will not answer at this grain because the key names more than one
+ *    configuration (several offers on the brand, or several orgs claiming it). This service asked
+ *    the wrong question; it is never treated as an empty set, and it is LOUD.
+ *  - `unavailable` — missing config, transport failure, non-2xx, unparseable payload. Nothing is
+ *    known this tick.
+ *  - `unknown_offer` — the offer id names nothing brand-service holds (404 on the offer read).
+ *    Distinct from `unavailable` because it does not fix itself by retrying.
  */
-export async function fetchDeclaredSalesFunnels(
-  brandId: string,
-  identity: IdentityHeaders,
-): Promise<DeclaredSalesFunnel[] | null> {
-  const url = process.env.BRAND_SERVICE_URL;
-  const apiKey = process.env.BRAND_SERVICE_API_KEY;
-  if (!url || !apiKey) return null;
+export type SalesFunnelsRead =
+  | { ok: true; funnels: DeclaredSalesFunnel[] }
+  | { ok: false; reason: "ambiguous" | "unavailable" | "unknown_offer"; detail: string };
 
+/**
+ * The refusal codes that mean "your key names more than one configuration, so there is no single
+ * answer" — whatever status brand-service dresses them in. Status 409 alone is enough; these are
+ * matched as well because a refusal must never be read as an empty set if it arrives as a 400.
+ */
+const AMBIGUITY_CODES = new Set([
+  "OFFER_REQUIRED",
+  "MULTIPLE_OFFERS",
+  "AMBIGUOUS_OFFER",
+  "ORG_REQUIRED",
+]);
+
+function headersFor(identity: IdentityHeaders, apiKey: string, brandId?: string): Record<string, string> {
   const headers: Record<string, string> = {
     "x-api-key": apiKey,
     // Per-brand configuration belongs to the (org, brand) pair — name the org rather than let
-    // brand-service pick one for a brand several orgs claim.
+    // brand-service pick one for a brand several orgs claim. An offer belongs to that same pair,
+    // so the org is named on the offer read too.
     "x-org-id": identity.orgId,
-    "x-brand-id": brandId,
   };
+  if (brandId) headers["x-brand-id"] = brandId;
   if (identity.userId) headers["x-user-id"] = identity.userId;
   if (identity.runId) headers["x-run-id"] = identity.runId;
   if (identity.campaignId) headers["x-campaign-id"] = identity.campaignId;
   if (identity.workflowSlug) headers["x-workflow-slug"] = identity.workflowSlug;
+  return headers;
+}
 
-  try {
-    const res = await fetch(
-      `${url.replace(/\/$/, "")}/internal/brands/${encodeURIComponent(brandId)}/sales-funnels`,
-      { headers },
-    );
-    if (!res.ok) return null;
+/** Only ACTIVE funnels reach a caller — a funnel the org switched off must never be worked. */
+function parseFunnels(data: unknown): DeclaredSalesFunnel[] | null {
+  const payload = data as { funnels?: Array<{ funnelKey?: string; active?: boolean }> };
+  if (!Array.isArray(payload?.funnels)) return null;
 
-    const data = await res.json() as {
-      funnels?: Array<{ funnelKey?: string; active?: boolean }>;
-    };
-    if (!Array.isArray(data.funnels)) return null;
-
-    const funnels: DeclaredSalesFunnel[] = [];
-    for (const raw of data.funnels) {
-      // Any spelling in, one canonical token out. A key neither catalogue names is skipped
-      // rather than worked: this service can only run a funnel it has a name for.
-      const funnelKey = toFunnelKey(raw?.funnelKey);
-      if (!funnelKey) continue;
-      if (raw.active === false) continue;
-      funnels.push({ funnelKey, active: true });
-    }
-    return funnels;
-  } catch {
-    return null;
+  const funnels: DeclaredSalesFunnel[] = [];
+  for (const raw of payload.funnels) {
+    // Any spelling in, one canonical token out. A key neither catalogue names is skipped rather
+    // than worked: this service can only run a funnel it has a name for.
+    const funnelKey = toFunnelKey(raw?.funnelKey);
+    if (!funnelKey) continue;
+    if (raw.active === false) continue;
+    funnels.push({ funnelKey, active: true });
   }
+  return funnels;
+}
+
+async function readSalesFunnels(
+  path: string,
+  headers: Record<string, string>,
+  baseUrl: string,
+  what: string,
+  // What a 404 means at this grain: an offer id that names nothing is a caller error that retrying
+  // never fixes; a brand-keyed 404 is just "nothing known this tick".
+  notFound: "unknown_offer" | "unavailable",
+): Promise<SalesFunnelsRead> {
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { headers });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      let code: string | undefined;
+      try {
+        const parsed = JSON.parse(body) as { code?: string; error?: { code?: string } };
+        code = parsed?.code ?? parsed?.error?.code;
+      } catch {
+        code = undefined;
+      }
+      if (res.status === 409 || (code && AMBIGUITY_CODES.has(code))) {
+        return {
+          ok: false,
+          reason: "ambiguous",
+          detail: `${what}: brand-service refuses this grain (${res.status}${code ? ` ${code}` : ""})`,
+        };
+      }
+      if (res.status === 404) {
+        return { ok: false, reason: notFound, detail: `${what}: 404` };
+      }
+      return { ok: false, reason: "unavailable", detail: `${what}: HTTP ${res.status}` };
+    }
+
+    const funnels = parseFunnels(await res.json());
+    if (!funnels) return { ok: false, reason: "unavailable", detail: `${what}: unparseable payload` };
+    return { ok: true, funnels };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: "unavailable", detail: `${what}: ${message}` };
+  }
+}
+
+/**
+ * Read the funnels ONE OFFER is sold through — the grain that has exactly one answer.
+ *
+ * Contract (brand-service): GET /internal/offers/{offerId}/sales-funnels (x-api-key)
+ *   -> { funnels: [{ funnelKey, active, name, steps, rates, ... }] }
+ *
+ * A campaign already states the offer it sells, so this is the question this service can always
+ * ask unambiguously: a brand selling ten offers has ten answers here and no ambiguity in any of
+ * them. A 404 is a caller error (an id that names nothing), NOT an unconfigured brand.
+ */
+export async function fetchOfferSalesFunnels(
+  offerId: string,
+  identity: IdentityHeaders,
+): Promise<SalesFunnelsRead> {
+  const url = process.env.BRAND_SERVICE_URL;
+  const apiKey = process.env.BRAND_SERVICE_API_KEY;
+  if (!url || !apiKey) {
+    return { ok: false, reason: "unavailable", detail: "brand-service not configured" };
+  }
+
+  return readSalesFunnels(
+    `/internal/offers/${encodeURIComponent(offerId)}/sales-funnels`,
+    headersFor(identity, apiKey),
+    url,
+    `offer ${offerId}`,
+    "unknown_offer",
+  );
+}
+
+/**
+ * Read the funnels a BRAND has declared it sells through — the pre-offer grain.
+ *
+ * Contract (brand-service): GET /internal/brands/{brandId}/sales-funnels (x-api-key [+ x-org-id])
+ *   -> { funnels: [...] }
+ *
+ * Kept for the one population it still answers for: a campaign that states NO offer, which
+ * behaves exactly as it did before offers existed. On a brand holding several offers this read is
+ * REFUSED (`ambiguous`) — that refusal is the whole reason the offer-grain read above exists, and
+ * it must never be laundered into an empty set here.
+ */
+export async function fetchBrandSalesFunnels(
+  brandId: string,
+  identity: IdentityHeaders,
+): Promise<SalesFunnelsRead> {
+  const url = process.env.BRAND_SERVICE_URL;
+  const apiKey = process.env.BRAND_SERVICE_API_KEY;
+  if (!url || !apiKey) {
+    return { ok: false, reason: "unavailable", detail: "brand-service not configured" };
+  }
+
+  return readSalesFunnels(
+    `/internal/brands/${encodeURIComponent(brandId)}/sales-funnels`,
+    headersFor(identity, apiKey, brandId),
+    url,
+    `brand ${brandId}`,
+    "unavailable",
+  );
 }

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -11,7 +11,11 @@ import {
 import { fetchFeatureSalesFunnels } from "./feature-sales-funnels-client.js";
 import { fetchActiveWorkflowSlugForFeature } from "./feature-workflow-client.js";
 import type { SalesFunnelKey } from "./sales-funnel-vocabulary.js";
-import { fetchDeclaredSalesFunnels, type DeclaredSalesFunnel } from "./brand-sales-funnels-client.js";
+import {
+  fetchBrandSalesFunnels,
+  fetchOfferSalesFunnels,
+  type SalesFunnelsRead,
+} from "./brand-sales-funnels-client.js";
 import { isSalesOutreachFeature, SALES_OUTREACH_FEATURE_SLUGS } from "./sales-outreach-campaign.js";
 import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 import { campaignIdentityColumns } from "./campaign-identity.js";
@@ -52,6 +56,12 @@ export interface ClaimedFunnelCampaign {
   funnelKey: string | null;
   /** The mirror of this campaign's funnel ceiling. Stated → it IS the ceiling this campaign runs on. */
   dailyBudgetCents: number | null;
+  /**
+   * The offer this campaign sells — brand-service's id, carried and never derived. It is what
+   * makes "which funnels are sold here?" a question with ONE answer on a brand selling several
+   * offers. NULL is the pre-offer population and keeps the brand-keyed read it has always had.
+   */
+  offerId?: string | null;
 }
 
 /** One funnel campaign in the running to take the brand's next turn. */
@@ -186,7 +196,9 @@ async function planOneBrand(
 
   const funded = fundedPairs(budgets, featureSlug);
   if (funded.length > 0) {
-    const declared = await fetchDeclaredSalesFunnels(brandId, identity);
+    // Asked over the WHOLE group, not just the seed: a brand selling several offers has one
+    // campaign per offer in flight, and each is ranked on the funnels of the offer IT sells.
+    const declared = await resolveDeclaredFunnels(group, brandId, identity);
     await ensureFundedFunnelCampaigns({ seed, brandId, funded, declared, identity, now });
   }
 
@@ -272,6 +284,98 @@ function fundedPairs(
 }
 
 /**
+ * Which funnels are sold through this brand, and — for each of them — WHICH OFFER declares it.
+ *
+ * "The funnels of brand X" stopped having one answer the day a brand could sell several offers:
+ * each offer owns its own funnels and its own economics, and brand-service refuses a brand-keyed
+ * read on a brand holding more than one rather than picking one. A campaign already states the
+ * offer it sells, so the unambiguous question is asked per OFFER and the answers are unioned here.
+ */
+export interface ResolvedDeclaredFunnels {
+  /**
+   * funnelKey → the offer that declares it. NULL means it came from the BRAND-keyed read, i.e.
+   * from a campaign that states no offer — the pre-offer world, unchanged.
+   */
+  offerByFunnel: Map<SalesFunnelKey, string | null>;
+  /**
+   * Declared by SEVERAL offers of this brand. There is no single offer to file a new campaign
+   * under, and picking one would rank it on another product's economics — so nothing is
+   * provisioned for it and it is said out loud.
+   */
+  contested: Set<SalesFunnelKey>;
+}
+
+const NO_DECLARED_FUNNELS: ResolvedDeclaredFunnels = {
+  offerByFunnel: new Map(),
+  contested: new Set(),
+};
+
+/**
+ * Ask for the declared funnels at the grain that HAS one answer: once per distinct offer the
+ * brand's campaigns state, plus the brand-keyed read only when a campaign states no offer.
+ *
+ * A failure is never laundered into "the brand declares nothing" — that collapse is exactly what
+ * made the offer level silent. An ambiguity refusal says the grain was wrong (loudly, because it
+ * is this service's own question that was unanswerable), a transport failure says nothing is known
+ * this tick, and an EMPTY list is a truthful answer that is not logged at all: it is the routine
+ * state of a brand that has never declared a funnel, on every sweep of every client.
+ */
+async function resolveDeclaredFunnels(
+  group: Array<{ offerId?: string | null }>,
+  brandId: string,
+  identity: IdentityHeaders,
+): Promise<ResolvedDeclaredFunnels> {
+  const offerIds = [...new Set(group.map((c) => c.offerId).filter((id): id is string => !!id))];
+  const anyOfferless = group.some((c) => !c.offerId);
+
+  const offerByFunnel = new Map<SalesFunnelKey, string | null>();
+  const contested = new Set<SalesFunnelKey>();
+
+  const note = (read: SalesFunnelsRead, what: string): void => {
+    if (read.ok) return;
+    if (read.reason === "ambiguous") {
+      console.warn(
+        `[campaign-service] brand-service will not state the sales funnels of ${what} (brand ${brandId}) — ${read.detail}. Nothing is provisioned from it; this is a REFUSAL, not an empty declaration.`,
+      );
+      return;
+    }
+    console.warn(
+      `[campaign-service] Could not read the sales funnels of ${what} (brand ${brandId}) — ${read.detail} (${read.reason})`,
+    );
+  };
+
+  for (const offerId of offerIds) {
+    const read = await fetchOfferSalesFunnels(offerId, identity);
+    note(read, `offer ${offerId}`);
+    if (!read.ok) continue;
+    for (const f of read.funnels) {
+      const seen = offerByFunnel.get(f.funnelKey);
+      if (seen !== undefined && seen !== null && seen !== offerId) {
+        // Two offers of one brand sell through the same chain. Both are equals and neither
+        // outranks the other, so there is nobody to attribute a new campaign to.
+        contested.add(f.funnelKey);
+        continue;
+      }
+      offerByFunnel.set(f.funnelKey, offerId);
+    }
+  }
+
+  if (offerIds.length === 0 || anyOfferless) {
+    const read = await fetchBrandSalesFunnels(brandId, identity);
+    note(read, `brand ${brandId}`);
+    if (read.ok) {
+      for (const f of read.funnels) {
+        // An offer's own statement is the finer one and wins; the brand-keyed answer only fills
+        // what no offer named, which is the whole pre-offer population.
+        if (!offerByFunnel.has(f.funnelKey)) offerByFunnel.set(f.funnelKey, null);
+      }
+    }
+  }
+
+  return { offerByFunnel, contested };
+}
+
+/**
  * Make sure every funded (funnel, channel) pair of the brand HAS a campaign.
  *
  * The campaign STATES its funnel, and that statement is the whole vocabulary for what it sells.
@@ -309,22 +413,31 @@ async function ensureFundedFunnelCampaigns({
   seed: ClaimedFunnelCampaign;
   brandId: string;
   funded: FundedPair[];
-  declared: DeclaredSalesFunnel[] | null;
+  declared: ResolvedDeclaredFunnels;
   identity: IdentityHeaders;
   now: Date;
 }): Promise<void> {
   // No readable funnel declaration → nothing says the brand still sells through these funnels.
   // Provisioning waits; whatever campaigns already exist keep running.
-  if (!declared || declared.length === 0) return;
+  if (declared.offerByFunnel.size === 0) return;
   if (!seed.createdByUserId) return; // no recipient/owner to attribute a new campaign to
 
-  const declaredKeys = new Set(declared.map((f) => f.funnelKey));
   // One read per CHANNEL, not per pair: a brand funding both of a channel's funnels asks once.
   const sellableByFeature = new Map<string, Set<SalesFunnelKey> | null>();
   const workflowByFeature = new Map<string, string | null>();
 
   for (const f of funded) {
-    if (!declaredKeys.has(f.funnelKey)) continue;
+    if (declared.contested.has(f.funnelKey)) {
+      // Several offers of this brand sell through this chain. Provisioning one campaign would file
+      // it under one of them, i.e. rank it on another product's economics — so it waits for a
+      // caller that states which offer it means, and it is not silent about waiting.
+      console.warn(
+        `[campaign-service] Not provisioning funnel ${f.funnelKey} for brand ${brandId} — several offers of this brand declare it and none outranks another`,
+      );
+      continue;
+    }
+    const offerId = declared.offerByFunnel.get(f.funnelKey);
+    if (offerId === undefined) continue; // funded, but nobody declares selling through it
     const featureSlug = f.featureSlug;
 
     if (!sellableByFeature.has(featureSlug)) {
@@ -416,6 +529,9 @@ async function ensureFundedFunnelCampaigns({
         // NOT written any more: it could not tell the two meeting funnels apart, and a consumer
         // reading it reads a poorer statement of the same thing.
         funnelKey: f.funnelKey,
+        // The offer whose declaration is what put this funnel in scope. Carried, never derived:
+        // NULL when the funnel came from the brand-keyed read, which is the pre-offer world.
+        offerId: offerId ?? null,
         featureInputs: null,
         status: "ongoing",
         nextRunAt: now,
@@ -489,10 +605,11 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
     feature_slug: string;
     workflow_slug: string;
     created_by_user_id: string;
+    offer_id: string | null;
   }>(sql`
     SELECT DISTINCT ON (c.org_id, coalesce(c.brand_id, c.brand_ids[1]))
            c.id, c.org_id, coalesce(c.brand_id, c.brand_ids[1]) AS brand_id,
-           c.feature_slug, c.workflow_slug, c.created_by_user_id
+           c.feature_slug, c.workflow_slug, c.created_by_user_id, c.offer_id
     FROM campaigns c
     WHERE c.feature_slug IN (${sql.join(slugs.map((s) => sql`${s}`), sql`, `)})
       AND coalesce(c.brand_id, c.brand_ids[1]) IS NOT NULL
@@ -515,6 +632,7 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
     feature_slug: string;
     workflow_slug: string;
     created_by_user_id: string;
+    offer_id: string | null;
   }>);
   const examined = rows.slice(0, FUNDING_SWEEP_MAX_BRANDS);
   if (rows.length > FUNDING_SWEEP_MAX_BRANDS) {
@@ -542,7 +660,11 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
       // the brand having no ongoing campaign.
       if (funded.length === 0) continue;
 
-      const declared = await fetchDeclaredSalesFunnels(row.brand_id, identity);
+      const declared = await resolveDeclaredFunnels(
+        [{ offerId: row.offer_id }],
+        row.brand_id,
+        identity,
+      );
       const before = await countOngoingSalesCampaigns(row.org_id, row.brand_id);
       await ensureFundedFunnelCampaigns({
         seed: {
@@ -554,6 +676,7 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
           featureSlug: row.feature_slug,
           funnelKey: null,
           dailyBudgetCents: null,
+          offerId: row.offer_id,
         },
         brandId: row.brand_id,
         funded,

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -107,6 +107,9 @@ export async function reRunDueCampaigns(): Promise<number> {
       audienceId: campaigns.audienceId,
       funnelKey: campaigns.funnelKey,
       dailyBudgetCents: campaigns.dailyBudgetCents,
+      // The offer this campaign sells. The turn planner asks brand-service for the funnels of THAT
+      // offer — the only grain with one answer on a brand selling several.
+      offerId: campaigns.offerId,
     });
 
   if (dueCampaigns.length === 0) return 0;

--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -71,6 +71,57 @@ describe('No Legacy Patterns - CRITICAL', () => {
     expect(code).not.toMatch(/\bcurrentGoal\b/);
   });
 
+  it('should NOT collapse a sales-funnels refusal back onto a nullable answer', () => {
+    // The three outcomes — a truthful answer (possibly EMPTY), a refusal to answer at this grain,
+    // and a transport failure — were one `null`, and that is what made the offer level silent: the
+    // day a customer creates their second offer, brand-service refuses the brand-keyed read and the
+    // brand simply looks like it declares no funnels. Returning a nullable array again reinstates
+    // exactly that. The client returns a discriminated `SalesFunnelsRead` and nothing else.
+    const client = fs.readFileSync(
+      path.join(srcDir, 'lib/brand-sales-funnels-client.ts'),
+      'utf-8',
+    );
+    const code = client
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('*') && !l.trimStart().startsWith('/*') && !l.trimStart().startsWith('//'))
+      .join('\n');
+
+    expect(code).not.toMatch(/fetchDeclaredSalesFunnels/);
+    expect(code).not.toMatch(/Promise<DeclaredSalesFunnel\[\] \| null>/);
+    for (const fn of ['fetchOfferSalesFunnels', 'fetchBrandSalesFunnels']) {
+      expect(code).toMatch(new RegExp(`${fn}[\\s\\S]{0,400}?Promise<SalesFunnelsRead>`));
+    }
+  });
+
+  it('should NOT resolve a brand to ONE of its offers', () => {
+    // Several offers of one brand are equals and none outranks another. Picking one would rank a
+    // campaign on another product's economics and, across orgs, file one org's configuration onto
+    // another org's campaign — inside the very per-offer grouping the column exists to make
+    // correct. A campaign STATES its offer, or it has none.
+    const files = getAllTsFiles(srcDir);
+    const violations: { file: string; line: number; code: string }[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      content.split('\n').forEach((line, index) => {
+        const code = line.trimStart();
+        if (code.startsWith('*') || code.startsWith('/*') || code.startsWith('//')) return;
+        if (/offerForBrand|resolveOfferForBrand|primaryOffer|defaultOffer|firstOffer/.test(line)) {
+          violations.push({
+            file: path.relative(srcDir, file),
+            line: index + 1,
+            code: line.trim().substring(0, 80),
+          });
+        }
+      });
+    }
+
+    expect(
+      violations,
+      `A brand is never resolved to one of its offers:\n${violations.map(v => `  ${v.file}:${v.line}\n    ${v.code}`).join('\n')}`
+    ).toHaveLength(0);
+  });
+
   it('should NOT translate between a goal and a funnel anywhere in src', () => {
     // The goal was the poorer word (both meeting funnels collapse onto one `meetingBooked`) and it
     // was wrong at the source (brand-service's column carried a NOT NULL default). Both directions

--- a/tests/unit/offer-grain-funnels.test.ts
+++ b/tests/unit/offer-grain-funnels.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * A brand is a globally-shared identity and an OFFER belongs to the (org, brand) pair, so "which
+ * funnels does this brand sell through?" stops having one answer the day a customer creates their
+ * second offer. brand-service refuses the brand-keyed read at that point rather than guessing.
+ *
+ * These tests pin the two halves of the fix: the question is asked at the OFFER grain (which
+ * always has exactly one answer), and a refusal is never laundered into "declares nothing".
+ */
+
+const {
+  mockListRuns,
+  mockGetStatsBudget,
+  mockFindFirst,
+  mockFindMany,
+  mockInsertValues,
+  mockUpdateSet,
+  mockUpdateWhere,
+  mockDeleteWhere,
+} = vi.hoisted(() => ({
+  mockListRuns: vi.fn(),
+  mockGetStatsBudget: vi.fn(),
+  mockFindFirst: vi.fn(),
+  mockFindMany: vi.fn(),
+  mockInsertValues: vi.fn(),
+  mockUpdateSet: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+  mockDeleteWhere: vi.fn(),
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  listRuns: mockListRuns,
+  getStatsBudget: mockGetStatsBudget,
+}));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    query: { campaigns: { findFirst: mockFindFirst, findMany: mockFindMany } },
+    insert: vi.fn().mockReturnValue({ values: mockInsertValues }),
+    update: vi.fn().mockReturnValue({
+      set: (values: unknown) => {
+        mockUpdateSet(values);
+        return { where: mockUpdateWhere };
+      },
+    }),
+    delete: vi.fn().mockReturnValue({ where: mockDeleteWhere }),
+  },
+}));
+
+vi.mock("../../src/db/schema.js", () => ({
+  campaigns: {
+    id: "id",
+    orgId: "org_id",
+    featureSlug: "feature_slug",
+    funnelKey: "funnel_key",
+    brandIds: "brand_ids",
+    createdAt: "created_at",
+    status: "status",
+    offerId: "offer_id",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  asc: vi.fn(),
+  desc: vi.fn(),
+  isNull: vi.fn(),
+  inArray: vi.fn(),
+  arrayContains: vi.fn(),
+  sql: Object.assign(vi.fn(), { join: vi.fn() }),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import {
+  fetchOfferSalesFunnels,
+  fetchBrandSalesFunnels,
+} from "../../src/lib/brand-sales-funnels-client.js";
+import { planFunnelTurns, type ClaimedFunnelCampaign } from "../../src/lib/funnel-campaigns.js";
+import { SALES_FUNNEL_KEYS } from "../../src/lib/sales-funnel-vocabulary.js";
+
+const SALES = "sales-cold-email-outreach";
+const OFFER_A = "11111111-1111-4111-8111-111111111111";
+const OFFER_B = "22222222-2222-4222-8222-222222222222";
+
+const IDENTITY = { orgId: "org-1", userId: "user-1", campaignId: "campaign-1" };
+
+function claimed(overrides: Partial<ClaimedFunnelCampaign> = {}): ClaimedFunnelCampaign {
+  return {
+    id: "campaign-1",
+    orgId: "org-1",
+    createdByUserId: "user-1",
+    workflowSlug: "sales-email-cold-outreach",
+    brandIds: ["brand-1"],
+    featureSlug: SALES,
+    funnelKey: null,
+    dailyBudgetCents: null,
+    offerId: null,
+    ...overrides,
+  };
+}
+
+function funnelsPayload(funnels: Array<{ funnelKey: string; active?: boolean }>) {
+  return {
+    funnels: funnels.map((f) => ({
+      funnelKey: f.funnelKey,
+      active: f.active ?? true,
+      name: f.funnelKey,
+      steps: [],
+      rates: {},
+      lifetimeRevenueUsd: null,
+      destinationUrl: null,
+      bookingUrl: null,
+      updatedAt: "2026-08-19T00:00:00.000Z",
+    })),
+  };
+}
+
+/** billing still emits the pre-rename spellings — every ceiling below is stated its way. */
+function mockFunnelBudgets(funnels: Array<{ funnelKey: string; dailyBudgetCents: string }>) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      brandId: "brand-1",
+      dailyBudgetCents: String(funnels.reduce((s, f) => s + Number(f.dailyBudgetCents), 0)),
+      funnels: funnels.map((f) => ({ ...f, updatedAt: null })),
+    }),
+  });
+}
+
+function mockDeclared(funnels: Array<{ funnelKey: string; active?: boolean }>) {
+  mockFetch.mockResolvedValueOnce({ ok: true, json: async () => funnelsPayload(funnels) });
+}
+
+/** brand-service refusing to guess which offer (or org) the caller meant. */
+function mockRefusal(status: number, code?: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    text: async () => (code ? JSON.stringify({ code }) : ""),
+  });
+}
+
+function mockSpend(cents: string) {
+  mockGetStatsBudget.mockResolvedValueOnce({
+    windows: [{ label: "today", totalCostInUsdCents: cents, netTotalCostInUsdCents: cents }],
+  });
+}
+
+let warnings: string[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.BRAND_SERVICE_URL = "https://brand.test";
+  process.env.BRAND_SERVICE_API_KEY = "brand-key";
+  process.env.BILLING_SERVICE_URL = "https://billing.test";
+  process.env.BILLING_SERVICE_API_KEY = "billing-key";
+  process.env.FEATURES_SERVICE_URL = "https://features.test";
+  process.env.FEATURES_SERVICE_API_KEY = "features-key";
+  process.env.WORKFLOW_SERVICE_URL = "https://workflow.test";
+  process.env.WORKFLOW_SERVICE_API_KEY = "workflow-key";
+  // The per-CHANNEL reads (which funnels a channel may sell, which workflow runs it) are answered
+  // by URL, so the ordered `mockResolvedValueOnce` queue above keeps describing the
+  // billing → brand/offer sequence and nothing else.
+  mockFetch.mockImplementation(async (input: URL | string) => {
+    const url = String(input);
+    if (url.includes("/features/")) {
+      return { ok: true, json: async () => ({ salesFunnels: [...SALES_FUNNEL_KEYS] }) };
+    }
+    if (url.includes("/workflows")) {
+      return {
+        ok: true,
+        json: async () => ({
+          workflows: [{ workflowSlug: "seed-workflow", createdAt: "2026-08-18T00:00:00.000Z" }],
+        }),
+      };
+    }
+    throw new Error(`unexpected fetch in test: ${url}`);
+  });
+  mockListRuns.mockResolvedValue({ runs: [] });
+  mockFindMany.mockResolvedValue([{ id: "campaign-1", featureSlug: SALES }]);
+  mockFindFirst.mockResolvedValue(undefined);
+  mockInsertValues.mockResolvedValue(undefined);
+  warnings = [];
+  vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("sales-funnels reads keep the three outcomes apart", () => {
+  it("reads ONE offer's funnels at the offer grain, naming the org", async () => {
+    mockDeclared([{ funnelKey: "website_purchases" }]);
+
+    const read = await fetchOfferSalesFunnels(OFFER_A, IDENTITY);
+
+    expect(read).toEqual({ ok: true, funnels: [{ funnelKey: "website_purchases", active: true }] });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(`https://brand.test/internal/offers/${OFFER_A}/sales-funnels`);
+    expect(init.headers["x-org-id"]).toBe("org-1");
+  });
+
+  it("an EMPTY list is a truthful answer, not a failure", async () => {
+    mockDeclared([]);
+    await expect(fetchBrandSalesFunnels("brand-1", IDENTITY)).resolves.toEqual({
+      ok: true,
+      funnels: [],
+    });
+  });
+
+  it("a 409 refusal is `ambiguous` — never an empty declaration", async () => {
+    mockRefusal(409, "MULTIPLE_OFFERS");
+    const read = await fetchBrandSalesFunnels("brand-1", IDENTITY);
+    expect(read.ok).toBe(false);
+    expect(read).toMatchObject({ reason: "ambiguous" });
+  });
+
+  it("a refusal dressed as a 400 is still `ambiguous`, matched on its code", async () => {
+    mockRefusal(400, "OFFER_REQUIRED");
+    expect(await fetchBrandSalesFunnels("brand-1", IDENTITY)).toMatchObject({ reason: "ambiguous" });
+  });
+
+  it("a transport failure is `unavailable`, and is NOT the same answer as a refusal", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("ECONNRESET"));
+    expect(await fetchOfferSalesFunnels(OFFER_A, IDENTITY)).toMatchObject({ reason: "unavailable" });
+
+    mockRefusal(500);
+    expect(await fetchBrandSalesFunnels("brand-1", IDENTITY)).toMatchObject({
+      reason: "unavailable",
+    });
+  });
+
+  it("an offer id that names nothing is `unknown_offer` — retrying never fixes it", async () => {
+    mockRefusal(404);
+    expect(await fetchOfferSalesFunnels(OFFER_A, IDENTITY)).toMatchObject({
+      reason: "unknown_offer",
+    });
+  });
+
+  it("an inactive funnel is never returned, whatever ceiling billing still holds", async () => {
+    mockDeclared([{ funnelKey: "website_purchases", active: false }, { funnelKey: "form_magnet" }]);
+    expect(await fetchOfferSalesFunnels(OFFER_A, IDENTITY)).toEqual({
+      ok: true,
+      funnels: [{ funnelKey: "form_magnet", active: true }],
+    });
+  });
+});
+
+describe("provisioning asks at the grain that has one answer", () => {
+  it("a campaign stating NO offer keeps the brand-keyed read, exactly as before offers existed", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+    mockDeclared([{ funnelKey: "website_purchases" }]);
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ offerId: null })]);
+
+    const urls = mockFetch.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes("/internal/brands/brand-1/sales-funnels"))).toBe(true);
+    expect(urls.some((u) => u.includes("/internal/offers/"))).toBe(false);
+  });
+
+  it("a brand selling SEVERAL offers is still arbitrated — each campaign on its own offer's funnels", async () => {
+    // Two campaigns of one brand, each selling a different offer. The brand-keyed read would be
+    // refused here; the offer-keyed reads each have exactly one answer.
+    mockFunnelBudgets([
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      { funnelKey: "reply_meeting", dailyBudgetCents: "1000" },
+    ]);
+    mockDeclared([{ funnelKey: "website_purchases" }]); // offer A
+    mockDeclared([{ funnelKey: "sales_meetings_from_conversation" }]); // offer B
+    mockSpend("900"); // A is 90% full
+    mockSpend("100"); // B is 10% full
+
+    const now = new Date("2026-08-19T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-a", funnelKey: "website_purchases", offerId: OFFER_A }),
+        claimed({ id: "c-b", funnelKey: "sales_meetings_from_conversation", offerId: OFFER_B }),
+      ],
+      now,
+    );
+
+    const urls = mockFetch.mock.calls.map((c) => String(c[0]));
+    expect(urls).toContain(`https://brand.test/internal/offers/${OFFER_A}/sales-funnels`);
+    expect(urls).toContain(`https://brand.test/internal/offers/${OFFER_B}/sales-funnels`);
+    // No campaign of the group states no offer, so the ambiguous brand-keyed read is never made.
+    expect(urls.some((u) => u.includes("/internal/brands/brand-1/sales-funnels"))).toBe(false);
+    // Both funnels are declared, so both stay in the running and the emptiest takes the turn.
+    expect(deferred.has("c-b")).toBe(false);
+    expect(deferred.has("c-a")).toBe(true);
+    expect(warnings).toEqual([]);
+  });
+
+  it("a campaign provisioned from an offer's declaration CARRIES that offer", async () => {
+    mockFunnelBudgets([
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      { funnelKey: "reply_meeting", dailyBudgetCents: "1000" },
+    ]);
+    mockDeclared([
+      { funnelKey: "website_purchases" },
+      { funnelKey: "sales_meetings_from_conversation" },
+    ]);
+    mockSpend("0");
+
+    await planFunnelTurns([
+      claimed({ id: "c-a", funnelKey: "website_purchases", offerId: OFFER_A }),
+    ]);
+
+    const inserted = mockInsertValues.mock.calls.map((c) => c[0]);
+    const meeting = inserted.find((v) => v.funnelKey === "sales_meetings_from_conversation");
+    expect(meeting).toBeDefined();
+    expect(meeting.offerId).toBe(OFFER_A);
+  });
+
+  it("a REFUSAL provisions nothing and says so — it is not read as 'declares nothing'", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+    mockRefusal(409, "MULTIPLE_OFFERS"); // the brand-keyed read on a multi-offer brand
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ offerId: null })]);
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(warnings.join("\n")).toMatch(/REFUSAL, not an empty declaration/);
+  });
+
+  it("a transport failure is logged as a transport failure, not as a refusal", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+    mockFetch.mockRejectedValueOnce(new Error("ECONNRESET"));
+    mockSpend("0");
+
+    await planFunnelTurns([claimed({ offerId: null })]);
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(warnings.join("\n")).toMatch(/unavailable/);
+    expect(warnings.join("\n")).not.toMatch(/REFUSAL/);
+  });
+
+  it("a funnel SEVERAL offers of one brand declare is not provisioned for either — none outranks another", async () => {
+    mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
+    mockDeclared([{ funnelKey: "website_purchases" }]); // offer A
+    mockDeclared([{ funnelKey: "website_purchases" }]); // offer B sells the same chain
+    mockSpend("0");
+    mockSpend("0");
+
+    await planFunnelTurns([
+      claimed({ id: "c-a", funnelKey: "website_purchases", offerId: OFFER_A }),
+      claimed({ id: "c-b", funnelKey: "website_purchases", offerId: OFFER_B }),
+    ]);
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(warnings.join("\n")).toMatch(/several offers of this brand declare it/);
+  });
+
+  it("an offer's statement wins over the brand-keyed one when a group holds both", async () => {
+    // One campaign states an offer, another (older) states none — so both reads happen, and the
+    // funnel the offer named is filed under that offer rather than under nobody.
+    mockFunnelBudgets([
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      { funnelKey: "reply_meeting", dailyBudgetCents: "1000" },
+    ]);
+    mockDeclared([{ funnelKey: "website_purchases" }]); // offer A
+    mockDeclared([
+      { funnelKey: "website_purchases" },
+      { funnelKey: "sales_meetings_from_conversation" },
+    ]); // brand-keyed
+    mockSpend("0");
+    mockSpend("0");
+
+    await planFunnelTurns([
+      claimed({ id: "c-a", funnelKey: "website_purchases", offerId: OFFER_A }),
+      claimed({ id: "c-old", funnelKey: "sales_meetings_from_conversation", offerId: null }),
+    ]);
+
+    const urls = mockFetch.mock.calls.map((c) => String(c[0]));
+    expect(urls).toContain(`https://brand.test/internal/offers/${OFFER_A}/sales-funnels`);
+    expect(urls.some((u) => u.includes("/internal/brands/brand-1/sales-funnels"))).toBe(true);
+    expect(warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

An offer owns its own declared sales funnels and their economics, so *"which funnels does this brand sell through?"* stopped having one answer the day a brand could sell several offers. brand-service refuses the brand-keyed read on a brand holding more than one offer rather than guessing which one the caller meant.

This service collapsed **every** non-2xx from that read onto `null`, and `funnel-campaigns.ts` read `null` as *"the brand declares nothing"*. So the refusal was indistinguishable from brand-service being unreachable and from a truthful empty answer — and the consequence was **silent**: the day a customer creates their second offer, their brand simply looks like it declares no funnels and its campaigns stop being provisioned. Nothing crashes, nothing is logged as an offer problem.

Nothing is broken today because every brand still has exactly one offer. This bites the first time a customer uses the feature the platform just shipped.

## Change

- **`SalesFunnelsRead` keeps the three outcomes apart** (`src/lib/brand-sales-funnels-client.ts`): a truthful answer (possibly EMPTY), `ambiguous` (a refusal), `unavailable` (transport / non-2xx / unparseable) and `unknown_offer` (404 on an offer id that names nothing). `ambiguous` is matched on status 409 **and** on the refusal codes (`OFFER_REQUIRED`, `MULTIPLE_OFFERS`, `AMBIGUOUS_OFFER`, `ORG_REQUIRED`) whatever status they arrive dressed in — a refusal read as an empty set is the entire failure mode, so it must not depend on one status forever.
- **`fetchOfferSalesFunnels`** reads the deployed `GET /internal/offers/{offerId}/sales-funnels` — the grain with exactly one answer. A campaign already states the offer it sells, so the unambiguous question was already on the row.
- **`resolveDeclaredFunnels`** asks once per distinct offer the claimed group states, unions the answers and keeps which offer declared each funnel. The brand-keyed read is made **only** when a campaign of the group states no offer.
- **A funnel several offers of one brand declare is provisioned for neither, loudly.** They are equals, none outranks another, and picking one would rank a campaign on another product's economics.
- **A campaign provisioned from an offer's declaration carries that offer.** Carried, never derived.
- Logging follows this repo's discipline: a refusal and a transport failure warn (and say which they are); an empty answer is not logged at all, because it is the routine state of a brand that has declared nothing.

## Acceptance criteria

| Criterion | Where |
|---|---|
| A brand selling several offers is still arbitrated, each campaign on its own offer's funnels | `offer-grain-funnels.test.ts` — *"a brand selling SEVERAL offers is still arbitrated"* |
| A brand selling exactly one offer behaves as today | `funnel-campaigns.test.ts` (28 files / 367 unit tests, unchanged and green) |
| A campaign stating no offer behaves exactly as today | *"a campaign stating NO offer keeps the brand-keyed read"* — brand-keyed read made, no offer read |
| A refusal / a transport failure / a truthful empty answer are distinguishable, in code and in logs | the client tests + *"a REFUSAL provisions nothing and says so"* / *"a transport failure is logged as a transport failure"* |
| Regression coverage for the multi-offer case | new `tests/unit/offer-grain-funnels.test.ts` (14 tests) |

Two `no-legacy` pins added: the nullable return cannot come back, and a brand is never resolved to one of its offers.

## Not done, deliberately

- brand-service's refusal is not asked to change, and no funnel is inferred from a campaign's goal, funnel key or workflow.
- The idle-brand sweep still takes one seed row per (org, brand) and asks off that row's `offer_id`. A multi-offer **idle** brand therefore gets its most-recently-touched campaign's offer provisioned per sweep; widening that seed to one row per offer is a separate change and is not required by any acceptance criterion here.

## Tests

- `pnpm test:unit` — 28 files / 367 tests green
- `pnpm test:integration` — 15 files / 228 tests green
- `tsc --noEmit` + `pnpm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)