### PR TITLE
release: fold funnel-less stopped ancestors on the tick (#377)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,33 @@ funded funnels get worked, each spending up to its own ceiling and stopping ther
   `ongoing` rows only, so writing a stopped row can never collide with it. Pinned by
   `tests/integration/stopped-ancestor-funnel-backfill.test.ts`, which applies the file itself to a
   prod-shaped database twice.
+- **That rule is an INVARIANT, so it lives on the TICK — a migration can only ever state it once.**
+  0048 ran against the fleet of 13 Aug and the bug recurred in nine days, on a brand that was not
+  yet eligible: org `d3367008` / brand `b97440f6` / `cold_email` read $53 on the offer and $1.81 on
+  the offer's one live campaign, $51.68 of it on an ancestor stating no funnel. The sequence is the
+  whole argument — on 13 Aug that ancestor was still LIVE and stated none, so 0048 correctly
+  declined it; on 16 Aug the funnel was funded and provisioning INSERTED a twin (a row at
+  `funnel_key NULL` can never match `eq(campaigns.funnelKey, …)`); on 19 Aug it stopped, becoming
+  eligible the same moment, with nothing left to apply the rule. `adoptFunnellessAncestors`
+  (`src/lib/funnel-ancestor-adoption.ts`) now applies it, scoped to one (org, brand, acquisition
+  channel), whenever a funnel campaign is provisioned OR confirmed for that triple. Migration
+  **0051** is the same rule re-stated for the one row eligible on 20 Aug, and is the last time it is
+  written as a migration. Same exclusions, same audit table, same idempotence in both halves;
+  `tests/integration/stopped-ancestor-funnel-rerun.test.ts` runs the file and the runtime rule over
+  ONE seed and asserts they reach the same verdict on every row, which is what stops the two copies
+  drifting. **The call site is collected into `adoptFor` and drained AFTER the loop on purpose**:
+  the existing-campaign check returns early with `continue`, so an adoption written inside it would
+  never run for a brand whose twin already exists — which is every brand this recurs on. The other
+  470 stopped funnel-less rows across 17 brands are NOT backfilled: the rule does not select them
+  (no live sibling stating a funnel on their triple), and the runtime half covers each the moment
+  its brand funds a funnel again.
+- **The live campaign of a (funnel, channel) wins the existing-campaign lookup over a stopped one,
+  whatever their creation dates.** Ordering on `created_at` alone answers "the newest row", a
+  different question: a stopped ancestor created after the incumbent — or one that only just became
+  findable because its funnel was folded onto this identity — is returned instead, and the resume
+  branch then brings it back alongside the incumbent. That is a `23505` on the partial unique index,
+  thrown INSIDE `planFunnelTurns`, which fail-closes and holds the whole brand every tick, forever,
+  for a brand whose campaign is running fine. It appears in no customer-visible state at all.
 - **The gate paces on that funnel's own ceiling** (`gate-check.ts`, block a2), fail-CLOSED like
   the brand ceiling. Precedence: campaign's own `dailyBudgetCents` → `funnelKey` ceiling → brand
   daily budget. A funnel funded at ZERO, or absent from billing while the brand funds OTHER

--- a/drizzle/0051_stopped_ancestors_state_their_campaign_funnel_again.sql
+++ b/drizzle/0051_stopped_ancestors_state_their_campaign_funnel_again.sql
@@ -1,0 +1,121 @@
+-- Migration 0048's rule, applied to the row that became eligible AFTER 0048 ran.
+--
+-- 0048 folds by rule: a stopped campaign carrying no funnel states the funnel of the live campaign
+-- of its (org, brand, acquisition channel), and only where that triple has exactly one live
+-- campaign stating one. The rule is right. It ran ONCE, as a migration, against the fleet as it
+-- stood on 13 Aug 2026 — and a one-shot migration cannot hold an invariant that new rows keep
+-- entering. Nine days later a customer read $53 of spend on an offer and $1.81 on that offer's
+-- single live campaign:
+--
+--   org d3367008-29cd-4dc5-a57e-d0d825bf1630 / brand b97440f6-5822-43de-ad1d-9886723536d6
+--   / offer b0cc1851-9813-457d-81d2-1ff3482adb4a / channel cold_email
+--
+--     2bd9ec88-2714-468f-a42f-2a7575d6dc4a  funnel NULL, stopped, created 29 Jul
+--                                           $51.68 net over 1,365 cost rows, 29 Jul -> 6 Aug
+--     9570e3ce-dd0d-4181-8e34-c9820df5f54f  sales_meetings_from_conversation, ongoing, created 16 Aug
+--                                           $1.81 net over 48 cost rows, 18 Aug
+--
+--   On 13 Aug 2bd9ec88 was still LIVE and stated no funnel, so 0048 correctly left it alone. On
+--   16 Aug the funnel was funded and provisioning INSERTED a twin rather than adopting it (a row
+--   at funnel_key NULL can never match `eq(campaigns.funnelKey, f.funnelKey)`). On 19 Aug the
+--   ancestor stopped, becoming eligible to the 0048 rule that same moment — and nothing would ever
+--   apply it again. features-service therefore files its $51.68 under an identity with no live
+--   member: the money counts at brand level and renders on no campaign line at all.
+--
+-- This migration is the SAME rule with the SAME exclusions, re-stated so it selects what is
+-- eligible TODAY. The lasting half of the fix is NOT here: it is
+-- src/lib/funnel-ancestor-adoption.ts, which applies the rule on the tick, at the one moment a
+-- live funnel identity comes into being for an (org, brand, acquisition channel) — so this is the
+-- last time it needs writing as a migration.
+--
+-- What the rule selects in prod, DRY-RUN against the live database before this file was written
+-- (2026-08-20): exactly ONE group, the one above, ONE row — 2bd9ec88. Nothing else fleet-wide.
+-- The other 470 stopped funnel-less rows across 17 brands are NOT selected and are NOT touched:
+-- none of them has a live sibling stating a funnel on its triple, so there is nothing to fold them
+-- onto, and parking them on a funnel now would invent an attribution nobody recorded. They are
+-- covered by the runtime half the moment their brand funds a funnel again.
+--
+-- Every other group is excluded by the rule itself, not by a list:
+--   * a triple with SEVERAL live campaigns stating funnels — which one an ancestor ran is unknown;
+--   * a triple with NO live campaign at all — nothing to answer to;
+--   * a live campaign that states NO funnel — not a funnel to fold onto;
+--   * a stopped row that already STATES a funnel — it answers to an identity already, and this
+--     only ever fills an absence;
+--   * another ORG's campaigns on the same brand row. A brand row is a shared global identity;
+--     what a customer declares belongs to the (org, brand) pair, so those are another customer's.
+--
+-- What this does NOT touch, on purpose:
+--   * status. The ancestor stays STOPPED — folding it onto the live member of the identity is the
+--     whole point, and resuming it would put a second campaign in the running.
+--   * `stop_reason` (NULL on the target row, which is the pre-funnel population), `goal`, schedule,
+--     budget, audiences, offer, history. The only column that moves is `funnel_key`.
+--   * any LIVE campaign. uniq_campaigns_org_brand_funnel_channel is PARTIAL on `status='ongoing'`
+--     — re-verified in prod's pg_indexes on 2026-08-20 rather than taken on trust — so writing a
+--     funnel onto stopped rows cannot collide with it.
+--
+-- REVERSIBLE. Every row it writes is recorded in `campaign_funnel_owner_decisions` with the value
+-- it replaced, so an operator can read back exactly what was written and undo it:
+--
+--   SELECT * FROM campaign_funnel_owner_decisions WHERE source = '0051_stopped_ancestors_state_their_campaign_funnel_again';
+--
+--   UPDATE campaigns c
+--   SET funnel_key = d.previous_funnel_key
+--   FROM campaign_funnel_owner_decisions d
+--   WHERE c.id::text = d.campaign_id
+--     AND d.source = '0051_stopped_ancestors_state_their_campaign_funnel_again'
+--     AND c.funnel_key = d.funnel_key;
+--
+-- IDEMPOTENT: both statements select only a stopped campaign whose funnel is still NULL, and the
+-- decision rows insert ON CONFLICT DO NOTHING. A row this migration has already written states a
+-- funnel, so a second run (or a second replica booting at the same moment) selects nothing and
+-- changes zero rows.
+
+-- Record the decision first, so the rows it is about to write are readable even if the apply step
+-- is interrupted. `campaigns.id` is a uuid in the database while schema.ts declares it text (a
+-- historical drift, older than funnels), so the decision row keys on the text spelling and every
+-- join casts.
+WITH "one_live_funnel" AS (
+  -- The (org, brand, channel) triples answering to exactly ONE live campaign that states a funnel.
+  SELECT
+    "org_id",
+    "brand_id",
+    "acquisition_channel",
+    min("funnel_key") AS "funnel_key"
+  FROM "campaigns"
+  WHERE "status" = 'ongoing'
+    AND "funnel_key" IS NOT NULL
+    AND "brand_id" IS NOT NULL
+    AND "acquisition_channel" IS NOT NULL
+  GROUP BY "org_id", "brand_id", "acquisition_channel"
+  HAVING count(*) = 1
+)
+INSERT INTO "campaign_funnel_owner_decisions" (
+  "campaign_id", "org_id", "brand_id", "previous_funnel_key", "funnel_key",
+  "decided_by", "decided_on", "source"
+)
+SELECT
+  c."id"::text,
+  c."org_id",
+  c."brand_id",
+  c."funnel_key",
+  l."funnel_key",
+  'campaign-identity',
+  DATE '2026-08-20',
+  '0051_stopped_ancestors_state_their_campaign_funnel_again'
+FROM "campaigns" c
+JOIN "one_live_funnel" l
+  ON c."org_id" = l."org_id"
+  AND c."brand_id" = l."brand_id"
+  AND c."acquisition_channel" = l."acquisition_channel"
+WHERE c."status" = 'stopped'
+  AND c."funnel_key" IS NULL
+ON CONFLICT ("campaign_id") DO NOTHING;
+
+UPDATE "campaigns" c
+SET "funnel_key" = d."funnel_key",
+    "updated_at" = now()
+FROM "campaign_funnel_owner_decisions" d
+WHERE c."id"::text = d."campaign_id"
+  AND d."source" = '0051_stopped_ancestors_state_their_campaign_funnel_again'
+  AND c."status" = 'stopped'
+  AND c."funnel_key" IS NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1777500000000,
       "tag": "0050_campaign_offer_id",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1777600000000,
+      "tag": "0051_stopped_ancestors_state_their_campaign_funnel_again",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/funnel-ancestor-adoption.ts
+++ b/src/lib/funnel-ancestor-adoption.ts
@@ -1,0 +1,185 @@
+import { sql } from "drizzle-orm";
+import { db } from "../db/index.js";
+
+/**
+ * A stopped campaign's funnel is NOT inert history — it decides whose totals its history lands in.
+ *
+ * features-service groups a brand's campaigns into families keyed on
+ * (org, brand, sales funnel, acquisition channel) and totals each family as ONE customer-visible
+ * campaign. A stopped ancestor carrying a NULL funnel does not key onto the live campaign's
+ * identity: it becomes a family of its own with no live member, so it renders no line at all —
+ * while its runs, spend, leads and replies keep counting at BRAND level. That gap is exactly what
+ * a customer reads between the offer view and the campaign view.
+ *
+ * Migration 0048 wrote that rule as a ONE-SHOT migration, against the fleet as it stood on 13 Aug.
+ * That cannot hold the invariant, and the recurrence proved it in nine days:
+ *
+ *   org d3367008 / brand b97440f6 / cold_email
+ *     2bd9ec88  funnel NULL, stopped 19 Aug, $51.68 of spend over 1,365 cost rows
+ *     9570e3ce  sales_meetings_from_conversation, ongoing since 16 Aug, $1.81
+ *
+ *   On 13 Aug 2bd9ec88 was still LIVE and stated no funnel, so 0048 correctly left it alone. On
+ *   16 Aug the funnel was funded and provisioning INSERTED a twin (a row at funnel_key NULL can
+ *   never match `eq(campaigns.funnelKey, f.funnelKey)`). On 19 Aug the ancestor stopped. It became
+ *   eligible to the 0048 rule the moment it did, and nothing would ever apply it again.
+ *
+ * So the rule lives HERE, on the tick, and is applied at the one moment a new funnel identity
+ * comes into being for an (org, brand, acquisition channel): when a funnel campaign is provisioned
+ * for it. The 471 stopped funnel-less rows still out there across 17 brands are covered the moment
+ * their brand funds a funnel again — which is the only moment the rule can select them anyway,
+ * because it needs a live sibling stating a funnel to fold onto.
+ *
+ * THE RULE, byte-for-byte the one migration 0048 states, and it is a fact rule, never a guess:
+ * a stopped campaign carrying NO funnel is folded onto the funnel of the live campaign of its
+ * (org, brand, acquisition channel), and ONLY when that triple has EXACTLY ONE live campaign
+ * stating a funnel. A triple with none, or with several, is left exactly as it is. Nothing is
+ * derived from a goal, a name, a workflow slug or a date.
+ *
+ * What it never touches, on purpose:
+ *   - a stopped row whose funnel is already STATED. It answers to an identity already; this only
+ *     ever fills an absence.
+ *   - `goal`, status, stop_reason, schedule, budget, audiences, offer, history. The only column
+ *     that moves is `funnel_key`. In particular the ancestor stays STOPPED: folding it onto the
+ *     live member of the identity is the whole point, and resuming it would put a second campaign
+ *     in the running.
+ *   - any LIVE campaign. uniq_campaigns_org_brand_funnel_channel is PARTIAL on `status='ongoing'`
+ *     (re-verified in prod's pg_indexes on 2026-08-20), so writing a funnel onto stopped rows
+ *     cannot collide with it.
+ *   - any other org's campaigns on the same brand row. A brand row is a shared global identity;
+ *     what a customer declares belongs to the (org, brand) pair, so another org's campaigns on the
+ *     same brand are another customer's.
+ */
+
+/** The handle an operator reads back and undoes runtime adoptions by. */
+export const ANCESTOR_ADOPTION_SOURCE = "runtime-funnel-campaign-provisioning";
+
+/** Who the decision is attributed to — the same author 0045/0047/0048 record. */
+const DECIDED_BY = "campaign-identity";
+
+/** The (org, brand, acquisition channel) a funnel campaign has just been provisioned for. */
+export interface AncestorAdoptionScope {
+  orgId: string;
+  brandId: string;
+  acquisitionChannel: string;
+}
+
+/**
+ * Fold the funnel-less stopped ancestors of ONE (org, brand, acquisition channel) onto the funnel
+ * of its single live campaign.
+ *
+ * Returns how many rows were written — zero on every ordinary tick, which is why nothing is logged
+ * on that path (a per-tick line for every campaign of every client buries real signal, and the
+ * decision is already durable in `campaign_funnel_owner_decisions` when it is not zero).
+ *
+ * IDEMPOTENT by construction: both statements select only a stopped campaign whose funnel is still
+ * NULL, and the decision rows insert ON CONFLICT DO NOTHING. A row this has already written states
+ * a funnel, so a second call selects nothing and changes zero rows.
+ *
+ * REVERSIBLE: every write records the value it replaced.
+ *
+ *   SELECT * FROM campaign_funnel_owner_decisions WHERE source = 'runtime-funnel-campaign-provisioning';
+ *
+ *   UPDATE campaigns c
+ *   SET funnel_key = d.previous_funnel_key
+ *   FROM campaign_funnel_owner_decisions d
+ *   WHERE c.id::text = d.campaign_id
+ *     AND d.source = 'runtime-funnel-campaign-provisioning'
+ *     AND c.funnel_key = d.funnel_key;
+ */
+export async function adoptFunnellessAncestors(
+  scope: AncestorAdoptionScope,
+  now: Date = new Date(),
+): Promise<number> {
+  const decidedOn = now.toISOString().slice(0, 10);
+
+  // Record the decision FIRST, so the rows about to be written are readable even if the apply step
+  // is interrupted. `campaigns.id` is a uuid in the database while schema.ts declares it text (a
+  // historical drift, older than funnels), so the decision row keys on the text spelling and every
+  // join casts.
+  await db.execute(sql`
+    WITH "one_live_funnel" AS (
+      SELECT
+        "org_id",
+        "brand_id",
+        "acquisition_channel",
+        min("funnel_key") AS "funnel_key"
+      FROM "campaigns"
+      WHERE "status" = 'ongoing'
+        AND "funnel_key" IS NOT NULL
+        AND "brand_id" IS NOT NULL
+        AND "acquisition_channel" IS NOT NULL
+        AND "org_id" = ${scope.orgId}
+        AND "brand_id" = ${scope.brandId}
+        AND "acquisition_channel" = ${scope.acquisitionChannel}
+      GROUP BY "org_id", "brand_id", "acquisition_channel"
+      HAVING count(*) = 1
+    )
+    INSERT INTO "campaign_funnel_owner_decisions" (
+      "campaign_id", "org_id", "brand_id", "previous_funnel_key", "funnel_key",
+      "decided_by", "decided_on", "source"
+    )
+    SELECT
+      c."id"::text,
+      c."org_id",
+      c."brand_id",
+      c."funnel_key",
+      l."funnel_key",
+      ${DECIDED_BY},
+      ${decidedOn}::date,
+      ${ANCESTOR_ADOPTION_SOURCE}
+    FROM "campaigns" c
+    JOIN "one_live_funnel" l
+      ON c."org_id" = l."org_id"
+      AND c."brand_id" = l."brand_id"
+      AND c."acquisition_channel" = l."acquisition_channel"
+    WHERE c."status" = 'stopped'
+      AND c."funnel_key" IS NULL
+    ON CONFLICT ("campaign_id") DO NOTHING
+  `);
+
+  const applied = await db.execute<{ id: string }>(sql`
+    UPDATE "campaigns" c
+    SET "funnel_key" = d."funnel_key",
+        "updated_at" = now()
+    FROM "campaign_funnel_owner_decisions" d
+    WHERE c."id"::text = d."campaign_id"
+      AND d."source" = ${ANCESTOR_ADOPTION_SOURCE}
+      AND c."org_id" = ${scope.orgId}
+      AND c."brand_id" = ${scope.brandId}
+      AND c."acquisition_channel" = ${scope.acquisitionChannel}
+      AND c."status" = 'stopped'
+      AND c."funnel_key" IS NULL
+    RETURNING c."id"
+  `);
+
+  return Array.isArray(applied) ? applied.length : 0;
+}
+
+/**
+ * Fail-SOFT wrapper for the provisioning tick.
+ *
+ * Adoption is an ATTRIBUTION correction: it decides whose totals a stopped row's history lands in,
+ * and it spends nothing and starts nothing. A failure must never hold up the provisioning that
+ * called it — the funded funnel still needs its campaign — so the error is said out loud once and
+ * the next tick tries again.
+ */
+export async function adoptFunnellessAncestorsSafely(
+  scope: AncestorAdoptionScope,
+  now: Date = new Date(),
+): Promise<number> {
+  try {
+    const adopted = await adoptFunnellessAncestors(scope, now);
+    if (adopted > 0) {
+      console.log(
+        `[campaign-service] ${adopted} stopped campaign(s) of brand ${scope.brandId} (org ${scope.orgId}, channel ${scope.acquisitionChannel}) now state the funnel of their live campaign — their spend and replies total onto it`,
+      );
+    }
+    return adopted;
+  } catch (err) {
+    console.warn(
+      `[campaign-service] Could not fold the funnel-less stopped campaigns of brand ${scope.brandId} (org ${scope.orgId}, channel ${scope.acquisitionChannel}) onto their live campaign's funnel:`,
+      err,
+    );
+    return 0;
+  }
+}

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -18,8 +18,9 @@ import {
 } from "./brand-sales-funnels-client.js";
 import { isSalesOutreachFeature, SALES_OUTREACH_FEATURE_SLUGS } from "./sales-outreach-campaign.js";
 import { toFunnelKey } from "./sales-funnel-vocabulary.js";
-import { campaignIdentityColumns } from "./campaign-identity.js";
+import { acquisitionChannelForFeature, campaignIdentityColumns } from "./campaign-identity.js";
 import { fundingFromBudgets } from "./campaign-funding.js";
+import { adoptFunnellessAncestorsSafely } from "./funnel-ancestor-adoption.js";
 
 // A campaign that did not get this brand's turn re-checks on the next active tick. The turn is
 // re-ranked from scratch every tick, so this is a "wait your turn", not a backoff. EVERY alive
@@ -426,6 +427,13 @@ async function ensureFundedFunnelCampaigns({
   const sellableByFeature = new Map<string, Set<SalesFunnelKey> | null>();
   const workflowByFeature = new Map<string, string | null>();
 
+  // The (org, brand, acquisition channel) triples a funnel campaign is provisioned for on this
+  // tick. Collected rather than acted on inline BECAUSE the existing-campaign check below returns
+  // early with `continue`: a brand whose twin already exists — which is precisely the brand this
+  // recurrence was found on — would never reach an adoption written after that check. See
+  // funnel-ancestor-adoption.ts for the rule and why it cannot stay a one-shot migration.
+  const adoptFor = new Set<string>();
+
   for (const f of funded) {
     if (declared.contested.has(f.funnelKey)) {
       // Several offers of this brand sell through this chain. Provisioning one campaign would file
@@ -457,6 +465,20 @@ async function ensureFundedFunnelCampaigns({
       continue;
     }
 
+    // This pair gets a campaign on this channel — whether one already exists or one is inserted
+    // below. Either way a live funnel identity exists for the triple, which is the one moment the
+    // funnel-less stopped ancestors of that triple can be folded onto it.
+    const channel = acquisitionChannelForFeature(featureSlug);
+    if (channel) adoptFor.add(channel);
+
+    // The LIVE campaign of this pair wins over a stopped one, whatever their creation dates.
+    // Ordering on `created_at` alone answers "the newest row", which is not the same question: a
+    // stopped ancestor created after the incumbent — or one that only just became findable here
+    // because its funnel was folded onto this identity — would be returned instead, and the resume
+    // below would then try to bring it back alongside the incumbent. That is a 23505 on the partial
+    // unique index (ongoing rows only), and it is thrown INSIDE planFunnelTurns, which fail-closes
+    // and holds the whole brand: every tick, forever, for a brand whose campaign is running fine.
+    // At most one ongoing campaign per identity holds, so there is at most one such row to prefer.
     const existing = await db.query.campaigns.findFirst({
       where: and(
         eq(campaigns.orgId, seed.orgId),
@@ -464,7 +486,7 @@ async function ensureFundedFunnelCampaigns({
         eq(campaigns.funnelKey, f.funnelKey),
         arrayContains(campaigns.brandIds, [brandId]),
       ),
-      orderBy: [desc(campaigns.createdAt)],
+      orderBy: [desc(sql`(${campaigns.status} = 'ongoing')`), desc(campaigns.createdAt)],
     });
 
     if (existing) {
@@ -544,6 +566,15 @@ async function ensureFundedFunnelCampaigns({
       const message = err instanceof Error ? err.message : String(err);
       if (!message.includes("uniq_campaigns_org_name")) throw err;
     }
+  }
+
+  // Reachable on every tick that provisions or confirms a funnel campaign, whatever branch each
+  // pair took above. Fail-soft and a no-op on every ordinary tick.
+  for (const channel of adoptFor) {
+    await adoptFunnellessAncestorsSafely(
+      { orgId: seed.orgId, brandId, acquisitionChannel: channel },
+      now,
+    );
   }
 }
 

--- a/tests/integration/funding-adopts-funnelless-ancestors.test.ts
+++ b/tests/integration/funding-adopts-funnelless-ancestors.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+
+/**
+ * The 16 Aug shape, reproduced: a stopped funnel-less ancestor plus a funding event.
+ *
+ * Migration 0048 folded stopped funnel-less ancestors onto the funnel of their triple's one live
+ * campaign, ONCE, against the fleet as it stood on 13 Aug. Nine days later a customer read $53 of
+ * spend on an offer and $1.81 on that offer's only live campaign, because $51.68 of the campaign's
+ * OWN history sat on an ancestor that answers to no funnel — a row that was still LIVE on 13 Aug,
+ * so 0048 correctly declined it, and that became eligible the day it stopped.
+ *
+ * What is pinned here is that provisioning a funnel campaign for an (org, brand, acquisition
+ * channel) leaves NO funnel-less ancestor of that triple behind — including, and especially, when
+ * the campaign for the funded funnel ALREADY EXISTS. That is the placement trap: the
+ * existing-campaign check returns early with `continue`, so an adoption written after it would
+ * never run for the very brand this recurrence was found on.
+ */
+
+const { mockExecute } = vi.hoisted(() => ({ mockExecute: vi.fn() }));
+
+vi.mock("../../src/lib/features-workflow-projection-client.js", () => ({
+  resolveWorkflowSlugForTrigger: vi.fn(async (a) => a.fallbackSlug),
+}));
+
+vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
+  return { ...original, executeCampaignWorkflow: mockExecute };
+});
+
+vi.mock("@distribute/runs-client", () => ({
+  listRuns: vi.fn().mockResolvedValue({ runs: [] }),
+  createRun: vi.fn().mockResolvedValue({ id: "run-1" }),
+  updateRun: vi.fn(),
+  getStatsBudget: vi.fn().mockResolvedValue({ windows: [] }),
+}));
+
+import { eq } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import { campaigns, campaignFunnelOwnerDecisions } from "../../src/db/schema.js";
+import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
+import { reRunDueCampaigns } from "../../src/lib/scheduler.js";
+import { SALES_OUTREACH_FEATURE_SLUG } from "../../src/lib/sales-outreach-campaign.js";
+import { resetFundingSweepThrottle } from "../../src/lib/funnel-campaigns.js";
+import { ANCESTOR_ADOPTION_SOURCE } from "../../src/lib/funnel-ancestor-adoption.js";
+
+const orgId = "ancestor-adoption-org";
+const otherOrgId = "ancestor-adoption-other-org";
+const CONVERSATION = "sales_meetings_from_conversation";
+const WEBSITE = "sales_meetings_from_website";
+const past = () => new Date(Date.now() - 60_000);
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+/**
+ * billing funds these funnels for every brand asked about. It still names them the pre-rename way
+ * on the wire, which is exactly what production sends today.
+ */
+function billingFunds(funnels: Array<{ funnelKey: string; dailyBudgetCents: string }>) {
+  mockFetch.mockImplementation(async (url: string) => {
+    if (String(url).includes("/funnel-budgets")) {
+      return {
+        ok: true,
+        json: async () => ({
+          brandId: "b",
+          dailyBudgetCents: "5000",
+          funnels: funnels.map((f) => ({ ...f, updatedAt: null })),
+        }),
+      };
+    }
+    if (String(url).includes("/workflows")) {
+      const featureSlug = new URL(String(url)).searchParams.get("featureSlug");
+      return {
+        ok: true,
+        json: async () => ({
+          workflows: [
+            { workflowSlug: `${featureSlug}-seed`, featureSlug, createdAt: "2026-08-18T00:00:00.000Z" },
+          ],
+        }),
+      };
+    }
+    if (String(url).includes("/features/")) {
+      return {
+        ok: true,
+        json: async () => ({
+          salesFunnels: [CONVERSATION, WEBSITE, "website_purchases", "form_magnet"],
+        }),
+      };
+    }
+    if (String(url).includes("/sales-funnels")) {
+      return {
+        ok: true,
+        json: async () => ({
+          funnels: [
+            { funnelKey: CONVERSATION, active: true, name: "x", steps: [], rates: {} },
+            { funnelKey: WEBSITE, active: true, name: "y", steps: [], rates: {} },
+          ],
+        }),
+      };
+    }
+    return { ok: false, status: 500, json: async () => ({}) };
+  });
+}
+
+function salesCampaign(brandId: string, org: string, over: Record<string, unknown> = {}) {
+  return insertTestCampaign(org, {
+    status: "ongoing",
+    nextRunAt: past(),
+    brandIds: [brandId],
+    brandId,
+    acquisitionChannel: "cold_email",
+    featureSlug: SALES_OUTREACH_FEATURE_SLUG,
+    createdByUserId: "user-x",
+    funnelKey: CONVERSATION,
+    ...over,
+  });
+}
+
+async function funnelOf(id: string): Promise<string | null> {
+  const [row] = await db.select().from(campaigns).where(eq(campaigns.id, id));
+  return row?.funnelKey ?? null;
+}
+
+async function statusOf(id: string): Promise<string | undefined> {
+  const [row] = await db.select().from(campaigns).where(eq(campaigns.id, id));
+  return row?.status;
+}
+
+beforeEach(async () => {
+  await cleanTestData();
+  await db.delete(campaignFunnelOwnerDecisions);
+  vi.clearAllMocks();
+  mockExecute.mockResolvedValue(undefined);
+  resetFundingSweepThrottle();
+  process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+  process.env.BILLING_SERVICE_API_KEY = "test-billing-key";
+  process.env.FEATURES_SERVICE_URL = "https://features.test.local";
+  process.env.FEATURES_SERVICE_API_KEY = "test-features-key";
+  process.env.WORKFLOW_SERVICE_URL = "https://workflow.test.local";
+  process.env.WORKFLOW_SERVICE_API_KEY = "test-workflow-key";
+});
+
+afterAll(async () => {
+  await cleanTestData();
+  await db.delete(campaignFunnelOwnerDecisions);
+  await closeDb();
+});
+
+describe("provisioning a funnel campaign leaves no funnel-less ancestor behind", () => {
+  it("folds the ancestor even though the funded funnel's campaign ALREADY EXISTS", async () => {
+    // Exactly the prod shape: 9570e3ce ongoing on the funnel, 2bd9ec88 stopped and stating none.
+    const brandId = crypto.randomUUID();
+    const live = await salesCampaign(brandId, orgId);
+    const ancestor = await salesCampaign(brandId, orgId, {
+      status: "stopped",
+      nextRunAt: null,
+      funnelKey: null,
+      stopReason: null,
+    });
+
+    billingFunds([{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }]);
+    await reRunDueCampaigns();
+
+    expect(await funnelOf(ancestor.id)).toBe(CONVERSATION);
+    // Nothing else about it moves — it stays STOPPED, which is the whole point: features-service
+    // folds a stopped ancestor onto the live member of the identity.
+    expect(await statusOf(ancestor.id)).toBe("stopped");
+    expect(await funnelOf(live.id)).toBe(CONVERSATION);
+    expect(await statusOf(live.id)).toBe("ongoing");
+  });
+
+  it("records the write with the value it replaced, under its own source tag", async () => {
+    const brandId = crypto.randomUUID();
+    await salesCampaign(brandId, orgId);
+    const ancestor = await salesCampaign(brandId, orgId, {
+      status: "stopped",
+      nextRunAt: null,
+      funnelKey: null,
+    });
+
+    billingFunds([{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }]);
+    await reRunDueCampaigns();
+
+    const [decision] = await db
+      .select()
+      .from(campaignFunnelOwnerDecisions)
+      .where(eq(campaignFunnelOwnerDecisions.source, ANCESTOR_ADOPTION_SOURCE));
+
+    expect(decision?.campaignId).toBe(ancestor.id);
+    expect(decision?.previousFunnelKey).toBeNull();
+    expect(decision?.funnelKey).toBe(CONVERSATION);
+    expect(decision?.orgId).toBe(orgId);
+    expect(decision?.brandId).toBe(brandId);
+  });
+
+  it("a second tick changes nothing — the ancestor states a funnel now", async () => {
+    const brandId = crypto.randomUUID();
+    const live = await salesCampaign(brandId, orgId);
+    const ancestor = await salesCampaign(brandId, orgId, {
+      status: "stopped",
+      nextRunAt: null,
+      funnelKey: null,
+    });
+
+    billingFunds([{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }]);
+    await reRunDueCampaigns();
+
+    const [before] = await db.select().from(campaigns).where(eq(campaigns.id, ancestor.id));
+    const decisionsBefore = await db.select().from(campaignFunnelOwnerDecisions);
+
+    await db.update(campaigns).set({ nextRunAt: past() }).where(eq(campaigns.id, live.id));
+    await reRunDueCampaigns();
+
+    const [after] = await db.select().from(campaigns).where(eq(campaigns.id, ancestor.id));
+    expect(after.funnelKey).toBe(before.funnelKey);
+    expect(after.updatedAt?.toISOString()).toBe(before.updatedAt?.toISOString());
+    expect(await db.select().from(campaignFunnelOwnerDecisions)).toHaveLength(
+      decisionsBefore.length,
+    );
+  });
+
+  it("never tries to resume the folded ancestor alongside the incumbent it now shares an identity with", async () => {
+    // Folding an ancestor onto the live campaign's funnel makes it findable by the
+    // existing-campaign lookup. Ordered on creation date alone, a stopped ancestor created AFTER
+    // the incumbent is returned instead of it, and the resume path then brings it back next to a
+    // campaign it now collides with on uniq_campaigns_org_brand_funnel_channel — a 23505 raised
+    // inside planFunnelTurns, which fail-closes and holds the brand every tick, forever.
+    const brandId = crypto.randomUUID();
+    const live = await salesCampaign(brandId, orgId);
+    // The incumbent is the OLDER row, so "the newest campaign of this pair" is the wrong answer.
+    await db
+      .update(campaigns)
+      .set({ createdAt: new Date(Date.now() - 86_400_000) })
+      .where(eq(campaigns.id, live.id));
+    const ancestor = await salesCampaign(brandId, orgId, {
+      status: "stopped",
+      nextRunAt: null,
+      funnelKey: null,
+      stopReason: null,
+    });
+
+    billingFunds([{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }]);
+    await reRunDueCampaigns();
+    // The fold happened on the first tick; the second is the one that would have collided.
+    await db.update(campaigns).set({ nextRunAt: past() }).where(eq(campaigns.id, live.id));
+    await reRunDueCampaigns();
+
+    expect(await funnelOf(ancestor.id)).toBe(CONVERSATION);
+    expect(await statusOf(ancestor.id)).toBe("stopped");
+    expect(await statusOf(live.id)).toBe("ongoing");
+    // The brand was never held: the campaign fired on both ticks.
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the ancestor alone when the triple has SEVERAL live funnels", async () => {
+    const brandId = crypto.randomUUID();
+    await salesCampaign(brandId, orgId, { funnelKey: CONVERSATION });
+    await salesCampaign(brandId, orgId, { funnelKey: WEBSITE });
+    const ancestor = await salesCampaign(brandId, orgId, {
+      status: "stopped",
+      nextRunAt: null,
+      funnelKey: null,
+    });
+
+    billingFunds([
+      { funnelKey: "reply_meeting", dailyBudgetCents: "5000" },
+      { funnelKey: "visit_meeting", dailyBudgetCents: "5000" },
+    ]);
+    await reRunDueCampaigns();
+
+    expect(await funnelOf(ancestor.id)).toBeNull();
+    expect(await db.select().from(campaignFunnelOwnerDecisions)).toHaveLength(0);
+  });
+
+  it("never touches another org's campaigns on the same brand row", async () => {
+    const brandId = crypto.randomUUID();
+    await salesCampaign(brandId, orgId);
+    const foreign = await salesCampaign(brandId, otherOrgId, {
+      status: "stopped",
+      nextRunAt: null,
+      funnelKey: null,
+    });
+
+    billingFunds([{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }]);
+    await reRunDueCampaigns();
+
+    expect(await funnelOf(foreign.id)).toBeNull();
+  });
+
+  it("never touches a stopped ancestor on a DIFFERENT acquisition channel", async () => {
+    const brandId = crypto.randomUUID();
+    await salesCampaign(brandId, orgId);
+    const otherChannel = await insertTestCampaign(orgId, {
+      status: "stopped",
+      brandIds: [brandId],
+      brandId,
+      acquisitionChannel: "pr_cold_email",
+      featureSlug: "pr-cold-email-outreach",
+      funnelKey: null,
+    });
+
+    billingFunds([{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }]);
+    await reRunDueCampaigns();
+
+    expect(await funnelOf(otherChannel.id)).toBeNull();
+  });
+});

--- a/tests/integration/stopped-ancestor-funnel-rerun.test.ts
+++ b/tests/integration/stopped-ancestor-funnel-rerun.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { eq, inArray } from "drizzle-orm";
+import { db, sql } from "../../src/db/index.js";
+import { campaigns, campaignFunnelOwnerDecisions } from "../../src/db/schema.js";
+import { cleanTestData, closeDb, insertTestCampaign, randomId } from "../helpers/test-db.js";
+import {
+  adoptFunnellessAncestors,
+  ANCESTOR_ADOPTION_SOURCE,
+} from "../../src/lib/funnel-ancestor-adoption.js";
+
+/**
+ * Migration 0051 and the RUNTIME rule it is the last migration for.
+ *
+ * The migration is applied here exactly as prod will apply it — the file itself, against a database
+ * seeded with the shape prod holds — so "a second run changes zero rows" is measured, not read off
+ * the SQL. The runtime rule is then run over the SAME seed and asserted to reach the SAME verdict
+ * on every row, which is what stops the two copies of one rule drifting apart.
+ */
+const TAG = "0051_stopped_ancestors_state_their_campaign_funnel_again";
+const MIGRATION = readFileSync(join(process.cwd(), "drizzle", `${TAG}.sql`), "utf8");
+
+const CONVERSATION = "sales_meetings_from_conversation";
+const WEBSITE = "sales_meetings_from_website";
+const PURCHASES = "website_purchases";
+
+const orgA = randomId();
+const orgB = randomId();
+const brandOneLive = randomId();
+const brandSeveralLive = randomId();
+const brandNoLive = randomId();
+const brandLiveNoFunnel = randomId();
+
+async function applyMigration() {
+  await sql.unsafe(MIGRATION);
+}
+
+async function funnelOf(id: string): Promise<string | null> {
+  const [row] = await db.select().from(campaigns).where(eq(campaigns.id, id));
+  return row?.funnelKey ?? null;
+}
+
+async function statusOf(id: string): Promise<string | undefined> {
+  const [row] = await db.select().from(campaigns).where(eq(campaigns.id, id));
+  return row?.status;
+}
+
+async function seed() {
+  // (1) THE QUALIFYING TRIPLE — one live campaign stating a funnel, on cold_email. This is the
+  // prod shape: 9570e3ce ongoing on sales_meetings_from_conversation, 2bd9ec88 its stopped
+  // funnel-less ancestor carrying the spend.
+  const live = await insertTestCampaign(orgA, {
+    status: "ongoing",
+    brandId: brandOneLive,
+    acquisitionChannel: "cold_email",
+    funnelKey: CONVERSATION,
+    featureSlug: "sales-cold-email-outreach",
+  });
+  const ancestors = [];
+  for (let i = 0; i < 3; i++) {
+    ancestors.push(
+      await insertTestCampaign(orgA, {
+        status: "stopped",
+        brandId: brandOneLive,
+        acquisitionChannel: "cold_email",
+        funnelKey: null,
+        // NULL on the prod row — the pre-funnel population. Unlike the funding-resume path in
+        // funnel-campaigns.ts, the reason is irrelevant here: this restates an attribution, it
+        // never resumes anything, so a row that stopped for a reason of its own folds too.
+        stopReason: i === 0 ? null : "manual",
+        featureSlug: "sales-cold-email-outreach",
+      }),
+    );
+  }
+  // A stopped row that already STATES a funnel answers to an identity already.
+  const statedAncestor = await insertTestCampaign(orgA, {
+    status: "stopped",
+    brandId: brandOneLive,
+    acquisitionChannel: "cold_email",
+    funnelKey: PURCHASES,
+  });
+  // Same pair, DIFFERENT channel — no live campaign there, so nothing to answer to.
+  const otherChannel = await insertTestCampaign(orgA, {
+    status: "stopped",
+    brandId: brandOneLive,
+    acquisitionChannel: "ai_visibility",
+    funnelKey: null,
+  });
+  // ANOTHER org on the SAME brand row — another customer's campaign.
+  const otherOrg = await insertTestCampaign(orgB, {
+    status: "stopped",
+    brandId: brandOneLive,
+    acquisitionChannel: "cold_email",
+    funnelKey: null,
+  });
+
+  // (2) SEVERAL live funnels on one channel — which one an ancestor ran is unknown.
+  await insertTestCampaign(orgA, {
+    status: "ongoing",
+    brandId: brandSeveralLive,
+    acquisitionChannel: "cold_email",
+    funnelKey: CONVERSATION,
+  });
+  await insertTestCampaign(orgA, {
+    status: "ongoing",
+    brandId: brandSeveralLive,
+    acquisitionChannel: "cold_email",
+    funnelKey: WEBSITE,
+  });
+  const severalLiveAncestor = await insertTestCampaign(orgA, {
+    status: "stopped",
+    brandId: brandSeveralLive,
+    acquisitionChannel: "cold_email",
+    funnelKey: null,
+  });
+
+  // (3) NO live campaign at all on the channel.
+  const noLiveAncestor = await insertTestCampaign(orgA, {
+    status: "stopped",
+    brandId: brandNoLive,
+    acquisitionChannel: "cold_email",
+    funnelKey: null,
+  });
+
+  // (4) A live campaign that states NO funnel is not something to fold onto.
+  const liveNoFunnel = await insertTestCampaign(orgA, {
+    status: "ongoing",
+    brandId: brandLiveNoFunnel,
+    acquisitionChannel: "pr_cold_email",
+    funnelKey: null,
+  });
+  const liveNoFunnelAncestor = await insertTestCampaign(orgA, {
+    status: "stopped",
+    brandId: brandLiveNoFunnel,
+    acquisitionChannel: "pr_cold_email",
+    funnelKey: null,
+  });
+
+  return {
+    live,
+    ancestors,
+    statedAncestor,
+    otherChannel,
+    otherOrg,
+    severalLiveAncestor,
+    noLiveAncestor,
+    liveNoFunnel,
+    liveNoFunnelAncestor,
+  };
+}
+
+/** Every (org, brand, channel) the seed holds — the runtime rule is scoped, so it is asked per triple. */
+const SCOPES = () => [
+  { orgId: orgA, brandId: brandOneLive, acquisitionChannel: "cold_email" },
+  { orgId: orgA, brandId: brandOneLive, acquisitionChannel: "ai_visibility" },
+  { orgId: orgB, brandId: brandOneLive, acquisitionChannel: "cold_email" },
+  { orgId: orgA, brandId: brandSeveralLive, acquisitionChannel: "cold_email" },
+  { orgId: orgA, brandId: brandNoLive, acquisitionChannel: "cold_email" },
+  { orgId: orgA, brandId: brandLiveNoFunnel, acquisitionChannel: "pr_cold_email" },
+];
+
+async function applyRuntimeRule(): Promise<number> {
+  let total = 0;
+  for (const scope of SCOPES()) total += await adoptFunnellessAncestors(scope);
+  return total;
+}
+
+beforeEach(async () => {
+  await cleanTestData();
+  await db.delete(campaignFunnelOwnerDecisions);
+});
+
+afterAll(async () => {
+  await cleanTestData();
+  await db.delete(campaignFunnelOwnerDecisions);
+  await closeDb();
+});
+
+describe("migration 0051 — the 0048 rule, applied to what is eligible now", () => {
+  it("folds the stopped ancestors of the ONE live campaign of an (org, brand, channel)", async () => {
+    const seeded = await seed();
+    await applyMigration();
+
+    for (const ancestor of seeded.ancestors) {
+      expect(await funnelOf(ancestor.id)).toBe(CONVERSATION);
+      // The ancestor stays STOPPED. Folding it onto the live member of the identity is the point;
+      // resuming it would put a second campaign in the running.
+      expect(await statusOf(ancestor.id)).toBe("stopped");
+    }
+    expect(await funnelOf(seeded.live.id)).toBe(CONVERSATION);
+  });
+
+  it("leaves alone a triple with SEVERAL live funnels, and one with NONE", async () => {
+    const seeded = await seed();
+    await applyMigration();
+
+    expect(await funnelOf(seeded.severalLiveAncestor.id)).toBeNull();
+    expect(await funnelOf(seeded.noLiveAncestor.id)).toBeNull();
+    expect(await funnelOf(seeded.liveNoFunnelAncestor.id)).toBeNull();
+    expect(await funnelOf(seeded.liveNoFunnel.id)).toBeNull();
+  });
+
+  it("never restates a stopped row that already states a funnel", async () => {
+    const seeded = await seed();
+    await applyMigration();
+
+    expect(await funnelOf(seeded.statedAncestor.id)).toBe(PURCHASES);
+  });
+
+  it("never crosses a channel, and never another org's campaigns on the same brand row", async () => {
+    const seeded = await seed();
+    await applyMigration();
+
+    expect(await funnelOf(seeded.otherChannel.id)).toBeNull();
+    expect(await funnelOf(seeded.otherOrg.id)).toBeNull();
+  });
+
+  it("records every write, with the value it replaced, under a tag an operator undoes by", async () => {
+    const seeded = await seed();
+    await applyMigration();
+
+    const decisions = await db
+      .select()
+      .from(campaignFunnelOwnerDecisions)
+      .where(eq(campaignFunnelOwnerDecisions.source, TAG));
+
+    expect(decisions.map((d) => d.campaignId).sort()).toEqual(
+      seeded.ancestors.map((a) => a.id).sort(),
+    );
+    for (const decision of decisions) {
+      expect(decision.previousFunnelKey).toBeNull();
+      expect(decision.funnelKey).toBe(CONVERSATION);
+      expect(decision.orgId).toBe(orgA);
+      expect(decision.brandId).toBe(brandOneLive);
+    }
+
+    // ...and the undo the file spells out returns every row to what it carried.
+    await sql.unsafe(`
+      UPDATE "campaigns" c
+      SET "funnel_key" = d."previous_funnel_key"
+      FROM "campaign_funnel_owner_decisions" d
+      WHERE c."id"::text = d."campaign_id"
+        AND d."source" = '${TAG}'
+        AND c."funnel_key" = d."funnel_key";
+    `);
+    for (const ancestor of seeded.ancestors) {
+      expect(await funnelOf(ancestor.id)).toBeNull();
+    }
+  });
+
+  it("a second run changes ZERO rows", async () => {
+    const seeded = await seed();
+    await applyMigration();
+
+    const ids = [
+      seeded.live.id,
+      ...seeded.ancestors.map((a) => a.id),
+      seeded.statedAncestor.id,
+      seeded.otherChannel.id,
+      seeded.otherOrg.id,
+      seeded.severalLiveAncestor.id,
+      seeded.noLiveAncestor.id,
+      seeded.liveNoFunnel.id,
+      seeded.liveNoFunnelAncestor.id,
+    ];
+    const snapshot = async () =>
+      (await db.select().from(campaigns).where(inArray(campaigns.id, ids)))
+        .map((c) => `${c.id}:${c.funnelKey}:${c.status}:${c.updatedAt?.toISOString()}`)
+        .sort();
+
+    const afterFirst = await snapshot();
+    const decisionsAfterFirst = await db.select().from(campaignFunnelOwnerDecisions);
+
+    await applyMigration();
+
+    expect(await snapshot()).toEqual(afterFirst);
+    expect(await db.select().from(campaignFunnelOwnerDecisions)).toHaveLength(
+      decisionsAfterFirst.length,
+    );
+  });
+});
+
+describe("the runtime rule reaches the SAME verdict as the migration", () => {
+  it("selects exactly the rows the migration selects, and nothing else", async () => {
+    const seeded = await seed();
+    await applyRuntimeRule();
+
+    for (const ancestor of seeded.ancestors) {
+      expect(await funnelOf(ancestor.id)).toBe(CONVERSATION);
+      expect(await statusOf(ancestor.id)).toBe("stopped");
+    }
+    expect(await funnelOf(seeded.statedAncestor.id)).toBe(PURCHASES);
+    expect(await funnelOf(seeded.otherChannel.id)).toBeNull();
+    expect(await funnelOf(seeded.otherOrg.id)).toBeNull();
+    expect(await funnelOf(seeded.severalLiveAncestor.id)).toBeNull();
+    expect(await funnelOf(seeded.noLiveAncestor.id)).toBeNull();
+    expect(await funnelOf(seeded.liveNoFunnelAncestor.id)).toBeNull();
+    expect(await funnelOf(seeded.live.id)).toBe(CONVERSATION);
+    expect(await funnelOf(seeded.liveNoFunnel.id)).toBeNull();
+  });
+
+  it("a second run changes ZERO rows and writes no second decision", async () => {
+    const seeded = await seed();
+    const first = await applyRuntimeRule();
+    expect(first).toBe(seeded.ancestors.length);
+
+    const ids = [seeded.live.id, ...seeded.ancestors.map((a) => a.id)];
+    const snapshot = async () =>
+      (await db.select().from(campaigns).where(inArray(campaigns.id, ids)))
+        .map((c) => `${c.id}:${c.funnelKey}:${c.status}:${c.updatedAt?.toISOString()}`)
+        .sort();
+
+    const afterFirst = await snapshot();
+    const decisionsAfterFirst = await db.select().from(campaignFunnelOwnerDecisions);
+
+    expect(await applyRuntimeRule()).toBe(0);
+    expect(await snapshot()).toEqual(afterFirst);
+    expect(await db.select().from(campaignFunnelOwnerDecisions)).toHaveLength(
+      decisionsAfterFirst.length,
+    );
+  });
+
+  it("records every write with the value it replaced, and the undo returns every row", async () => {
+    const seeded = await seed();
+    await applyRuntimeRule();
+
+    const decisions = await db
+      .select()
+      .from(campaignFunnelOwnerDecisions)
+      .where(eq(campaignFunnelOwnerDecisions.source, ANCESTOR_ADOPTION_SOURCE));
+
+    expect(decisions.map((d) => d.campaignId).sort()).toEqual(
+      seeded.ancestors.map((a) => a.id).sort(),
+    );
+    for (const decision of decisions) {
+      expect(decision.previousFunnelKey).toBeNull();
+      expect(decision.funnelKey).toBe(CONVERSATION);
+      expect(decision.orgId).toBe(orgA);
+      expect(decision.brandId).toBe(brandOneLive);
+      expect(decision.decidedBy).toBe("campaign-identity");
+    }
+
+    await sql.unsafe(`
+      UPDATE "campaigns" c
+      SET "funnel_key" = d."previous_funnel_key"
+      FROM "campaign_funnel_owner_decisions" d
+      WHERE c."id"::text = d."campaign_id"
+        AND d."source" = '${ANCESTOR_ADOPTION_SOURCE}'
+        AND c."funnel_key" = d."funnel_key";
+    `);
+    for (const ancestor of seeded.ancestors) {
+      expect(await funnelOf(ancestor.id)).toBeNull();
+    }
+  });
+
+  it("a live campaign appearing on a triple LATER is what makes its ancestors eligible", async () => {
+    // The recurrence, in one test: on the day the migration runs the ancestor is still LIVE, so
+    // the rule correctly declines it. It becomes eligible only afterwards — which a one-shot
+    // migration can never revisit and the runtime rule catches on the next tick.
+    const ancestor = await insertTestCampaign(orgA, {
+      status: "ongoing",
+      brandId: brandNoLive,
+      acquisitionChannel: "cold_email",
+      funnelKey: null,
+      featureSlug: "sales-cold-email-outreach",
+    });
+    const scope = { orgId: orgA, brandId: brandNoLive, acquisitionChannel: "cold_email" };
+
+    await applyMigration();
+    expect(await funnelOf(ancestor.id)).toBeNull();
+
+    // The funnel gets funded: a twin is provisioned...
+    await insertTestCampaign(orgA, {
+      status: "ongoing",
+      brandId: brandNoLive,
+      acquisitionChannel: "cold_email",
+      funnelKey: CONVERSATION,
+      featureSlug: "sales-cold-email-outreach",
+    });
+    // ...and the funnel-less original is stopped.
+    await db.update(campaigns).set({ status: "stopped" }).where(eq(campaigns.id, ancestor.id));
+
+    expect(await adoptFunnellessAncestors(scope)).toBe(1);
+    expect(await funnelOf(ancestor.id)).toBe(CONVERSATION);
+    expect(await statusOf(ancestor.id)).toBe("stopped");
+  });
+});

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -36,6 +36,10 @@ vi.mock("../../src/db/index.js", () => ({
       },
     }),
     delete: vi.fn().mockReturnValue({ where: mockDeleteWhere }),
+    // Raw-SQL seam. The funnel-less-ancestor adoption runs through it and is inert here: these
+    // tests pin which QUESTIONS provisioning asks, not what the rule writes (that is measured
+    // against a real database in tests/integration/stopped-ancestor-funnel-rerun.test.ts).
+    execute: vi.fn().mockResolvedValue([]),
   },
 }));
 

--- a/tests/unit/offer-grain-funnels.test.ts
+++ b/tests/unit/offer-grain-funnels.test.ts
@@ -45,6 +45,10 @@ vi.mock("../../src/db/index.js", () => ({
       },
     }),
     delete: vi.fn().mockReturnValue({ where: mockDeleteWhere }),
+    // Raw-SQL seam. The funnel-less-ancestor adoption runs through it and is inert here: these
+    // tests pin which QUESTIONS provisioning asks, not what the rule writes (that is measured
+    // against a real database in tests/integration/stopped-ancestor-funnel-rerun.test.ts).
+    execute: vi.fn().mockResolvedValue([]),
   },
 }));
 


### PR DESCRIPTION
Promotes #377 to prod.

Fixes the offer-vs-campaign spend gap on brand `b97440f6`: $51.68 of the live campaign's own history sits on a stopped ancestor stating no funnel, so features-service files it under an identity with no live member.

- Migration `0051` states the funnel of the ONE row eligible today (dry-run against prod: exactly one group, one row, `2bd9ec88`).
- `src/lib/funnel-ancestor-adoption.ts` applies the same rule on the tick, so it stops being a migration.
- Also fixes a `23505` hard stop the fold activates: the existing-campaign lookup now prefers the ongoing row over the newest one.

Boot-time migration, idempotent and reversible. 612 tests green, build green, journal OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)