### PR TITLE
hotfix: Provisioning states a full identity on its two channel reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,28 @@ work ONE funnel through BOTH, and each is a campaign of its own.
   migration attributed some brands' single ceiling to the DEFAULT channel while their campaign runs
   another sales feature, and holding those would break a brand that has funded one channel per
   funnel all along.
+- **THE PROVISIONING PATH STATES A FULL IDENTITY, RUN ID INCLUDED — its two channel reads are
+  REFUSED without one.** features-service `GET /features/{slug}` answers `400 Missing required
+  headers: x-run-id` and workflow-service `GET /workflows` answers `400 x-org-id, x-user-id, and
+  x-run-id headers are required`, whatever the caller is doing. The provisioning identity is built
+  from a CAMPAIGN ROW, which carries no run, so both reads were rejected on every sweep and both
+  rejections were laundered into "unknown" and skipped: per-channel funding never worked once in
+  production (brand `75d7e3e8` funded the feedback-request channel on 19 Aug and had no campaign
+  for it nineteen hours later, with nothing in the logs about any of it). The brand-service read on
+  the same path answers 200 without a run id, which is why only this half was dead and why it
+  looked like nothing at all. `buildProvisioningIdentity` (`src/lib/provisioning-identity.ts`)
+  establishes the campaign's own ancestor via `ensureCampaignRunId` — a run runs-service can
+  resolve, never a minted uuid — and `ProvisioningIdentity` makes `userId` and `runId` REQUIRED so
+  the two clients cannot go back to attaching them when they happen to have them.
+  `tests/unit/no-legacy.test.ts` fails on a conditional identity header in either client.
+- **A pair passed over because a statement could not be READ says so, naming the pair.** "This
+  channel sells no such funnel" and "features-service would not answer" are different answers and
+  are returned as different ones (`FeatureSalesFunnelsRead` / `ActiveWorkflowRead`, both
+  `{ok:false, detail}` on a failure). A pair the customer is paying for that we FAILED to evaluate
+  is not a pair we evaluated and rejected, and collapsing the two is what let a read that was
+  rejected on every sweep look exactly like a channel with no dynasty. Skipping stays correct;
+  only the silence was wrong. Fail-SOFT still: an unreadable statement provisions nothing and does
+  NOT hold the brand — this decides which questions can be asked, not whether money may be spent.
 - **Which funnels a channel may be SOLD THROUGH is features-service's statement, asked per feature**
   (`GET /features/{slug}` → `salesFunnels`, `src/lib/feature-sales-funnels-client.ts`). The feedback
   request states `sales_meetings_from_conversation` alone: its offer buys a CONVERSATION, and the

--- a/src/lib/feature-sales-funnels-client.ts
+++ b/src/lib/feature-sales-funnels-client.ts
@@ -1,5 +1,5 @@
-import type { IdentityHeaders } from "@distribute/runs-client";
 import { toFunnelKey, type SalesFunnelKey } from "./sales-funnel-vocabulary.js";
+import type { ProvisioningIdentity } from "./provisioning-identity.js";
 
 /**
  * WHICH SALES FUNNELS AN ACQUISITION CHANNEL MAY BE SOLD THROUGH — features-service's statement,
@@ -11,32 +11,43 @@ import { toFunnelKey, type SalesFunnelKey } from "./sales-funnel-vocabulary.js";
  * the feature row every consumer already reads. Hardcoding the matrix here would be a second copy
  * of one fact, drifting the day a channel gains or loses a chain.
  *
- * Contract (features-service): GET /features/{slug} (x-api-key + identity)
+ * Contract (features-service): GET /features/{slug} (x-api-key + FULL identity)
  *   -> { slug, ..., salesFunnels: string[] }
+ *
+ * The identity is not tracking: features-service answers `400 Missing required headers: x-run-id`
+ * to a request that does not state one, whatever the caller is doing. So the header is always sent
+ * and the run id is one runs-service can resolve — see provisioning-identity.ts for why that took
+ * this feature out of production for its whole life.
  *
  * ALWAYS PRESENT on the wire: a feature that sells through no sales funnel states `[]` and one that
  * sells through every declared chain states all four keys. So an EMPTY list is a real answer —
  * "this feature sells through no sales funnel" — and never means "all of them".
  *
- * Returns null when the statement could not be read (missing config, network error, non-2xx,
- * unparseable payload, or the field absent because features-service predates it). The caller treats
- * that exactly as it treats an unreadable brand funnel declaration: provision nothing rather than
- * guess a pair a customer may not be able to sell through.
+ * A failure is NEVER laundered into an empty declaration: `{ ok: false }` says the statement could
+ * not be READ, which the caller passes over LOUDLY. A pair the customer is paying for that we
+ * cannot evaluate is not the same thing as a pair we evaluated and rejected, and telling them apart
+ * is the difference between a feature that has never worked and one that has never said so.
  */
+export type FeatureSalesFunnelsRead =
+  | { ok: true; funnels: Set<SalesFunnelKey> }
+  | { ok: false; detail: string };
+
 export async function fetchFeatureSalesFunnels(
   featureSlug: string,
-  identity: IdentityHeaders,
-): Promise<Set<SalesFunnelKey> | null> {
+  identity: ProvisioningIdentity,
+): Promise<FeatureSalesFunnelsRead> {
   const baseUrl = process.env.FEATURES_SERVICE_URL;
   const apiKey = process.env.FEATURES_SERVICE_API_KEY;
-  if (!baseUrl || !apiKey) return null;
+  if (!baseUrl || !apiKey) {
+    return { ok: false, detail: "FEATURES_SERVICE_URL / FEATURES_SERVICE_API_KEY not configured" };
+  }
 
   const headers: Record<string, string> = {
     "x-api-key": apiKey,
     "x-org-id": identity.orgId,
+    "x-user-id": identity.userId,
+    "x-run-id": identity.runId,
   };
-  if (identity.userId) headers["x-user-id"] = identity.userId;
-  if (identity.runId) headers["x-run-id"] = identity.runId;
   if (identity.campaignId) headers["x-campaign-id"] = identity.campaignId;
   if (identity.brandId) headers["x-brand-id"] = identity.brandId;
   if (identity.workflowSlug) headers["x-workflow-slug"] = identity.workflowSlug;
@@ -46,20 +57,32 @@ export async function fetchFeatureSalesFunnels(
       `${baseUrl.replace(/\/$/, "")}/features/${encodeURIComponent(featureSlug)}`,
       { headers },
     );
-    if (!res.ok) return null;
+    if (!res.ok) {
+      // The BODY is what says which header was missing (`Missing required headers: x-run-id`), so
+      // it is carried into the log line rather than a bare status nobody can act on.
+      let body = "";
+      try {
+        body = (await res.text()).slice(0, 200);
+      } catch {
+        body = "";
+      }
+      return { ok: false, detail: `HTTP ${res.status}${body ? ` ${body}` : ""}` };
+    }
 
     const data = await res.json() as { salesFunnels?: unknown };
-    if (!Array.isArray(data.salesFunnels)) return null;
+    if (!Array.isArray(data.salesFunnels)) {
+      return { ok: false, detail: "response states no salesFunnels array" };
+    }
 
-    const keys = new Set<SalesFunnelKey>();
+    const funnels = new Set<SalesFunnelKey>();
     for (const raw of data.salesFunnels) {
       // Any spelling in, one canonical token out — the same tolerance every other funnel read
       // here has. A key no catalogue names is skipped rather than worked.
       const key = typeof raw === "string" ? toFunnelKey(raw) : null;
-      if (key) keys.add(key);
+      if (key) funnels.add(key);
     }
-    return keys;
-  } catch {
-    return null;
+    return { ok: true, funnels };
+  } catch (err) {
+    return { ok: false, detail: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/src/lib/feature-workflow-client.ts
+++ b/src/lib/feature-workflow-client.ts
@@ -1,4 +1,4 @@
-import type { IdentityHeaders } from "@distribute/runs-client";
+import type { ProvisioningIdentity } from "./provisioning-identity.js";
 
 /**
  * A workflow that can actually RUN a given acquisition channel.
@@ -14,26 +14,39 @@ import type { IdentityHeaders } from "@distribute/runs-client";
  * campaign, and the next sweep provisions it the moment the dynasty ships. The slug chosen here is
  * only the seed — the greedy rotation re-picks one every run from that feature's own evidence.
  *
- * Contract (workflow-service): GET /workflows?featureSlug=&status=active
+ * Contract (workflow-service): GET /workflows?featureSlug=&status=active (x-api-key + FULL identity)
  *   -> { workflows: [{ workflowSlug, workflowDynastySlug, featureSlug, createdAt, ... }] }
  *
- * Returns null on missing config, network error, non-2xx, an unparseable payload, or a feature with
- * no active workflow.
+ * The identity is not tracking: workflow-service answers `400 x-org-id, x-user-id, and x-run-id
+ * headers are required` to anything less, so all three are always sent and the run id is one
+ * runs-service can resolve (see provisioning-identity.ts).
+ *
+ * "This channel has NO active workflow" and "I could not READ what workflows this channel has" are
+ * different answers and are returned as different ones. Both skip the pair — but only one of them
+ * means the customer is funding something we failed to evaluate, and collapsing them is how a read
+ * that was rejected outright on every sweep looked exactly like a channel with no dynasty.
  */
+export type ActiveWorkflowRead =
+  | { ok: true; workflowSlug: string }
+  | { ok: true; workflowSlug: null }
+  | { ok: false; detail: string };
+
 export async function fetchActiveWorkflowSlugForFeature(
   featureSlug: string,
-  identity: IdentityHeaders,
-): Promise<string | null> {
+  identity: ProvisioningIdentity,
+): Promise<ActiveWorkflowRead> {
   const baseUrl = process.env.WORKFLOW_SERVICE_URL;
   const apiKey = process.env.WORKFLOW_SERVICE_API_KEY;
-  if (!baseUrl || !apiKey) return null;
+  if (!baseUrl || !apiKey) {
+    return { ok: false, detail: "WORKFLOW_SERVICE_URL / WORKFLOW_SERVICE_API_KEY not configured" };
+  }
 
   const headers: Record<string, string> = {
     "x-api-key": apiKey,
     "x-org-id": identity.orgId,
+    "x-user-id": identity.userId,
+    "x-run-id": identity.runId,
   };
-  if (identity.userId) headers["x-user-id"] = identity.userId;
-  if (identity.runId) headers["x-run-id"] = identity.runId;
   if (identity.brandId) headers["x-brand-id"] = identity.brandId;
 
   try {
@@ -42,12 +55,24 @@ export async function fetchActiveWorkflowSlugForFeature(
     url.searchParams.set("status", "active");
 
     const res = await fetch(url, { headers });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      // The BODY names the missing header (`x-org-id, x-user-id, and x-run-id headers are
+      // required`), which is the whole diagnostic — a bare status says nothing actionable.
+      let body = "";
+      try {
+        body = (await res.text()).slice(0, 200);
+      } catch {
+        body = "";
+      }
+      return { ok: false, detail: `HTTP ${res.status}${body ? ` ${body}` : ""}` };
+    }
 
     const data = await res.json() as {
       workflows?: Array<{ workflowSlug?: string; featureSlug?: string; createdAt?: string }>;
     };
-    if (!Array.isArray(data.workflows)) return null;
+    if (!Array.isArray(data.workflows)) {
+      return { ok: false, detail: "response states no workflows array" };
+    }
 
     // Filtered again on the feature: the seed must belong to the channel it is provisioned for,
     // whatever the query returned.
@@ -55,13 +80,13 @@ export async function fetchActiveWorkflowSlugForFeature(
       (w) => typeof w?.workflowSlug === "string" && w.workflowSlug.length > 0
         && (w.featureSlug === undefined || w.featureSlug === featureSlug),
     );
-    if (candidates.length === 0) return null;
+    if (candidates.length === 0) return { ok: true, workflowSlug: null };
 
     // Newest first, so a brand-new campaign starts on the channel's current workflow rather than
     // its oldest one. Ties (or an absent createdAt) fall back to the listed order, which is stable.
     candidates.sort((a, b) => String(b.createdAt ?? "").localeCompare(String(a.createdAt ?? "")));
-    return candidates[0]!.workflowSlug!;
-  } catch {
-    return null;
+    return { ok: true, workflowSlug: candidates[0]!.workflowSlug! };
+  } catch (err) {
+    return { ok: false, detail: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -8,8 +8,9 @@ import {
   fundedFunnels,
   type FunnelBudgetsRead,
 } from "./funnel-budget-client.js";
-import { fetchFeatureSalesFunnels } from "./feature-sales-funnels-client.js";
-import { fetchActiveWorkflowSlugForFeature } from "./feature-workflow-client.js";
+import { fetchFeatureSalesFunnels, type FeatureSalesFunnelsRead } from "./feature-sales-funnels-client.js";
+import { fetchActiveWorkflowSlugForFeature, type ActiveWorkflowRead } from "./feature-workflow-client.js";
+import { buildProvisioningIdentity, type ProvisioningIdentity } from "./provisioning-identity.js";
 import type { SalesFunnelKey } from "./sales-funnel-vocabulary.js";
 import {
   fetchBrandSalesFunnels,
@@ -51,6 +52,12 @@ export interface ClaimedFunnelCampaign {
   id: string;
   orgId: string;
   createdByUserId: string | null;
+  /**
+   * This campaign's ancestor run — what the provisioning reads state as their `x-run-id`, and what
+   * a trigger hands workflow-service. NULL until `ensureCampaignRunId` establishes one; never a
+   * minted uuid, which runs-service refuses.
+   */
+  parentRunId: string | null;
   workflowSlug: string;
   brandIds: string[] | null;
   featureSlug: string | null;
@@ -197,10 +204,25 @@ async function planOneBrand(
 
   const funded = fundedPairs(budgets, featureSlug);
   if (funded.length > 0) {
-    // Asked over the WHOLE group, not just the seed: a brand selling several offers has one
-    // campaign per offer in flight, and each is ranked on the funnels of the offer IT sells.
-    const declared = await resolveDeclaredFunnels(group, brandId, identity);
-    await ensureFundedFunnelCampaigns({ seed, brandId, funded, declared, identity, now });
+    // The reads below are REFUSED without a full identity, and the campaign row this path is built
+    // from carries no run — so the campaign's own ancestor run is established first and stated on
+    // every one of them. Null here provisions nothing this sweep and is already logged; it does
+    // not hold the brand, because this decides which questions can be asked, not whether money
+    // may be spent.
+    const provisioning = await buildProvisioningIdentity(seed, brandId);
+    if (provisioning) {
+      // Asked over the WHOLE group, not just the seed: a brand selling several offers has one
+      // campaign per offer in flight, and each is ranked on the funnels of the offer IT sells.
+      const declared = await resolveDeclaredFunnels(group, brandId, provisioning);
+      await ensureFundedFunnelCampaigns({
+        seed,
+        brandId,
+        funded,
+        declared,
+        identity: provisioning,
+        now,
+      });
+    }
   }
 
   // (0) The hold. A campaign the customer funds nothing for waits for money, not for a turn — so
@@ -324,7 +346,7 @@ const NO_DECLARED_FUNNELS: ResolvedDeclaredFunnels = {
 async function resolveDeclaredFunnels(
   group: Array<{ offerId?: string | null }>,
   brandId: string,
-  identity: IdentityHeaders,
+  identity: ProvisioningIdentity,
 ): Promise<ResolvedDeclaredFunnels> {
   const offerIds = [...new Set(group.map((c) => c.offerId).filter((id): id is string => !!id))];
   const anyOfferless = group.some((c) => !c.offerId);
@@ -415,7 +437,7 @@ async function ensureFundedFunnelCampaigns({
   brandId: string;
   funded: FundedPair[];
   declared: ResolvedDeclaredFunnels;
-  identity: IdentityHeaders;
+  identity: ProvisioningIdentity;
   now: Date;
 }): Promise<void> {
   // No readable funnel declaration → nothing says the brand still sells through these funnels.
@@ -424,8 +446,8 @@ async function ensureFundedFunnelCampaigns({
   if (!seed.createdByUserId) return; // no recipient/owner to attribute a new campaign to
 
   // One read per CHANNEL, not per pair: a brand funding both of a channel's funnels asks once.
-  const sellableByFeature = new Map<string, Set<SalesFunnelKey> | null>();
-  const workflowByFeature = new Map<string, string | null>();
+  const sellableByFeature = new Map<string, FeatureSalesFunnelsRead>();
+  const workflowByFeature = new Map<string, ActiveWorkflowRead>();
 
   // The (org, brand, acquisition channel) triples a funnel campaign is provisioned for on this
   // tick. Collected rather than acted on inline BECAUSE the existing-campaign check below returns
@@ -453,9 +475,16 @@ async function ensureFundedFunnelCampaigns({
     }
     const sellable = sellableByFeature.get(featureSlug)!;
     // Unreadable → provision nothing for this channel, exactly as an unreadable brand declaration
-    // provisions nothing for the brand. A pair is not guessed at.
-    if (!sellable) continue;
-    if (!sellable.has(f.funnelKey)) {
+    // provisions nothing for the brand. A pair is not guessed at — but it is not passed over in
+    // silence either: the customer's money is on this pair and we failed to evaluate it, which is
+    // a different thing from evaluating it and saying no.
+    if (!sellable.ok) {
+      console.warn(
+        `[campaign-service] Not provisioning ${featureSlug} for funnel ${f.funnelKey} (brand ${brandId}, org ${seed.orgId}) — could not READ features-service's statement of which funnels this channel sells: ${sellable.detail}`,
+      );
+      continue;
+    }
+    if (!sellable.funnels.has(f.funnelKey)) {
       // A pair nobody can run: the customer funds it, but this channel has no way to sell that
       // chain. Logged once per sweep rather than silently dropped — the money is real and the
       // customer is owed an answer about it eventually.
@@ -523,7 +552,16 @@ async function ensureFundedFunnelCampaigns({
           await fetchActiveWorkflowSlugForFeature(featureSlug, identity),
         );
       }
-      workflowSlug = workflowByFeature.get(featureSlug)!;
+      const read = workflowByFeature.get(featureSlug)!;
+      // "This channel has no dynasty yet" is a routine answer; "workflow-service would not tell
+      // me" is a funded pair nobody evaluated. Same skip, different sentence, on purpose.
+      if (!read.ok) {
+        console.warn(
+          `[campaign-service] Not provisioning ${featureSlug} for funnel ${f.funnelKey} (brand ${brandId}, org ${seed.orgId}) — could not READ workflow-service's active workflows for this channel: ${read.detail}`,
+        );
+        continue;
+      }
+      workflowSlug = read.workflowSlug;
     }
     if (!workflowSlug) {
       console.log(
@@ -637,10 +675,11 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
     workflow_slug: string;
     created_by_user_id: string;
     offer_id: string | null;
+    parent_run_id: string | null;
   }>(sql`
     SELECT DISTINCT ON (c.org_id, coalesce(c.brand_id, c.brand_ids[1]))
            c.id, c.org_id, coalesce(c.brand_id, c.brand_ids[1]) AS brand_id,
-           c.feature_slug, c.workflow_slug, c.created_by_user_id, c.offer_id
+           c.feature_slug, c.workflow_slug, c.created_by_user_id, c.offer_id, c.parent_run_id
     FROM campaigns c
     WHERE c.feature_slug IN (${sql.join(slugs.map((s) => sql`${s}`), sql`, `)})
       AND coalesce(c.brand_id, c.brand_ids[1]) IS NOT NULL
@@ -664,6 +703,7 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
     workflow_slug: string;
     created_by_user_id: string;
     offer_id: string | null;
+    parent_run_id: string | null;
   }>);
   const examined = rows.slice(0, FUNDING_SWEEP_MAX_BRANDS);
   if (rows.length > FUNDING_SWEEP_MAX_BRANDS) {
@@ -675,6 +715,19 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
   let provisioned = 0;
   for (const row of examined) {
     try {
+      const seed: ClaimedFunnelCampaign = {
+        id: row.id,
+        orgId: row.org_id,
+        createdByUserId: row.created_by_user_id,
+        parentRunId: row.parent_run_id,
+        workflowSlug: row.workflow_slug,
+        brandIds: [row.brand_id],
+        featureSlug: row.feature_slug,
+        funnelKey: null,
+        dailyBudgetCents: null,
+        offerId: row.offer_id,
+      };
+
       const identity: IdentityHeaders = {
         orgId: row.org_id,
         userId: row.created_by_user_id,
@@ -691,28 +744,23 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
       // the brand having no ongoing campaign.
       if (funded.length === 0) continue;
 
+      // Same identity discipline as the tick: the two channel reads are refused without a run id,
+      // and this sweep's seed carries one no more than a claimed row does.
+      const provisioning = await buildProvisioningIdentity(seed, row.brand_id);
+      if (!provisioning) continue;
+
       const declared = await resolveDeclaredFunnels(
         [{ offerId: row.offer_id }],
         row.brand_id,
-        identity,
+        provisioning,
       );
       const before = await countOngoingSalesCampaigns(row.org_id, row.brand_id);
       await ensureFundedFunnelCampaigns({
-        seed: {
-          id: row.id,
-          orgId: row.org_id,
-          createdByUserId: row.created_by_user_id,
-          workflowSlug: row.workflow_slug,
-          brandIds: [row.brand_id],
-          featureSlug: row.feature_slug,
-          funnelKey: null,
-          dailyBudgetCents: null,
-          offerId: row.offer_id,
-        },
+        seed,
         brandId: row.brand_id,
         funded,
         declared,
-        identity,
+        identity: provisioning,
         now,
       });
       const after = await countOngoingSalesCampaigns(row.org_id, row.brand_id);

--- a/src/lib/provisioning-identity.ts
+++ b/src/lib/provisioning-identity.ts
@@ -1,0 +1,68 @@
+import type { IdentityHeaders } from "@distribute/runs-client";
+import { ensureCampaignRunId, type AnchorableCampaign } from "./trigger-run.js";
+
+/**
+ * The identity the PROVISIONING path carries — well-formed enough for a sibling to accept it.
+ *
+ * Provisioning asks two services what a funded pair may do: features-service which funnels a
+ * channel sells (`GET /features/{slug}`) and workflow-service which workflow can run it
+ * (`GET /workflows?featureSlug=`). Both REJECT a request that does not state a full identity —
+ * `400 Missing required headers: x-run-id` and `400 x-org-id, x-user-id, and x-run-id headers are
+ * required` — whatever the caller happens to be doing.
+ *
+ * The provisioning identity was built from a CAMPAIGN ROW, which carries no run, so both reads
+ * 400'd on every sweep and both rejections were laundered into "unknown" and skipped. The whole
+ * per-channel funding promise therefore never worked once in production: brand 75d7e3e8 funded the
+ * feedback-request channel on 2026-08-19 and had no campaign for it nineteen hours later, with not
+ * one line in the logs about any of it. The brand-service read on the same path answers 200 without
+ * a run id, which is why only this half was dead and why it looked like nothing at all.
+ *
+ * So the identity STATES a run id, and it is a run that EXISTS: the campaign's own ancestor via
+ * `ensureCampaignRunId`, created once and persisted on the row. Never a minted uuid — a run id this
+ * service hands another service must be one runs-service can resolve (see trigger-run.ts), and
+ * `tests/unit/no-legacy.test.ts` fails on a minted uuid here.
+ *
+ * `userId` and `runId` are REQUIRED by the type rather than filled in when convenient: both clients
+ * used to attach their headers only when they happened to have them, which is exactly how a
+ * silently-identity-less read survives a refactor.
+ */
+export interface ProvisioningIdentity extends IdentityHeaders {
+  userId: string;
+  runId: string;
+}
+
+/**
+ * Establish the identity provisioning reads with, or say why it could not be.
+ *
+ * Fail-SOFT: a campaign with no owner to attribute a new campaign to, or an anchor runs-service
+ * would not create, provisions nothing this sweep and is looked at again on the next one. It does
+ * NOT hold the brand — this decides which questions can be asked, not whether money may be spent,
+ * and the turn-taking and the funding hold are deliberately untouched by it.
+ */
+export async function buildProvisioningIdentity(
+  seed: AnchorableCampaign & { workflowSlug?: string | null },
+  brandId: string,
+): Promise<ProvisioningIdentity | null> {
+  if (!seed.createdByUserId) return null;
+
+  let runId: string;
+  try {
+    runId = await ensureCampaignRunId(seed);
+  } catch (err) {
+    console.warn(
+      `[campaign-service] Not provisioning funded funnels of brand ${brandId} (org ${seed.orgId}) this sweep — the ancestor run its reads must state could not be established:`,
+      err,
+    );
+    return null;
+  }
+
+  return {
+    orgId: seed.orgId,
+    userId: seed.createdByUserId,
+    runId,
+    campaignId: seed.id,
+    brandId,
+    workflowSlug: seed.workflowSlug ?? undefined,
+    featureSlug: seed.featureSlug ?? undefined,
+  };
+}

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -9,9 +9,13 @@ const {
   mockUpdateSet,
   mockUpdateWhere,
   mockDeleteWhere,
+  mockCreateRun,
+  mockUpdateRun,
 } = vi.hoisted(() => ({
   mockListRuns: vi.fn(),
   mockGetStatsBudget: vi.fn(),
+  mockCreateRun: vi.fn(),
+  mockUpdateRun: vi.fn(),
   mockFindFirst: vi.fn(),
   mockFindMany: vi.fn(),
   mockInsertValues: vi.fn(),
@@ -23,6 +27,8 @@ const {
 vi.mock("@distribute/runs-client", () => ({
   listRuns: mockListRuns,
   getStatsBudget: mockGetStatsBudget,
+  createRun: mockCreateRun,
+  updateRun: mockUpdateRun,
 }));
 
 vi.mock("../../src/db/index.js", () => ({
@@ -82,6 +88,8 @@ import {
 
 const SALES = "sales-cold-email-outreach";
 const FEEDBACK = "feedback-request-cold-email-outreach";
+const ANCESTOR_RUN_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // The brand's alive campaigns, as the sales-scoped liveness check reads them.
 let aliveBrandCampaigns: Array<{ id: string; featureSlug: string | null }> = [];
@@ -90,6 +98,8 @@ function claimed(overrides: Partial<ClaimedFunnelCampaign> = {}): ClaimedFunnelC
     id: "campaign-1",
     orgId: "org-1",
     createdByUserId: "user-1",
+    // The campaign's ancestor run — what every provisioning read states as its `x-run-id`.
+    parentRunId: ANCESTOR_RUN_ID,
     workflowSlug: "sales-email-cold-outreach",
     brandIds: ["brand-1"],
     featureSlug: SALES,
@@ -145,6 +155,20 @@ function mockDeclaredFunnels(funnels: Array<{ funnelKey: string; active?: boolea
       })),
     }),
   });
+}
+
+/** Run something and return everything it said on console.warn, joined. */
+async function captureWarnings(run: () => Promise<unknown>): Promise<string> {
+  const said: string[] = [];
+  const warn = vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+    said.push(args.map((a) => (a instanceof Error ? a.message : String(a))).join(" "));
+  });
+  try {
+    await run();
+  } finally {
+    warn.mockRestore();
+  }
+  return said.join("\n");
 }
 
 function mockSpend(cents: string) {
@@ -368,6 +392,59 @@ describe("planFunnelTurns", () => {
     expect(mockInsertValues).not.toHaveBeenCalled();
   });
 
+  it("states a FULL identity on both channel reads — the run id included, and it resolves", async () => {
+    // The whole feature was dead in production on exactly this: the provisioning identity was
+    // built from a campaign row, so it carried no run, and both services rejected it outright
+    // (`400 Missing required headers: x-run-id` / `400 x-org-id, x-user-id, and x-run-id headers
+    // are required`). Both rejections became "unknown" and the pair was skipped, silently.
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "2000" }],
+      "2000",
+      [{ funnelKey: "reply_meeting", featureSlug: FEEDBACK, dailyBudgetCents: "2000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    const reads = mockFetch.mock.calls.filter(
+      (c) => String(c[0]).includes("/features/") || String(c[0]).includes("/workflows"),
+    );
+    expect(reads.length).toBeGreaterThanOrEqual(2);
+    for (const [, init] of reads) {
+      const headers = (init as { headers: Record<string, string> }).headers;
+      expect(headers["x-org-id"]).toBe("org-1");
+      expect(headers["x-user-id"]).toBe("user-1");
+      // Well-formed enough for the downstream to accept, and a run runs-service can resolve —
+      // never a minted uuid (see trigger-run.ts / no-legacy).
+      expect(headers["x-run-id"]).toBe(ANCESTOR_RUN_ID);
+      expect(headers["x-run-id"]).toMatch(UUID_RE);
+    }
+  });
+
+  it("anchors a campaign that has no ancestor run BEFORE asking, and reuses that run", async () => {
+    const minted = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    mockCreateRun.mockResolvedValue({ id: minted });
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "2000" }],
+      "2000",
+      [{ funnelKey: "reply_meeting", featureSlug: FEEDBACK, dailyBudgetCents: "2000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([
+      claimed({ funnelKey: "sales_meetings_from_conversation", parentRunId: null }),
+    ]);
+
+    // Created once and PERSISTED on the campaign, so the next sweep takes the same branch as a
+    // campaign born with one.
+    expect(mockCreateRun).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSet).toHaveBeenCalledWith(expect.objectContaining({ parentRunId: minted }));
+    const featureRead = mockFetch.mock.calls.find((c) => String(c[0]).includes("/features/"))!;
+    expect((featureRead[1] as { headers: Record<string, string> }).headers["x-run-id"]).toBe(minted);
+  });
+
   it("provisions nothing for a channel whose funnel statement cannot be read", async () => {
     mockFunnelBudgets(
       [{ funnelKey: "reply_meeting", dailyBudgetCents: "2000" }],
@@ -378,10 +455,47 @@ describe("planFunnelTurns", () => {
     mockFindFirst.mockResolvedValue(undefined);
     mockFetch.mockImplementationOnce(async () => ({ ok: false, status: 500, json: async () => ({}) }));
 
-    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+    const said = await captureWarnings(() =>
+      planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]),
+    );
 
     // A pair is never guessed at — the same stance an unreadable brand declaration takes.
     expect(mockInsertValues).not.toHaveBeenCalled();
+    // ...and it is never passed over in SILENCE. The customer's money is on this pair and we
+    // failed to evaluate it, which is a different thing from evaluating it and saying no.
+    expect(said).toMatch(/could not READ features-service/);
+    expect(said).toContain(FEEDBACK);
+    expect(said).toContain("sales_meetings_from_conversation");
+    expect(said).toContain("brand-1");
+  });
+
+  it("says which funded pair it passed over when workflow-service will not answer", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "2000" }],
+      "2000",
+      [{ funnelKey: "reply_meeting", featureSlug: FEEDBACK, dailyBudgetCents: "2000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+    mockFetch.mockImplementation(async (input: URL | string) => {
+      const url = String(input);
+      if (url.includes("/features/")) {
+        return { ok: true, json: async () => ({ salesFunnels: [...SALES_FUNNEL_KEYS] }) };
+      }
+      // A REJECTION, not an empty catalogue. Collapsing the two is how a read that was refused on
+      // every sweep looked exactly like a channel with no dynasty.
+      return { ok: false, status: 400, text: async () => "x-run-id header required" };
+    });
+
+    const said = await captureWarnings(() =>
+      planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]),
+    );
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(said).toMatch(/could not READ workflow-service/);
+    expect(said).toContain(FEEDBACK);
+    expect(said).toContain("sales_meetings_from_conversation");
+    expect(said).toContain("400");
   });
 
   it("provisions nothing for a channel with no active workflow to run it", async () => {

--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -365,7 +365,12 @@ describe('No Legacy Patterns - CRITICAL', () => {
     // while the campaign kept looking ongoing and freshly rescheduled (prod 2026-08-18: 3,593
     // refusals in six hours, a different id on every line). A campaign's ancestor run is
     // established ONCE, for real, in src/lib/trigger-run.ts.
-    const guarded = ['lib/scheduler.ts', 'lib/campaign-resume.ts', 'lib/transactional-email.ts'];
+    const guarded = [
+      'lib/scheduler.ts',
+      'lib/campaign-resume.ts',
+      'lib/transactional-email.ts',
+      'lib/provisioning-identity.ts',
+    ];
     const violations: string[] = [];
 
     for (const rel of guarded) {
@@ -379,6 +384,35 @@ describe('No Legacy Patterns - CRITICAL', () => {
     expect(
       violations,
       `A run id handed to another service must be one runs-service can resolve — use ensureCampaignRunId:\n${violations.join('\n')}`,
+    ).toHaveLength(0);
+  });
+
+  it('should NOT make the provisioning identity headers conditional', () => {
+    // features-service and workflow-service REFUSE a read that does not state a full identity —
+    // `400 Missing required headers: x-run-id` and `400 x-org-id, x-user-id, and x-run-id headers
+    // are required` — whatever the caller happens to be doing. Both clients used to attach those
+    // headers only when they happened to have them, and the provisioning path never did: every
+    // read was rejected outright, every rejection became "unknown", and the whole per-channel
+    // funding promise never worked once in production while saying nothing at all. Sending them
+    // unconditionally is what makes the refusal impossible to reintroduce quietly.
+    const guarded = ['lib/feature-sales-funnels-client.ts', 'lib/feature-workflow-client.ts'];
+    const violations: string[] = [];
+
+    for (const rel of guarded) {
+      const content = fs.readFileSync(path.join(srcDir, rel), 'utf-8');
+      content.split('\n').forEach((line, index) => {
+        if (/if\s*\(identity\.(runId|userId|orgId)\)/.test(line)) {
+          violations.push(`src/${rel}:${index + 1}\n    ${line.trim()}`);
+        }
+      });
+      for (const header of ['x-org-id', 'x-user-id', 'x-run-id']) {
+        if (!content.includes(`"${header}"`)) violations.push(`src/${rel} states no ${header}`);
+      }
+    }
+
+    expect(
+      violations,
+      `A provisioning read states its full identity or it is refused:\n${violations.join('\n')}`,
     ).toHaveLength(0);
   });
 

--- a/tests/unit/offer-grain-funnels.test.ts
+++ b/tests/unit/offer-grain-funnels.test.ts
@@ -32,6 +32,12 @@ const {
 vi.mock("@distribute/runs-client", () => ({
   listRuns: mockListRuns,
   getStatsBudget: mockGetStatsBudget,
+  // Provisioning states an ancestor run on every read it makes — the seeds below already carry
+  // one, so these exist to fail loudly if a path ever mints a second.
+  createRun: vi.fn(async () => {
+    throw new Error("createRun must not be called: the seed already states an ancestor run");
+  }),
+  updateRun: vi.fn(),
 }));
 
 vi.mock("../../src/db/index.js", () => ({
@@ -97,6 +103,7 @@ function claimed(overrides: Partial<ClaimedFunnelCampaign> = {}): ClaimedFunnelC
     id: "campaign-1",
     orgId: "org-1",
     createdByUserId: "user-1",
+    parentRunId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
     workflowSlug: "sales-email-cold-outreach",
     brandIds: ["brand-1"],
     featureSlug: SALES,


### PR DESCRIPTION
Automated by release.sh