### PR TITLE
fix(provisioning): a funded channel stands up on the funding cadence, whatever the brand's other campaigns are doing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,13 +341,24 @@ holding 11 `ongoing` campaigns the scheduler would never claim. The flag is reti
   Turn-taking is fail-soft because it only reorders work already allowed; this decides whether to
   spend, and the gate refuses the same run on the same unreadable read anyway — firing it could
   only burn a run.
-- **A brand with NOTHING running is claimed by nobody, so it is swept.**
-  `provisionFundedFunnelsForIdleBrands` (own 10-min cadence) reads the (org, brand) pairs that
-  have sales campaigns and no `ongoing` one — 27 of 44 today — and stands up one campaign per
-  funded, DECLARED funnel. Without it, funding a funnel on a brand whose campaigns are all stopped
-  would mean nothing forever, which is precisely the brand this exists for. The scheduler's idle
-  sleep is capped at that interval for the same reason the resume sweep needed it: a brand with
-  nothing ongoing yields an empty snapshot and would otherwise be looked at hourly.
+- **A brand nothing will CLAIM soon is swept, and "soon" is the selection — not "has nothing
+  running".** `provisionFundedPairsForQuietBrands` (own 10-min cadence) reads the (org, brand)
+  pairs that have sales campaigns and none of them in flight or due within the sweep interval,
+  and stands up one campaign per funded, DECLARED pair. Selecting on "no `ongoing` campaign" was
+  right for the brand whose campaigns are all STOPPED (27 of 44 the day it shipped) and blind to
+  the brand PARKED AT ITS CEILING: the turn planner defers it to the day rollover, so the claim
+  path — where provisioning otherwise lives — does not look at it again until midnight UTC, and a
+  channel funded in the meantime waits for the rollover. That brand is too alive for an
+  idle-selection sweep and too quiet for the claim path, and it fell between them for nineteen
+  hours in prod (brand `75d7e3e8`, second channel funded 2026-08-19 13:59, no campaign until the
+  next day — issue #386). Read volume is unchanged for a brand that is working: it is EXCLUDED
+  here precisely because the claim path reaches it sooner, so the cost is one billing read per
+  QUIET brand per ten minutes — the same cadence and the same argument as `FUNDING_RECHECK_MS`.
+  The scheduler's idle sleep is capped at that interval for the same reason the resume sweep
+  needed it: a brand with nothing ongoing yields an empty snapshot and would otherwise be looked
+  at hourly. The seed prefers an `ongoing` row (it carries the current owner, workflow and offer),
+  and the declared-funnel question is asked over every offer the pair's sales campaigns state, not
+  just the seed's. (Widened 2026-08-23.)
 - **Funding brings back the campaign that was HELD, never the campaign that stopped for a reason
   of its own.** A row carrying `audience_exhausted`, `max_leads_reached`, `manual` or
   `org_teardown` said why it stopped and money answers none of them (the exhaustion sweep owns the
@@ -499,7 +510,7 @@ offer, ten answers on the brand ten orgs claim.
 - **A campaign provisioned from an offer's declaration CARRIES that offer** (`offerId` on the
   insert). Still carried, never derived: the value comes from the campaign whose declaration put the
   funnel in scope, not from the funnel, the goal or the workflow.
-- The idle-brand funding sweep asks the same way, off its seed row's `offer_id`.
+- The quiet-brand funding sweep asks the same way, over the offers its pair's campaigns state.
 (Set 2026-08-19.)
 
 ## Nothing can be unattributable — so nothing holds a brand's provisioning back
@@ -572,7 +583,7 @@ Unit tests (`pnpm test:unit`) need neither — they fully mock db/runs-client.
 
 ## Raw-`sql` list params need `sql.join`, NOT a bare JS array — and workflow dynasties live in the DB, not src
 
-**Interpolating a JS array into a drizzle raw `sql` template does NOT expand it into a param list.** `sql\`... IN (${arr})\`` binds the whole array as ONE composite → `operator does not exist: text = record`; `= ANY(${arr})` → `op ANY/ALL (array) requires array on right side`. Neither works. To expand a small in-code list (e.g. the sales-outreach feature family in `funnel-campaigns.ts`'s idle-brand sweep), use `sql.join([...set].map((v) => sql\`${v}\`), sql\`, \`)` inside `IN (...)`. Caught only by the integration tests (unit tests mock the DB), so run `pnpm test:integration` after any raw-`sql` list change. (Set 2026-07-24, sales-crm feature-family pause clause; the clause itself is gone, the trap is not.)
+**Interpolating a JS array into a drizzle raw `sql` template does NOT expand it into a param list.** `sql\`... IN (${arr})\`` binds the whole array as ONE composite → `operator does not exist: text = record`; `= ANY(${arr})` → `op ANY/ALL (array) requires array on right side`. Neither works. To expand a small in-code list (e.g. the sales-outreach feature family in `funnel-campaigns.ts`'s idle-brand sweep), use `sql.join([...set].map((v) => sql\`${v}\`), sql\`, \`)` inside `IN (...)`. Caught only by the integration tests (unit tests mock the DB), so run `pnpm test:integration` after any raw-`sql` change. **Same template, second trap: a JS `Date` parameter is REFUSED outright** — postgres.js binds raw-`sql` params itself and throws `The "string" argument must be of type string ... Received an instance of Date`. Pass `d.toISOString()` and cast (`::timestamptz`). (2026-08-23, the quiet-brand sweep's due-soon bound.) (Set 2026-07-24, sales-crm feature-family pause clause; the clause itself is gone, the trap is not.)
 
 **Workflow dynasties/slugs are DB-resident (workflow-service `workflows` table), NOT seeded in workflow-service `src`.** To answer "does feature X have a workflow dynasty / which slugs exist / has it ever run," query the workflow-service Neon DB (`workflows` grouped by `feature_slug, workflow_dynasty_slug`; runs via `workflow_runs`), do NOT `git grep` workflow-service src — a src grep returns only test fixtures and misses every real dynasty. Cost 2026-07-24: grepped workflow-service src, wrongly concluded `sales-crm-email-outreach` had no dynasty (blocking a plan); the DB showed 5 active CRM dynasties seeded the day before. features-service also cannot resolve "which feature is a brand on" — all 31 of its endpoints take `featureSlug` as INPUT; the feature identity comes from the caller (`x-feature-slug`), never from features-service.
 
@@ -792,7 +803,7 @@ same branch.
 
 - **A campaign's `parentRunId` is its ANCESTOR run**, written once at creation from the creator's
   `x-run-id`, and every execution's run tree chains under it. A creator carrying no run of its own
-  — the per-funnel provisioner, the idle-brand sweep — leaves it NULL, which is where the minting
+  — the per-funnel provisioner, the quiet-brand sweep — leaves it NULL, which is where the minting
   came from.
 - **`ensureCampaignRunId` (`src/lib/trigger-run.ts`) is the ONE place a missing ancestor is
   filled**, shared by the leg that TRIGGERS (scheduler) and the leg that RESUMES

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -643,30 +643,48 @@ export function resetFundingSweepThrottle(): void {
 }
 
 /**
- * Provision the funded funnels of a brand that has NOTHING running.
+ * Provision the funded (funnel, channel) pairs of a brand nothing else will look at soon.
  *
- * `planFunnelTurns` provisions off the campaigns claimed this tick, so it can only ever help a
- * brand that already has one ongoing campaign. A brand whose campaigns are all stopped is claimed
- * by nobody, so nothing would ever look at it again — and that is precisely the brand this
- * feature is for: 27 of the 44 brands with sales campaigns have no ongoing one, and under the old
- * flag their way back was a pause button that no longer exists anywhere in the fleet.
+ * `planFunnelTurns` provisions off the campaigns CLAIMED this tick, so it only ever reaches a brand
+ * that has a campaign due right now. Two brands fall outside that, for opposite reasons, and both
+ * are the same customer-visible failure — a funded channel with no campaign:
  *
- * So funding is asked about them directly. One campaign is stood up per funnel the customer FUNDS
- * and brand-service DECLARES; a brand that funds nothing is read and left exactly as it is, which
- * is what keeps every brand held today held after this ships.
+ *   - a brand whose campaigns are ALL STOPPED is claimed by nobody, so nothing would look at it
+ *     again ever (27 of the 44 brands with sales campaigns, the day this sweep was written);
+ *   - a brand whose campaigns are all PARKED AT THEIR CEILING is deferred to the day rollover, so
+ *     nothing looks at it again until midnight UTC. Its funding is perfectly readable the whole
+ *     time. That is how brand 75d7e3e8 funded a second acquisition channel at 13:59 on 19 Aug and
+ *     had no campaign for it nineteen hours later (issue #386) — too alive for a sweep that
+ *     selected on "nothing ongoing", too quiet for the claim path.
+ *
+ * So the selection is on WHEN the brand will next be looked at, not on whether it has something
+ * running: a pair is examined here unless one of the brand's sales campaigns is in flight or due
+ * within the sweep interval, in which case the claim path provisions it sooner than this would.
+ * A brand actively working therefore still costs this sweep NOTHING — the read volume is one
+ * billing read per QUIET brand per ten minutes, which is the same cadence and the same argument as
+ * FUNDING_RECHECK_MS: money moves when a person edits it, hours or days apart.
+ *
+ * One campaign is stood up per pair the customer FUNDS and brand-service DECLARES; a brand that
+ * funds nothing is read and left exactly as it is, which is what keeps every brand held today held.
  *
  * Fail-soft per brand: an unreadable brand is skipped, never provisioned on a guess.
  */
-export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()): Promise<number> {
+export async function provisionFundedPairsForQuietBrands(now: Date = new Date()): Promise<number> {
   if (now.getTime() - lastFundingSweepAt < FUNDING_SWEEP_INTERVAL_MS) return 0;
   lastFundingSweepAt = now.getTime();
 
   const slugs = [...SALES_OUTREACH_FEATURE_SLUGS];
 
-  // One row per (org, brand) that has sales campaigns and NO ongoing one — the most recently
-  // touched of them, which is what a new campaign inherits its owner and workflow from. Done in
-  // SQL rather than by reading every sales campaign into memory: the stopped population is large
-  // (682 rows today) and grows, while the answer is at most one row per brand.
+  // A brand whose sales campaigns are in flight or due within the sweep interval is looked at by
+  // the CLAIM path sooner than this sweep would look at it, so it is not examined here at all —
+  // that is what keeps the read volume of an actively-working brand at zero.
+  const dueSoon = new Date(now.getTime() + FUNDING_SWEEP_INTERVAL_MS);
+
+  // One row per (org, brand) that has sales campaigns and none of them due soon — preferring an
+  // ONGOING row as the seed (it carries the current owner, workflow and offer) and otherwise the
+  // most recently touched. Done in SQL rather than by reading every sales campaign into memory:
+  // the stopped population is large (682 rows today) and grows, while the answer is at most one
+  // row per brand.
   const seeds = await db.execute<{
     id: string;
     org_id: string;
@@ -690,8 +708,17 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
           AND o.status = 'ongoing'
           AND o.feature_slug IN (${sql.join(slugs.map((s) => sql`${s}`), sql`, `)})
           AND coalesce(o.brand_id, o.brand_ids[1]) = coalesce(c.brand_id, c.brand_ids[1])
+          -- In flight (next_run_at cleared at claim time) or due within the sweep interval: the
+          -- claim path reaches this brand sooner than this sweep would, and provisioning there is
+          -- the same code. A campaign parked past that horizon — at its ceiling until the day
+          -- rollover, or held on the funding cadence — leaves the brand quiet, and quiet is
+          -- exactly what this sweep is for.
+          -- Bound as an ISO string, not a Date: this is a raw sql template, where postgres.js
+          -- binds the parameter itself and refuses a Date outright.
+          AND (o.next_run_at IS NULL OR o.next_run_at <= ${dueSoon.toISOString()}::timestamptz)
       )
-    ORDER BY c.org_id, coalesce(c.brand_id, c.brand_ids[1]), c.updated_at DESC
+    ORDER BY c.org_id, coalesce(c.brand_id, c.brand_ids[1]),
+             (c.status = 'ongoing') DESC, c.updated_at DESC
     LIMIT ${FUNDING_SWEEP_MAX_BRANDS + 1}
   `);
 
@@ -708,7 +735,7 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
   const examined = rows.slice(0, FUNDING_SWEEP_MAX_BRANDS);
   if (rows.length > FUNDING_SWEEP_MAX_BRANDS) {
     console.log(
-      `[campaign-service] Funding sweep examining ${examined.length} of ${rows.length}+ idle brands — the rest are examined on the next sweep (least recently touched first)`,
+      `[campaign-service] Funding sweep examining ${examined.length} of ${rows.length}+ quiet brands — the rest are examined on the next sweep (least recently touched first)`,
     );
   }
 
@@ -749,8 +776,12 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
       const provisioning = await buildProvisioningIdentity(seed, row.brand_id);
       if (!provisioning) continue;
 
+      // Asked over every offer the brand's sales campaigns state, not just the seed's: a brand
+      // selling several offers has one campaign per offer, and a funnel declared by the offer the
+      // seed does NOT sell would otherwise read as "nobody declares selling through it" and be
+      // passed over in silence. The seed's own offer is always in the set.
       const declared = await resolveDeclaredFunnels(
-        [{ offerId: row.offer_id }],
+        await offerStatingCampaigns(row.org_id, row.brand_id, row.offer_id),
         row.brand_id,
         provisioning,
       );
@@ -776,6 +807,28 @@ export async function provisionFundedFunnelsForIdleBrands(now: Date = new Date()
   }
 
   return provisioned;
+}
+
+/**
+ * The offers this (org, brand)'s sales campaigns state, as the group `resolveDeclaredFunnels`
+ * takes. Every status is read, not just `ongoing`: the brand this sweep exists for may have
+ * nothing ongoing at all, and its stopped campaigns are what say which offers it sells.
+ */
+async function offerStatingCampaigns(
+  orgId: string,
+  brandId: string,
+  seedOfferId: string | null,
+): Promise<Array<{ offerId: string | null }>> {
+  const rows = await db.query.campaigns.findMany({
+    where: and(
+      eq(campaigns.orgId, orgId),
+      inArray(campaigns.featureSlug, [...SALES_OUTREACH_FEATURE_SLUGS]),
+      arrayContains(campaigns.brandIds, [brandId]),
+    ),
+    columns: { offerId: true },
+  });
+  const group = rows.map((r) => ({ offerId: r.offerId }));
+  return group.length > 0 ? group : [{ offerId: seedOfferId }];
 }
 
 /** How many ongoing sales campaigns this (org, brand) holds — the sweep's before/after. */

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -6,7 +6,7 @@ import { resolveWorkflowSlugForTrigger } from "./features-workflow-projection-cl
 import { listRuns } from "@distribute/runs-client";
 import {
   planFunnelTurns,
-  provisionFundedFunnelsForIdleBrands,
+  provisionFundedPairsForQuietBrands,
   FUNDING_SWEEP_INTERVAL_MS,
 } from "./funnel-campaigns.js";
 import { resumeServeableCampaigns } from "./campaign-resume.js";
@@ -348,10 +348,11 @@ async function tick(): Promise<void> {
       // this very tick instead of waiting for the next one. Throttled to its own cadence
       // (RESUME_SWEEP_INTERVAL_MS), so a 60s tick does not turn into a 60s fan-out.
       await resumeServeableCampaigns();
-      // A brand whose campaigns are ALL stopped is claimed by nobody, so the claim path below
-      // could never notice that its owner funded a funnel. Asked on its own cadence, before the
-      // claim, so a campaign stood up here takes its turn on this very tick.
-      await provisionFundedFunnelsForIdleBrands();
+      // A brand nothing will claim soon — every campaign stopped, or every campaign parked at its
+      // ceiling until the day rollover — is invisible to the claim path below, so nothing would
+      // notice that its owner funded a channel. Asked on its own cadence, before the claim, so a
+      // campaign stood up here takes its turn on this very tick.
+      await provisionFundedPairsForQuietBrands();
       await claimStuckCampaigns();
       await reRunDueCampaigns();
     } catch (err) {

--- a/tests/integration/funding-drives-eligibility.test.ts
+++ b/tests/integration/funding-drives-eligibility.test.ts
@@ -260,14 +260,67 @@ describe("the scheduler holds what the customer funds nothing for", () => {
   });
 });
 
-describe("funding brings back a brand that has nothing running", () => {
+describe("funding brings back a brand nothing else will look at soon", () => {
+  it("provisions a newly funded channel for a brand PARKED AT ITS CEILING, without waiting for the day rollover", async () => {
+    // The brand is not idle: it has an ongoing campaign. It is simply at its ceiling, so the turn
+    // planner parked it on the day rollover and the claim path will not look at it again until
+    // midnight. Its owner funds a SECOND acquisition channel now — issue #386, and nineteen hours
+    // of silence for brand 75d7e3e8 in production.
+    billingAnswers(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }],
+      "5000",
+      [
+        { funnelKey: "reply_meeting", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "3000" },
+        { funnelKey: "reply_meeting", featureSlug: "feedback-request-cold-email-outreach", dailyBudgetCents: "2000" },
+      ],
+    );
+    const brandId = crypto.randomUUID();
+    const parked = new Date(Date.now() + 20 * 60 * 60_000); // next day rollover
+    await insertSalesCampaign(brandId, { nextRunAt: parked });
+
+    const { provisionFundedPairsForQuietBrands } = await import("../../src/lib/funnel-campaigns.js");
+    expect(await provisionFundedPairsForQuietBrands()).toBe(1);
+
+    const ongoing = await db.query.campaigns.findMany({ where: eq(campaigns.status, "ongoing") });
+    expect(ongoing).toHaveLength(2);
+    const provisioned = ongoing.find((c) => c.featureSlug === "feedback-request-cold-email-outreach")!;
+    expect(provisioned.funnelKey).toBe("sales_meetings_from_conversation");
+    expect(provisioned.acquisitionChannel).toBe("feedback_request_email");
+    // Due now: the very next tick claims it like any other campaign.
+    expect(provisioned.nextRunAt!.getTime()).toBeLessThanOrEqual(Date.now() + 1_000);
+    // The parked incumbent is left exactly where the turn planner put it.
+    const incumbent = ongoing.find((c) => c.featureSlug === SALES_OUTREACH_FEATURE_SLUG)!;
+    expect(incumbent.nextRunAt!.getTime()).toBe(parked.getTime());
+  });
+
+  it("does not examine a brand whose campaign is due soon — the claim path reaches it first, so no billing read at all", async () => {
+    billingAnswers([{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }], "5000");
+    const brandId = crypto.randomUUID();
+    await insertSalesCampaign(brandId); // due now
+
+    const { provisionFundedPairsForQuietBrands } = await import("../../src/lib/funnel-campaigns.js");
+    expect(await provisionFundedPairsForQuietBrands()).toBe(0);
+    // The whole read-volume argument: an actively-working brand costs this sweep nothing.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("does not examine a brand whose campaign is IN FLIGHT (nextRunAt cleared at claim time)", async () => {
+    billingAnswers([{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }], "5000");
+    const brandId = crypto.randomUUID();
+    await insertSalesCampaign(brandId, { nextRunAt: null });
+
+    const { provisionFundedPairsForQuietBrands } = await import("../../src/lib/funnel-campaigns.js");
+    expect(await provisionFundedPairsForQuietBrands()).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("provisions a campaign per funded, declared funnel for a brand whose campaigns are all stopped", async () => {
     billingAnswers([{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }], "5000");
     const brandId = crypto.randomUUID();
     await insertSalesCampaign(brandId, { status: "stopped", nextRunAt: null, funnelKey: null });
 
-    const { provisionFundedFunnelsForIdleBrands } = await import("../../src/lib/funnel-campaigns.js");
-    expect(await provisionFundedFunnelsForIdleBrands()).toBe(1);
+    const { provisionFundedPairsForQuietBrands } = await import("../../src/lib/funnel-campaigns.js");
+    expect(await provisionFundedPairsForQuietBrands()).toBe(1);
 
     const ongoing = await db.query.campaigns.findMany({
       where: eq(campaigns.status, "ongoing"),
@@ -288,8 +341,8 @@ describe("funding brings back a brand that has nothing running", () => {
     const brandId = crypto.randomUUID();
     await insertSalesCampaign(brandId, { status: "stopped", nextRunAt: null, funnelKey: null });
 
-    const { provisionFundedFunnelsForIdleBrands } = await import("../../src/lib/funnel-campaigns.js");
-    expect(await provisionFundedFunnelsForIdleBrands()).toBe(2);
+    const { provisionFundedPairsForQuietBrands } = await import("../../src/lib/funnel-campaigns.js");
+    expect(await provisionFundedPairsForQuietBrands()).toBe(2);
 
     const ongoing = await db.query.campaigns.findMany({ where: eq(campaigns.status, "ongoing") });
     expect(ongoing).toHaveLength(2);
@@ -321,8 +374,8 @@ describe("funding brings back a brand that has nothing running", () => {
     const brandId = crypto.randomUUID();
     await insertSalesCampaign(brandId, { status: "stopped", nextRunAt: null, funnelKey: null });
 
-    const { provisionFundedFunnelsForIdleBrands } = await import("../../src/lib/funnel-campaigns.js");
-    expect(await provisionFundedFunnelsForIdleBrands()).toBe(1);
+    const { provisionFundedPairsForQuietBrands } = await import("../../src/lib/funnel-campaigns.js");
+    expect(await provisionFundedPairsForQuietBrands()).toBe(1);
 
     const ongoing = await db.query.campaigns.findMany({ where: eq(campaigns.status, "ongoing") });
     expect(ongoing).toHaveLength(1);
@@ -339,8 +392,8 @@ describe("funding brings back a brand that has nothing running", () => {
       stopReason: "manual",
     });
 
-    const { provisionFundedFunnelsForIdleBrands } = await import("../../src/lib/funnel-campaigns.js");
-    await provisionFundedFunnelsForIdleBrands();
+    const { provisionFundedPairsForQuietBrands } = await import("../../src/lib/funnel-campaigns.js");
+    await provisionFundedPairsForQuietBrands();
 
     const after = await db.query.campaigns.findFirst({ where: eq(campaigns.id, stopped.id) });
     expect(after!.status).toBe("stopped");
@@ -351,8 +404,8 @@ describe("funding brings back a brand that has nothing running", () => {
     const brandId = crypto.randomUUID();
     const stopped = await insertSalesCampaign(brandId, { status: "stopped", nextRunAt: null });
 
-    const { provisionFundedFunnelsForIdleBrands } = await import("../../src/lib/funnel-campaigns.js");
-    expect(await provisionFundedFunnelsForIdleBrands()).toBe(0);
+    const { provisionFundedPairsForQuietBrands } = await import("../../src/lib/funnel-campaigns.js");
+    expect(await provisionFundedPairsForQuietBrands()).toBe(0);
 
     const after = await db.query.campaigns.findFirst({ where: eq(campaigns.id, stopped.id) });
     expect(after!.status).toBe("stopped");


### PR DESCRIPTION
Closes #386.

## The gap

Provisioning runs inside `planFunnelTurns`, i.e. only for campaigns the scheduler CLAIMED on that tick. A brand parked at its daily ceiling is deferred to the day rollover, so nothing of it is claimed — and nothing reads its funding — until midnight UTC. The sweep that exists precisely for un-claimed brands (`provisionFundedFunnelsForIdleBrands`) selected on "has NO ongoing campaign", so it skipped this brand: it has one, it is simply parked.

Prod: org `b645207b` / brand `75d7e3e8` funded a second acquisition channel at 2026-08-19 13:59 and had no campaign for it nineteen hours later. The funding was readable the whole time.

## The change

The sweep (renamed `provisionFundedPairsForQuietBrands`) selects on **when the brand will next be looked at**, not on whether it has something running. A (org, brand) pair is examined unless one of its sales campaigns is in flight (`next_run_at IS NULL`) or due within the sweep interval — in which case the claim path reaches it sooner and provisions it there, with the same code.

That covers all three states with one selection: nothing ongoing (unchanged), parked at the ceiling (the fix), actively working (excluded, as before).

Two consequences of the sweep now reaching brands that HAVE campaigns:

- the seed prefers an `ongoing` row (it carries the current owner, workflow and offer), falling back to most-recently-touched;
- the declared-funnel question is asked over every offer the pair's sales campaigns state, not just the seed's — otherwise a funnel declared by the *other* offer of a multi-offer brand reads as "nobody declares selling through it" and is silently passed over.

No third code path: same sweep, same `ensureFundedFunnelCampaigns`, same rules.

## Read volume

Unchanged for a brand whose funding has not changed and whose campaigns are working: such a brand is **excluded** from the sweep by the due-soon clause, so it makes zero extra billing reads (pinned by two tests asserting `fetch` is never called).

What is added is one billing read per **quiet** brand per ten minutes — brands parked at their ceiling, on top of the idle brands already swept. That is the same cadence and the same argument as `FUNDING_RECHECK_MS`: money moves when a person edits it, hours or days apart, so ten minutes is the latency the customer is owed and one read per brand per ten minutes is what it costs. The sweep's 100-brand cap and least-recently-touched ordering are untouched; the fleet is 44 brands with sales campaigns.

## Not touched

Turn-taking, the per-funnel/pair ceiling gate, the funding hold, and the rule that funding never resumes a campaign that stopped for a reason of its own (`audience_exhausted`, `max_leads_reached`, `manual`, `org_teardown`) — that last one is pinned by an existing test that stays green.

## Tests

- **New, and failing before this change**: a brand with an ongoing campaign parked on the day rollover funds a second channel → the sweep provisions it, due now, and leaves the parked incumbent's `next_run_at` exactly where the turn planner put it.
- **New**: a brand whose campaign is due now, and one whose campaign is in flight, are not examined at all (no billing read).
- Full suite green: 380 unit + 251 integration.

## Triage

Hotfix to main. A paying customer waited nineteen hours for a channel they had funded, and the next customer to fund one would wait too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
