### PR TITLE
fix(end-run): a campaign with nobody to contact waits on that reason's cadence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -680,6 +680,18 @@ real audience.
   ten seconds after birth on a channel funded at $10/day) and `cb965e9d` (Lux Projects Bali, the
   0-audience brand above). Pinned by `tests/integration/unpark-never-served-migration.test.ts`,
   which applies the file itself twice.
+- **It WAITS on the reason's cadence, it does not retry on the run's.** Rescheduling that campaign
+  on `RERUN_GRACE_MS` (10s) fired a workflow every eleven seconds, forever, for a campaign whose
+  situation cannot change in eleven seconds — 33 runs in the first minutes on `4769db14` and the
+  same on `cb965e9d`, each unable to reach anything, flooding every service in the chain. "Nobody
+  to contact" is the MONEY kind of wait, not the TURN kind: it moves when a customer edits their
+  audiences or when a never-run channel finally accumulates evidence, hours or days apart. So it
+  reschedules at `NO_SERVEABLE_AUDIENCE_RECHECK_MS` (10 min, the same figure and the same argument
+  as `FUNDING_RECHECK_MS`), which IS the latency — the campaign runs within ten minutes of having
+  somebody, with no manual step. The wait is a RESCHEDULE, never a stop: it stays `ongoing`, so
+  nothing has to be undone when the audience appears. One line says it is waiting and why, on that
+  cadence; the generic reschedule line is suppressed under it and the no-audience-ran line is
+  `info`, not `warn` — an expected business state.
 - WHY that campaign's first serve came back empty on a brand whose sibling served 109 leads the
   same day is a separate lead-service investigation. This service's job was to stop reading an
   empty answer as a finished one. (Set 2026-08-20.)

--- a/src/lib/audience-exhaustion.ts
+++ b/src/lib/audience-exhaustion.ts
@@ -75,6 +75,23 @@ export function isExhaustionStopWarranted(evidence: {
 }
 
 /**
+ * How long a campaign with NOBODY to contact waits before it is looked at again.
+ *
+ * A campaign that has served nothing is deliberately not stopped (see
+ * `isExhaustionStopWarranted`) — it is rescheduled instead. Rescheduled on the RUN cadence
+ * (`RERUN_GRACE_MS`, 10s) that meant a workflow fired every eleven seconds for a campaign whose
+ * situation cannot change in eleven seconds: "nobody to contact" moves when a customer edits
+ * their audiences, or when a channel that has never run finally accumulates evidence — hours or
+ * days apart, never within the same minute.
+ *
+ * So it waits on the reason's own timescale, exactly as an unfunded campaign waits on
+ * `FUNDING_RECHECK_MS` rather than on its turn: the same 10 minutes, for the same reason, and it
+ * is the feature's latency — a campaign starts running within ten minutes of having somebody to
+ * contact, with no manual step and no stop to undo.
+ */
+export const NO_SERVEABLE_AUDIENCE_RECHECK_MS = 10 * 60_000; // 10 min
+
+/**
  * Audience ids currently exhausted for a campaign — i.e. marked within the TTL window.
  * Marks older than the TTL are ignored (the audience is due for a re-probe), so they never
  * appear here and the bandit will consider that audience again on the next run.

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -10,7 +10,7 @@ import { EndRunBody, TransferBrandBody } from "../schemas.js";
 import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "../lib/brand-runtime-client.js";
-import { markAudienceExhausted, getFreshExhaustedAudienceIds, hasExhaustedAudience, isExhaustionStopWarranted } from "../lib/audience-exhaustion.js";
+import { markAudienceExhausted, getFreshExhaustedAudienceIds, hasExhaustedAudience, isExhaustionStopWarranted, NO_SERVEABLE_AUDIENCE_RECHECK_MS } from "../lib/audience-exhaustion.js";
 import { maybeSendExtendAudienceEmail } from "../lib/transactional-email.js";
 import { serveableAudienceIdsForCampaign } from "../lib/serveable-audience.js";
 import { STOP_REASONS } from "../lib/stop-reason.js";
@@ -479,6 +479,11 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
     // exhausted (24h TTL; the bandit then skips it) and auto-stop the campaign ONLY when it has
     // no serveable, non-exhausted audience left. Otherwise fall through to the normal reschedule
     // so the next tick re-draws from the remaining audiences.
+    // Set when the campaign has nobody to contact and has served nothing: it is rescheduled
+    // rather than stopped, but on the RECHECK cadence below instead of the run cadence — the
+    // reason it cannot run does not move in eleven seconds.
+    let waitingForAudience = false;
+
     if (stopCampaign === true) {
       try {
         const exhaustedAudienceId = req.audienceId;
@@ -489,7 +494,9 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
           // this campaign ever contacted anybody. Says what it decided rather than proceeding:
           // the stop below is gated on that evidence, so this run cannot end in a verdict about
           // work that never happened.
-          console.warn(`[campaign-service] stopCampaign=true for campaign ${campaignId} with no x-audience-id — no audience ran, so nothing is marked exhausted and this run cannot conclude the campaign is exhausted`);
+          // Expected business state, not a fault: log at info. It is paired with the waiting
+          // line below and both now fire on the recheck cadence, not once per run.
+          console.log(`[campaign-service] stopCampaign=true for campaign ${campaignId} with no x-audience-id — no audience ran, so nothing is marked exhausted and this run cannot conclude the campaign is exhausted`);
         }
 
         const campaign = await db.query.campaigns.findFirst({
@@ -523,8 +530,14 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
           });
 
         if (!serveable && !stopWarranted) {
-          console.warn(`[campaign-service] Campaign ${campaignId} has no serveable audience and has never exhausted one — it has served nothing, so it is NOT auto-stopped as ${STOP_REASONS.AUDIENCE_EXHAUSTED}; rescheduling so it is looked at again`);
-          // Falls through to the reschedule below.
+          // Not stopped — and not re-fired in ten seconds either. "Nobody to contact" changes
+          // when the customer's audiences change or when a never-run channel finally has
+          // evidence, so the campaign WAITS on that timescale (the money cadence, not the turn
+          // cadence). Rescheduling on the run cadence is what fired a workflow every eleven
+          // seconds for campaigns 4769db14 and cb965e9d, each run unable to do anything.
+          waitingForAudience = true;
+          console.log(`[campaign-service] Campaign ${campaignId} has no serveable audience and has never exhausted one — it has served nothing, so it is NOT auto-stopped as ${STOP_REASONS.AUDIENCE_EXHAUSTED}; waiting ${NO_SERVEABLE_AUDIENCE_RECHECK_MS}ms for it to have somebody to contact`);
+          // Falls through to the reschedule below, which uses the recheck cadence.
         } else if (!serveable) {
           // Fully contacted: every targeted audience is exhausted and the campaign is
           // being auto-stopped. Nudge the user to extend an audience so outreach can
@@ -569,7 +582,13 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       // Failed runs get a 60s backoff; completed runs re-run after a short grace
       // (RERUN_GRACE_MS) so the wrapping workflow run finishes teardown before the
       // re-run tick — otherwise the in-flight guard sees it alive and forces +60s.
-      const delayMs = status === "failed" ? 60_000 : RERUN_GRACE_MS;
+      // A campaign waiting for somebody to contact waits on that reason's cadence — it is not
+      // waiting its turn, and firing it sooner cannot change the answer.
+      const delayMs = waitingForAudience
+        ? NO_SERVEABLE_AUDIENCE_RECHECK_MS
+        : status === "failed"
+          ? 60_000
+          : RERUN_GRACE_MS;
       const nextRunAt = new Date(Date.now() + delayMs);
 
       if (req.runId) {
@@ -589,7 +608,11 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       // instead of waiting out the current idle sleep.
       wakeScheduler();
 
-      if (status === "failed") {
+      if (waitingForAudience) {
+        // The waiting line above already said what was decided and until when; repeating the
+        // generic reschedule line under it is the third of the three lines that were filling
+        // the logs.
+      } else if (status === "failed") {
         console.warn(`[campaign-service] Run failed — rescheduled campaign ${campaignId} in ${delayMs}ms (nextRunAt=${nextRunAt.toISOString()})`);
       } else {
         console.log(`[campaign-service] Set nextRunAt=${nextRunAt.toISOString()} for campaign ${campaignId} (status=${status})`);

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -57,6 +57,7 @@ import app from "../../src/index.js";
 import { db } from "../../src/db/index.js";
 import { campaigns, campaignAudienceExhaustion } from "../../src/db/schema.js";
 import { eq, and } from "drizzle-orm";
+import { NO_SERVEABLE_AUDIENCE_RECHECK_MS } from "../../src/lib/audience-exhaustion.js";
 import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
 
 const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
@@ -1296,6 +1297,56 @@ describe("Pipeline routes", () => {
       expect(updated!.status).toBe("ongoing");
       expect(updated!.stopReason).toBeNull();
       expect(updated!.nextRunAt).not.toBeNull();
+
+      // And it waits on the RECHECK cadence, not the run cadence: "nobody to contact" cannot
+      // change in ten seconds, so rescheduling on RERUN_GRACE_MS fired a workflow every eleven
+      // seconds forever for a campaign that could not do anything with it.
+      const waitMs = updated!.nextRunAt!.getTime() - Date.now();
+      expect(waitMs).toBeGreaterThan(NO_SERVEABLE_AUDIENCE_RECHECK_MS - 60_000);
+      expect(waitMs).toBeLessThanOrEqual(NO_SERVEABLE_AUDIENCE_RECHECK_MS);
+    });
+
+    it("a campaign waiting for an audience comes back by itself once it has one — the wait is a reschedule, never a stop", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        status: "ongoing",
+        featureSlug: "sales-cold-email-v1",
+        createdByUserId: "user_test",
+      });
+
+      mockListRuns.mockResolvedValue({
+        runs: [
+          { id: "run-792", status: "running", startedAt: new Date().toISOString() },
+        ],
+      });
+      // First pass: nothing serveable, nothing ever exhausted → waits.
+      mockFetchCandidates.mockResolvedValue([]);
+
+      await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .send({ success: true, stopCampaign: true })
+        .expect(200);
+      await new Promise((r) => setTimeout(r, 150));
+
+      const waiting = await db.query.campaigns.findFirst({ where: eq(campaigns.id, campaign.id) });
+      expect(waiting!.status).toBe("ongoing");
+
+      // The customer activates an audience — the very next run finds somebody and the campaign
+      // is rescheduled promptly, with no manual step and no stop to undo.
+      mockFetchCandidates.mockResolvedValue([projectionRow("aud-fresh")]);
+
+      await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .send({ success: true, stopCampaign: false })
+        .expect(200);
+      await new Promise((r) => setTimeout(r, 150));
+
+      const back = await db.query.campaigns.findFirst({ where: eq(campaigns.id, campaign.id) });
+      expect(back!.status).toBe("ongoing");
+      expect(back!.stopReason).toBeNull();
+      expect(back!.nextRunAt!.getTime() - Date.now()).toBeLessThan(60_000);
     });
 
     it("should set nextRunAt and NOT fire-and-forget when stopCampaign is false", async () => {


### PR DESCRIPTION
## Problem (live)

PR #387 stopped auto-stopping a campaign that has served nothing and rescheduled it instead — on the **run** cadence (`RERUN_GRACE_MS`, 10s). So campaigns `4769db14` (brand `75d7e3e8`, second cold-email channel funded at \$10/day) and `cb965e9d` cycled continuously: the same three log lines every ~11 seconds, 33 runs in the first minutes, each firing a workflow that cannot do anything. Spend is zero today only because every run fails before reaching anything metered.

## Fix

"No serveable audience" is the **money** kind of wait, not the **turn** kind: it changes when a customer edits their audiences, or when a never-run channel finally accumulates evidence — hours or days apart, never within the same minute. So the campaign now waits on that reason's timescale.

- `NO_SERVEABLE_AUDIENCE_RECHECK_MS` = 10 min (`src/lib/audience-exhaustion.ts`) — the same figure and the same argument as `FUNDING_RECHECK_MS`. That interval **is** the latency: the campaign runs within ten minutes of having somebody to contact, with no manual step.
- `/end-run` sets `waitingForAudience` on the served-nothing branch and reschedules at that cadence instead of `RERUN_GRACE_MS`.
- Still a **reschedule, never a stop** — the campaign stays `ongoing`, so nothing has to be undone when the audience appears. #387's verdict rule (`isExhaustionStopWarranted`) is untouched.
- Logging: one line saying it is waiting and why, on that cadence. The generic "Set nextRunAt" line is suppressed under it, and the no-audience-ran line drops `warn` → `info` (an expected business state, per the repo's log discipline).

Not touched: turn-taking, the funding hold, the gate, the identity work from #380/#383. No workaround for the features-service projection returning no rows for a never-run channel — that is being fixed in that repo, and this campaign starts finding an audience on its own when it lands.

## Tests

- New integration test pins the wait cadence on the served-nothing branch, and a second pins that the campaign comes back promptly by itself once an audience exists (no stop to undo).
- `pnpm test:unit` 380 passed / `pnpm test:integration` 248 passed / `pnpm run build` clean.

Triage: hotfix → main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)