### PR TITLE
hotfix: a campaign that served nothing has exhausted nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -630,10 +630,10 @@ out of people, not whether an audience is dry right now). Every other guard aske
 is set up to keep spending; none asked whether anybody was ever contacted, so a brand with NO
 audience and NO contacts reached the same auto-stop branch and was told its outreach had finished:
 zero out of zero read as everyone. That brand writes no exhaustion row precisely because its stop
-carries no audience id — the case `/end-run` already logs as "cannot mark a specific audience
-exhausted" — so the mark IS the evidence, and no new state was needed to tell the two apart. The
-campaign still stops; only the claim is withheld, and the dashboard's persistent "no active
-audience" banner is what that brand reads instead. Verified in prod 2026-08-16: the three campaigns
+carries no audience id — the case `/end-run` already logs as "no audience ran" — so the mark IS
+the evidence, and no new state was needed to tell the two apart. **Since 2026-08-20 that same
+evidence gates the STOP itself, not only the claim** (next section): withholding the email while
+still stopping was half the fix. Verified in prod 2026-08-16: the three campaigns
 that ever received this email hold 11, 3 and **0** exhaustion rows — the zero is Lux Projects Bali
 (`cb965e9d`, brand `ccc29ba2`, emailed twice, 0 contacts and 0 audiences ever); the other two are
 unaffected.
@@ -648,6 +648,41 @@ body, so the name is escaped here. The name comes from brand-service `/runtime-c
 this service already makes; if it cannot be resolved the footer is EMPTY and the email reads exactly
 as it did before. Never substitute a placeholder or an id for a name a customer will read.
 (Set 2026-08-16.)
+
+## A campaign that served NOTHING has exhausted nothing — the terminal verdict rests on POSITIVE evidence, never on an empty remainder
+
+The auto-stop asked ONE question: is there a serveable audience left? "None left" is equally true
+of a campaign that never had one, so a campaign that had contacted nobody took the same branch as
+one that had genuinely worked its audiences to the end — 0 of 0 read as 100%. The verdict is now
+gated on evidence that work HAPPENED through that campaign: `isExhaustionStopWarranted`
+(`src/lib/audience-exhaustion.ts`) is `!serveable && hasExhaustedAudience(campaignId)`, the SAME
+mark the extend-audience email is gated on, and it is only ever written for a run that named a
+real audience.
+
+- **Without that evidence the campaign is NOT stopped at all.** It stays `ongoing` and falls
+  through to the normal reschedule, so the next tick looks at it again. Nothing new decides
+  whether it may spend: the turn planner holds it if its pair is unfunded and the gate refuses a
+  run it cannot price. The alternative — stopping it — is STICKY: funding deliberately resumes a
+  campaign that was HELD but never one that stopped for a reason of its own, so
+  `audience_exhausted` parks a funded channel indefinitely with no manual path back, and the
+  funding sweep says exactly that on every pass.
+- **The degenerate branch states its decision.** `stopCampaign=true` with no `x-audience-id` used
+  to log that it could not mark an audience and then proceed to the stop anyway; it now says no
+  audience ran, and the gate says it is therefore not concluding exhaustion.
+- **The exhaustion stop itself is untouched.** A campaign that HAS served and then genuinely
+  exhausts still stops, still emails, still resumes through the sweep. Money is not an answer to
+  exhaustion; only the zero-evidence case was wrong.
+- **Migration 0052** applies the same rule to the rows already carrying the verdict — stopped for
+  `audience_exhausted` with zero exhaustion marks, and no live twin holding their identity — and
+  returns them to `ongoing` / no reason / due now, auditing each in
+  `campaign_stop_reason_decisions`. It selected the whole stopped-for-exhaustion population in
+  prod, two rows: `4769db14` (the first campaign the per-channel provisioner ever created, dead
+  ten seconds after birth on a channel funded at $10/day) and `cb965e9d` (Lux Projects Bali, the
+  0-audience brand above). Pinned by `tests/integration/unpark-never-served-migration.test.ts`,
+  which applies the file itself twice.
+- WHY that campaign's first serve came back empty on a brand whose sibling served 109 leads the
+  same day is a separate lead-service investigation. This service's job was to stop reading an
+  empty answer as a finished one. (Set 2026-08-20.)
 
 ## A campaign that ran out of people to contact comes BACK on its own — the customer's action is the trigger, and they were told so
 

--- a/drizzle/0052_unpark_never_served_exhaustion_stops.sql
+++ b/drizzle/0052_unpark_never_served_exhaustion_stops.sql
@@ -48,6 +48,11 @@
 -- IDEMPOTENT: a second run selects nothing (the rows it wrote are no longer stopped). REVERSIBLE
 -- by the ids the audit table records.
 
+-- campaign_id is `text` on purpose, and every comparison against it casts. The two id columns
+-- this file touches disagree on type in prod (campaigns.id is uuid, campaign_audience_exhaustion
+-- .campaign_id is text — a historical drift), and a from-scratch migrate chain lands them
+-- differently again, so `text` on both sides of an explicit cast is the only spelling that holds
+-- everywhere.
 CREATE TABLE IF NOT EXISTS campaign_stop_reason_decisions (
   id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   campaign_id     text NOT NULL,
@@ -87,7 +92,7 @@ WITH candidates AS (
 audited AS (
   INSERT INTO campaign_stop_reason_decisions
     (campaign_id, previous_status, previous_reason, new_status, new_reason, decided_by)
-  SELECT c.id, c.status, c.stop_reason, 'ongoing', NULL,
+  SELECT c.id::text, c.status, c.stop_reason, 'ongoing', NULL,
          '0052_unpark_never_served_exhaustion_stops'
   FROM campaigns c
   JOIN candidates k ON k.id = c.id
@@ -101,4 +106,4 @@ SET status = 'ongoing',
     next_run_at = now(),
     updated_at = now()
 FROM audited a
-WHERE c.id = a.campaign_id;
+WHERE c.id::text = a.campaign_id;

--- a/drizzle/0052_unpark_never_served_exhaustion_stops.sql
+++ b/drizzle/0052_unpark_never_served_exhaustion_stops.sql
@@ -1,0 +1,104 @@
+-- A campaign that served NOTHING was never exhausted — un-park the ones stopped on that verdict.
+--
+-- /end-run auto-stops a campaign as `audience_exhausted` when it has no serveable audience left.
+-- "Nothing left to serve" is also true for a campaign that never had anything to serve, so the
+-- test was satisfied trivially at zero: a campaign that had contacted nobody took the same branch
+-- as one that had genuinely worked its audiences to the end. 0 of 0 read as 100%.
+--
+-- That verdict is STICKY. Funding deliberately brings back a campaign that was HELD but never one
+-- that stopped for a reason of its own, so `audience_exhausted` parks a campaign indefinitely and
+-- the funding sweep says so on every pass ("Not resuming ... it stopped for audience_exhausted").
+-- A customer therefore funds a channel that produces nothing, forever, with no manual path back.
+--
+-- The code half of the fix (src/routes/internal.ts) gates the stop on POSITIVE evidence that
+-- outreach actually ran out of people through that campaign: a row in
+-- campaign_audience_exhaustion, which is only ever written for a run that named a real audience.
+-- A campaign holding none is not stopped at all — it stays ongoing and is rescheduled.
+--
+-- This file states the SAME rule over the rows that already carry the verdict: a campaign stopped
+-- for `audience_exhausted` that has never marked a single audience exhausted was parked on a
+-- conclusion about work that never happened, so it goes back to the state the fixed code would
+-- have produced — `ongoing`, no stop reason, due now.
+--
+-- What it selects in prod, read against the live database before this file was written
+-- (2026-08-20): the WHOLE stopped-for-exhaustion population is two rows, and both hold zero
+-- exhaustion marks.
+--
+--   4769db14-0a79-4f8e-8b3e-983189d0296d  org b645207b / brand 75d7e3e8
+--                                         sales_meetings_from_conversation / feedback_request_email
+--                                         created 10:08:01, stopped 10:08:11 the same day —
+--                                         the first campaign the per-channel provisioner ever
+--                                         created, dead ten seconds after birth having served
+--                                         nothing, on a channel the customer funds at $10/day.
+--   cb965e9d-211f-4caa-98bb-033102017633  org b645207b / brand ccc29ba2
+--                                         website_purchases / crm_email — the brand with 0
+--                                         audiences and 0 contacts ever (already documented as
+--                                         the one that was wrongly told its outreach had
+--                                         finished).
+--
+-- Neither collides: the partial unique index is on (org, brand, funnel, channel) over `ongoing`
+-- rows, and the only live campaign on either brand is 9bc27ed7 (75d7e3e8 / cold_email), a
+-- different channel. The exclusion below is stated as a rule anyway, so a re-run can never write
+-- a row the index would refuse.
+--
+-- Returning a campaign to `ongoing` does NOT authorize it to spend: the turn planner holds an
+-- unfunded campaign every tick and the gate refuses a run it cannot price. Money keeps deciding
+-- what runs — this only removes a verdict about work that never happened.
+--
+-- IDEMPOTENT: a second run selects nothing (the rows it wrote are no longer stopped). REVERSIBLE
+-- by the ids the audit table records.
+
+CREATE TABLE IF NOT EXISTS campaign_stop_reason_decisions (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id     text NOT NULL,
+  previous_status text,
+  previous_reason text,
+  new_status      text NOT NULL,
+  new_reason      text,
+  decided_by      text NOT NULL,
+  decided_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_campaign_stop_reason_decisions_campaign
+  ON campaign_stop_reason_decisions (campaign_id);
+
+WITH candidates AS (
+  SELECT c.id
+  FROM campaigns c
+  WHERE c.status = 'stopped'
+    AND c.stop_reason = 'audience_exhausted'
+    -- POSITIVE evidence is what is missing: this campaign never ran out of people in an audience
+    -- it actually had, because no run of it ever named one.
+    AND NOT EXISTS (
+      SELECT 1 FROM campaign_audience_exhaustion e
+      WHERE e.campaign_id::text = c.id::text
+    )
+    -- At most one ongoing campaign per identity. A twin already holding it keeps it; bringing a
+    -- second one back is what the partial unique index exists to refuse.
+    AND NOT EXISTS (
+      SELECT 1 FROM campaigns live
+      WHERE live.status = 'ongoing'
+        AND live.org_id = c.org_id
+        AND live.brand_id IS NOT DISTINCT FROM c.brand_id
+        AND live.acquisition_channel IS NOT DISTINCT FROM c.acquisition_channel
+        AND coalesce(live.funnel_key, '') = coalesce(c.funnel_key, '')
+    )
+),
+audited AS (
+  INSERT INTO campaign_stop_reason_decisions
+    (campaign_id, previous_status, previous_reason, new_status, new_reason, decided_by)
+  SELECT c.id, c.status, c.stop_reason, 'ongoing', NULL,
+         '0052_unpark_never_served_exhaustion_stops'
+  FROM campaigns c
+  JOIN candidates k ON k.id = c.id
+  RETURNING campaign_id
+)
+UPDATE campaigns c
+SET status = 'ongoing',
+    stop_reason = NULL,
+    -- Due now: the very next tick treats it like any other live campaign, where funding and the
+    -- gate decide whether it may actually spend.
+    next_run_at = now(),
+    updated_at = now()
+FROM audited a
+WHERE c.id = a.campaign_id;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1777600000000,
       "tag": "0051_stopped_ancestors_state_their_campaign_funnel_again",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1777700000000,
+      "tag": "0052_unpark_never_served_exhaustion_stops",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/audience-exhaustion.ts
+++ b/src/lib/audience-exhaustion.ts
@@ -32,8 +32,14 @@ export async function markAudienceExhausted(campaignId: string, audienceId: stri
  * audience it actually had", not "is an audience dry right now". A brand that never had an
  * audience — and therefore never contacted anybody — never writes a row here, because the
  * DAG's stopCampaign carries no audience id for it (the same case /end-run already logs as
- * "cannot mark a specific audience exhausted"). That distinction is what separates a
- * campaign that finished its people from one that never had any.
+ * "no audience ran"). That distinction is what separates a campaign that finished its people
+ * from one that never had any.
+ *
+ * TWO legs read it, and they must read the same one: the auto-STOP itself (a campaign that has
+ * exhausted nothing has not exhausted everything, so it is never stopped as
+ * `audience_exhausted`) and the extend-audience email that stop sends (never claim everyone was
+ * contacted when nobody was). A campaign stopped on this reason is sticky against funding, so a
+ * wrong verdict here parks a funded channel indefinitely.
  */
 export async function hasExhaustedAudience(campaignId: string): Promise<boolean> {
   const rows = await db
@@ -42,6 +48,30 @@ export async function hasExhaustedAudience(campaignId: string): Promise<boolean>
     .where(eq(campaignAudienceExhaustion.campaignId, campaignId))
     .limit(1);
   return rows.length > 0;
+}
+
+/**
+ * May this campaign be auto-stopped as `audience_exhausted`?
+ *
+ * The rule, stated in one place because it is the whole of the verdict:
+ *
+ *   nothing left to serve  AND  it actually ran out of somebody.
+ *
+ * The first half alone is an EMPTY REMAINDER, and an empty remainder is equally true of a
+ * campaign that never had anything to do — 0 of 0 reads as 100%. So the terminal verdict is
+ * gated on the second half, POSITIVE evidence that work happened: an exhaustion mark, written
+ * only for a run that named a real audience. A campaign that has served nothing has exhausted
+ * nothing and is never stopped for it.
+ *
+ * Pure on purpose — the two facts are read by the caller, the rule is stated here.
+ */
+export function isExhaustionStopWarranted(evidence: {
+  /** Does features-service still offer a serveable, non-exhausted audience for this campaign? */
+  hasServeableAudience: boolean;
+  /** Has ANY audience of this campaign ever been marked exhausted? (`hasExhaustedAudience`) */
+  hasEverExhaustedAnAudience: boolean;
+}): boolean {
+  return !evidence.hasServeableAudience && evidence.hasEverExhaustedAnAudience;
 }
 
 /**

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -10,7 +10,7 @@ import { EndRunBody, TransferBrandBody } from "../schemas.js";
 import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "../lib/brand-runtime-client.js";
-import { markAudienceExhausted, getFreshExhaustedAudienceIds } from "../lib/audience-exhaustion.js";
+import { markAudienceExhausted, getFreshExhaustedAudienceIds, hasExhaustedAudience, isExhaustionStopWarranted } from "../lib/audience-exhaustion.js";
 import { maybeSendExtendAudienceEmail } from "../lib/transactional-email.js";
 import { serveableAudienceIdsForCampaign } from "../lib/serveable-audience.js";
 import { STOP_REASONS } from "../lib/stop-reason.js";
@@ -485,7 +485,11 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
         if (exhaustedAudienceId) {
           await markAudienceExhausted(campaignId, exhaustedAudienceId);
         } else {
-          console.warn(`[campaign-service] stopCampaign=true for campaign ${campaignId} with no x-audience-id — cannot mark a specific audience exhausted`);
+          // No audience id means no audience RAN, so there is nothing to mark and no evidence
+          // this campaign ever contacted anybody. Says what it decided rather than proceeding:
+          // the stop below is gated on that evidence, so this run cannot end in a verdict about
+          // work that never happened.
+          console.warn(`[campaign-service] stopCampaign=true for campaign ${campaignId} with no x-audience-id — no audience ran, so nothing is marked exhausted and this run cannot conclude the campaign is exhausted`);
         }
 
         const campaign = await db.query.campaigns.findFirst({
@@ -498,7 +502,30 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
             ? await hasServeableAudience(campaign, req)
             : false;
 
-        if (!serveable) {
+        // "Nothing left to serve" is ALSO true for a campaign that never had anything to serve,
+        // so an empty remainder is not evidence of exhaustion — 0 of 0 reads as 100%. The
+        // verdict rests on POSITIVE evidence that outreach actually ran out of people through
+        // THIS campaign: an exhaustion mark, which is only ever written for a run that named a
+        // real audience. Same definition the extend-audience email is gated on.
+        //
+        // Without that evidence the campaign is NOT stopped: it has a funded ceiling and nothing
+        // to show for it, so it stays `ongoing` and falls through to the normal reschedule below
+        // — the next tick looks at it again. Parking it on `audience_exhausted` would be sticky
+        // (funding deliberately never resumes that reason), so a campaign that never worked
+        // would sit on a funded channel forever, which is exactly what happened to the first
+        // campaign the per-channel provisioner ever created (4769db14, 2026-08-20: stopped ten
+        // seconds after birth having served nothing).
+        const stopWarranted =
+          !serveable &&
+          isExhaustionStopWarranted({
+            hasServeableAudience: serveable,
+            hasEverExhaustedAnAudience: await hasExhaustedAudience(campaignId),
+          });
+
+        if (!serveable && !stopWarranted) {
+          console.warn(`[campaign-service] Campaign ${campaignId} has no serveable audience and has never exhausted one — it has served nothing, so it is NOT auto-stopped as ${STOP_REASONS.AUDIENCE_EXHAUSTED}; rescheduling so it is looked at again`);
+          // Falls through to the reschedule below.
+        } else if (!serveable) {
           // Fully contacted: every targeted audience is exhausted and the campaign is
           // being auto-stopped. Nudge the user to extend an audience so outreach can
           // resume. Fire-and-forget — never blocks or fails run finalization, and the

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -1255,6 +1255,49 @@ describe("Pipeline routes", () => {
       expect(updated!.stopReason).toBe("audience_exhausted");
     });
 
+    it("stopCampaign=true does NOT stop a campaign that has served nothing — no audience ran, so nothing was exhausted", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        status: "ongoing",
+        featureSlug: "sales-cold-email-v1",
+        createdByUserId: "user_test",
+      });
+
+      mockListRuns.mockResolvedValue({
+        runs: [
+          { id: "run-791", status: "running", startedAt: new Date().toISOString() },
+        ],
+      });
+      // Nothing serveable AND nothing ever exhausted — the degenerate case: the campaign was
+      // created, its first serve came back empty carrying no audience id, and it has contacted
+      // nobody. An empty remainder is not evidence it finished its people.
+      mockFetchCandidates.mockResolvedValue([]);
+
+      await request(app)
+        .post("/end-run")
+        // Deliberately NO x-audience-id: no audience ran, so there is nothing to mark.
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .send({ success: true, stopCampaign: true })
+        .expect(200);
+
+      await new Promise((r) => setTimeout(r, 150));
+
+      const marks = await db
+        .select()
+        .from(campaignAudienceExhaustion)
+        .where(eq(campaignAudienceExhaustion.campaignId, campaign.id));
+      expect(marks).toHaveLength(0);
+
+      // Stays ongoing and is rescheduled so it is looked at again, rather than parked on
+      // `audience_exhausted` — a stop reason funding deliberately never resumes.
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      expect(updated!.status).toBe("ongoing");
+      expect(updated!.stopReason).toBeNull();
+      expect(updated!.nextRunAt).not.toBeNull();
+    });
+
     it("should set nextRunAt and NOT fire-and-forget when stopCampaign is false", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,

--- a/tests/integration/unpark-never-served-migration.test.ts
+++ b/tests/integration/unpark-never-served-migration.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { db, sql } from "../../src/db/index.js";
+import { campaigns, campaignAudienceExhaustion } from "../../src/db/schema.js";
+import { cleanTestData, closeDb, insertTestCampaign, randomId } from "../helpers/test-db.js";
+
+/**
+ * The migration is applied here exactly as prod will apply it — the file itself, against a
+ * database seeded with the shape prod holds — so both halves are measured rather than read off
+ * the SQL: WHICH rows it selects, and that a second run changes nothing.
+ *
+ * The rule it states is the runtime rule (src/lib/audience-exhaustion.ts
+ * `isExhaustionStopWarranted`) applied to the rows that already carry the verdict: a campaign
+ * stopped for `audience_exhausted` that never marked a single audience exhausted was parked on a
+ * conclusion about work that never happened.
+ */
+const TAG = "0052_unpark_never_served_exhaustion_stops";
+const MIGRATION = readFileSync(join(process.cwd(), "drizzle", `${TAG}.sql`), "utf8");
+
+const CONVERSATION = "sales_meetings_from_conversation";
+const PURCHASES = "website_purchases";
+
+async function applyMigration() {
+  await sql.unsafe(MIGRATION);
+}
+
+async function rowOf(id: string) {
+  const [row] = await db.select().from(campaigns).where(eq(campaigns.id, id));
+  return row!;
+}
+
+async function auditCount(): Promise<number> {
+  const rows = await sql<{ n: string }[]>`
+    SELECT count(*)::text AS n FROM campaign_stop_reason_decisions WHERE decided_by = ${TAG}
+  `;
+  return Number(rows[0]!.n);
+}
+
+describe(`migration ${TAG}`, () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    // The audit table is created BY the migration, so it may not exist on the first run.
+    await sql.unsafe(`DELETE FROM campaign_stop_reason_decisions WHERE true`).catch(() => {});
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("un-parks a campaign that stopped for exhaustion having never exhausted an audience, and leaves every other row alone", async () => {
+    const org = randomId();
+    const brand = randomId();
+
+    // (1) THE CASE — stopped for exhaustion, zero exhaustion marks. Prod's 4769db14.
+    const neverServed = await insertTestCampaign(org, {
+      status: "stopped",
+      stopReason: "audience_exhausted",
+      brandId: brand,
+      funnelKey: CONVERSATION,
+      acquisitionChannel: "feedback_request_email",
+      featureSlug: "feedback-request-cold-email-outreach",
+    });
+
+    // (2) GENUINELY exhausted — it ran out of people it actually had. Must stay stopped: money is
+    // not an answer to exhaustion and this verdict is the true one.
+    const genuinelyExhausted = await insertTestCampaign(org, {
+      status: "stopped",
+      stopReason: "audience_exhausted",
+      brandId: randomId(),
+      funnelKey: PURCHASES,
+      acquisitionChannel: "cold_email",
+      featureSlug: "sales-cold-email-outreach",
+    });
+    await db.insert(campaignAudienceExhaustion).values({
+      campaignId: genuinelyExhausted.id,
+      audienceId: randomId(),
+      exhaustedAt: new Date(),
+    });
+
+    // (3) Its identity is already held by a live twin — bringing it back is what the partial
+    // unique index exists to refuse.
+    const heldBrand = randomId();
+    const collides = await insertTestCampaign(org, {
+      status: "stopped",
+      stopReason: "audience_exhausted",
+      brandId: heldBrand,
+      funnelKey: PURCHASES,
+      acquisitionChannel: "cold_email",
+      featureSlug: "sales-cold-email-outreach",
+    });
+    const incumbent = await insertTestCampaign(org, {
+      status: "ongoing",
+      brandId: heldBrand,
+      funnelKey: PURCHASES,
+      acquisitionChannel: "cold_email",
+      featureSlug: "sales-cold-email-outreach",
+    });
+
+    // (4) Stopped for a reason of its own — a person switched it off. Never touched.
+    const manual = await insertTestCampaign(org, {
+      status: "stopped",
+      stopReason: "manual",
+      brandId: randomId(),
+      funnelKey: PURCHASES,
+      acquisitionChannel: "cold_email",
+      featureSlug: "sales-cold-email-outreach",
+    });
+
+    await applyMigration();
+
+    const back = await rowOf(neverServed.id);
+    expect(back.status).toBe("ongoing");
+    expect(back.stopReason).toBeNull();
+    // Due now: the next tick treats it like any other live campaign, where funding and the gate
+    // decide whether it may actually spend.
+    expect(back.nextRunAt).not.toBeNull();
+
+    expect((await rowOf(genuinelyExhausted.id)).status).toBe("stopped");
+    expect((await rowOf(collides.id)).status).toBe("stopped");
+    expect((await rowOf(incumbent.id)).status).toBe("ongoing");
+    expect((await rowOf(manual.id)).stopReason).toBe("manual");
+
+    // Auditable: one row per campaign written, holding what it replaced.
+    expect(await auditCount()).toBe(1);
+
+    // Idempotent — a second run selects nothing, because what it wrote is no longer stopped.
+    await applyMigration();
+    expect(await auditCount()).toBe(1);
+    expect((await rowOf(neverServed.id)).status).toBe("ongoing");
+  });
+});

--- a/tests/unit/exhaustion-stop-rule.test.ts
+++ b/tests/unit/exhaustion-stop-rule.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { isExhaustionStopWarranted } from "../../src/lib/audience-exhaustion.js";
+
+/**
+ * The terminal "everyone has been contacted" verdict rests on POSITIVE evidence that outreach
+ * actually ran out of people, never on an empty remainder — "nothing left to serve" is equally
+ * true of a campaign that never had anything to serve.
+ *
+ * Prod 2026-08-20: campaign 4769db14, the first one the per-channel provisioner ever created,
+ * stopped itself ten seconds after birth having served zero leads and holding zero exhaustion
+ * marks. The stop is sticky against funding, so the customer's $10/day channel was parked
+ * indefinitely on a verdict about work that never happened.
+ */
+describe("isExhaustionStopWarranted", () => {
+  it("does NOT warrant a stop for a campaign that has never exhausted an audience — 0 of 0 is not 100%", () => {
+    expect(
+      isExhaustionStopWarranted({
+        hasServeableAudience: false,
+        hasEverExhaustedAnAudience: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("warrants the stop when the campaign ran out of people it actually had", () => {
+    expect(
+      isExhaustionStopWarranted({
+        hasServeableAudience: false,
+        hasEverExhaustedAnAudience: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("never warrants a stop while a serveable audience remains, evidence or not", () => {
+    expect(
+      isExhaustionStopWarranted({
+        hasServeableAudience: true,
+        hasEverExhaustedAnAudience: true,
+      }),
+    ).toBe(false);
+    expect(
+      isExhaustionStopWarranted({
+        hasServeableAudience: true,
+        hasEverExhaustedAnAudience: false,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## The bug

Campaign `4769db14` — the first campaign the fixed per-channel provisioning path (#380, #383) ever created — stopped itself ten seconds after birth, on a channel the customer funds at $10/day.

```
created  2026-08-20 10:08:01
stopped  2026-08-20 10:08:11   stop_reason = audience_exhausted
```

It has served zero leads and holds zero rows in lead-service. Its own log says the quiet part out loud:

```
stopCampaign=true for campaign 4769db14... with no x-audience-id
  — cannot mark a specific audience exhausted
All targeted audiences exhausted — auto-stopped campaign 4769db14...
```

It noticed it could not name a single exhausted audience and auto-stopped the campaign anyway. The auto-stop asked one question — is a serveable audience left? "None left" is equally true of a campaign that never had one, so a campaign that had contacted nobody took the same branch as one that genuinely worked its audiences to the end. 0 of 0 read as 100%.

And the verdict is **sticky**: funding deliberately brings back a campaign that was HELD but never one that stopped for a reason of its own, so `audience_exhausted` parks the campaign indefinitely — the funding sweep prints "Not resuming campaign 4769db14 for funded funnel — it stopped for audience_exhausted" on every pass. The customer funds a channel that produces nothing, with no path back.

The brand is demonstrably not exhausted: its sibling campaign on the same brand and the same four active audiences served 109 leads that same day. Why the fresh campaign's first serve came back empty is a separate lead-service investigation and is untouched here.

## The fix

The terminal verdict now rests on positive evidence that work actually happened through the campaign, never on an empty remainder.

`isExhaustionStopWarranted` (`src/lib/audience-exhaustion.ts`) states the rule in one place:

```
nothing left to serve  AND  it actually ran out of somebody
```

The second half is `hasExhaustedAudience(campaignId)` — any row in `campaign_audience_exhaustion`, which is only ever written for a run that named a real audience. That is the same definition the extend-audience email is already gated on, so the two legs cannot drift.

Without that evidence the campaign is **not stopped at all**. It stays `ongoing` and falls through to the normal reschedule, so the next tick looks at it again. Nothing new decides whether it may spend: the turn planner holds it if its pair is unfunded, and the gate refuses a run it cannot price. Money keeps deciding what runs; this only removes a verdict about work that never happened.

The degenerate branch states its decision instead of proceeding silently:

```
stopCampaign=true for campaign X with no x-audience-id — no audience ran, so nothing is
marked exhausted and this run cannot conclude the campaign is exhausted
```

**Unchanged:** a campaign that HAS served and then genuinely exhausts still stops, still emails, still resumes through the sweep, with its existing tests green. Money is not an answer to exhaustion, and funding still never resumes an `audience_exhausted` campaign.

## Migration 0052 — the rows already carrying the verdict

Same rule applied once to history: stopped for `audience_exhausted`, zero exhaustion marks, and no live twin holding their `(org, brand, funnel, channel)` identity → back to `ongoing`, no stop reason, due now. Each write is audited in `campaign_stop_reason_decisions` (previous status + reason + the tag that wrote it), so the undo is exactly the ids it recorded. Idempotent — a second run selects nothing.

Read against the live database before the file was written, that rule selects the entire stopped-for-exhaustion population, two rows:

| campaign | brand | identity | why |
|---|---|---|---|
| `4769db14` | `75d7e3e8` | `sales_meetings_from_conversation` / `feedback_request_email` | dead ten seconds after birth, $10/day funded |
| `cb965e9d` | `ccc29ba2` | `website_purchases` / `crm_email` | the 0-audience, 0-contact brand already documented as wrongly told its outreach had finished |

Neither collides: the only live campaign on either brand is `9bc27ed7` (`75d7e3e8` / `cold_email`), a different channel. The exclusion is stated as a rule anyway, so a re-run can never write a row the partial unique index would refuse.

## Verification

- `tests/unit/exhaustion-stop-rule.test.ts` — the rule, all four combinations.
- `tests/integration/internal-routes.test.ts` — `/end-run` with `stopCampaign=true`, no audience id, nothing serveable: stays `ongoing`, `stopReason` null, rescheduled. The existing genuine-exhaustion test still asserts the stop.
- `tests/integration/unpark-never-served-migration.test.ts` — applies the migration file itself, twice, over a seed holding all four shapes (never-served, genuinely exhausted, identity-collided, stopped-for-another-reason).
- Full suite: **627 passed**, build clean.

## Triage

Hotfix → main. A customer's funded channel is parked on a verdict about work that never happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
