### PR TITLE
hotfix: A raised funnel ceiling is spent the same day: the at-ceiling defer is bounded by the funding cadence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,7 +294,15 @@ funded funnels get worked, each spending up to its own ceiling and stopping ther
   never a fixed order and never "the primary first". A fixed order starves whatever sits last —
   if the first funnel can absorb the whole day the others never run, and that shows up in no log
   at all. A funnel at its ceiling yields with no special case (ratio ≥ 1 → not a candidate); all
-  funnels full → parked until the day rollover. EVERY alive campaign of the brand is a candidate
+  funnels full → parked, but on the FUNDING cadence (`min(nextDayStart, now + FUNDING_RECHECK_MS)`),
+  never on the day rollover alone. That defer is written ONCE from the ceiling current at that
+  instant and nothing re-checks an ongoing campaign due tomorrow — not the claim
+  (`next_run_at <= now()`), not `claimStuckCampaigns` (`next_run_at IS NULL`), not the resume sweep
+  (stopped rows only) — so a customer who RAISES a ceiling mid-day saw the money spent the next day
+  (prod 2026-08-23, brand `75d7e3e8`: $39.13 of a $40 ceiling, raised to $50 at 14:57, zero runs
+  after 13:24). `FUNDING_RECHECK_MS` already carries that promise for a campaign funded from ZERO;
+  one funded MORE is the same rule, missing branch. A brand still at its ceiling simply re-ranks and
+  defers again — no run, no spend, gate untouched. EVERY alive campaign of the brand is a candidate
   every tick — one that states no funnel is ranked on the brand daily budget, the ceiling the gate
   actually binds it to. No campaign is ever held out of the running because another one covers its
   funnel; there is no superseded state, and `tests/unit/no-legacy.test.ts` fails if the concept

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -263,8 +263,24 @@ async function planOneBrand(
   }
 
   const winner = selectLowestFillRatio(candidates);
-  // Every funded funnel is at its ceiling — nothing runs until they reset at the day rollover.
-  const reset = winner === null ? nextDayStart(now) : null;
+  // Every funded pair is at its ceiling. What re-opens it is NOT only the day rollover: a customer
+  // who raises a ceiling at 14:57 has bought headroom that exists the moment they buy it. The defer
+  // is written ONCE, from the ceiling current at this instant, and nothing else looks at an ongoing
+  // campaign deferred to tomorrow — not the claim (`next_run_at <= now()`), not `claimStuckCampaigns`
+  // (`next_run_at IS NULL`), not the resume sweep (stopped rows only). So parking on the rollover
+  // makes the raise land the NEXT DAY, with real funded headroom unused (prod 2026-08-23, brand
+  // 75d7e3e8: $39.13 of a $40 ceiling, raised to $50 at 14:57, zero runs after 13:24).
+  //
+  // Bounded by the funding cadence instead — the same figure and the same argument as
+  // FUNDING_RECHECK_MS, whose promise ("funding a funnel makes its campaign eligible within this
+  // window, with no manual step") held for a campaign funded from ZERO and not for one funded MORE.
+  // Same rule, missing branch. A brand STILL at its ceiling simply re-ranks and defers again: no run
+  // fires, no spend, and the gate is untouched. Ten minutes before midnight the rollover is the
+  // nearer of the two and wins, so the day reset is never overshot.
+  const reset =
+    winner === null
+      ? new Date(Math.min(nextDayStart(now).getTime(), now.getTime() + FUNDING_RECHECK_MS))
+      : null;
 
   for (const c of candidates) {
     if (c.campaignId === winner) continue;
@@ -651,11 +667,14 @@ export function resetFundingSweepThrottle(): void {
  *
  *   - a brand whose campaigns are ALL STOPPED is claimed by nobody, so nothing would look at it
  *     again ever (27 of the 44 brands with sales campaigns, the day this sweep was written);
- *   - a brand whose campaigns are all PARKED AT THEIR CEILING is deferred to the day rollover, so
- *     nothing looks at it again until midnight UTC. Its funding is perfectly readable the whole
- *     time. That is how brand 75d7e3e8 funded a second acquisition channel at 13:59 on 19 Aug and
- *     had no campaign for it nineteen hours later (issue #386) — too alive for a sweep that
- *     selected on "nothing ongoing", too quiet for the claim path.
+ *   - a brand whose campaigns are all PARKED AT THEIR CEILING used to be deferred to the day
+ *     rollover, so nothing looked at it again until midnight UTC while its funding stayed perfectly
+ *     readable the whole time. That is how brand 75d7e3e8 funded a second acquisition channel at
+ *     13:59 on 19 Aug and had no campaign for it nineteen hours later (issue #386) — too alive for
+ *     a sweep that selected on "nothing ongoing", too quiet for the claim path. That defer is now
+ *     bounded by FUNDING_RECHECK_MS, so such a brand is due within the sweep interval and the claim
+ *     path reaches it first; this selection covers it either way, which is the point of selecting on
+ *     WHEN it is next looked at rather than on which state parked it.
  *
  * So the selection is on WHEN the brand will next be looked at, not on whether it has something
  * running: a pair is examined here unless one of the brand's sales campaigns is in flight or due

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -348,10 +348,10 @@ async function tick(): Promise<void> {
       // this very tick instead of waiting for the next one. Throttled to its own cadence
       // (RESUME_SWEEP_INTERVAL_MS), so a 60s tick does not turn into a 60s fan-out.
       await resumeServeableCampaigns();
-      // A brand nothing will claim soon — every campaign stopped, or every campaign parked at its
-      // ceiling until the day rollover — is invisible to the claim path below, so nothing would
-      // notice that its owner funded a channel. Asked on its own cadence, before the claim, so a
-      // campaign stood up here takes its turn on this very tick.
+      // A brand nothing will claim soon — every campaign stopped, or every campaign parked past the
+      // sweep horizon — is invisible to the claim path below, so nothing would notice that its owner
+      // funded a channel. Asked on its own cadence, before the claim, so a campaign stood up here
+      // takes its turn on this very tick.
       await provisionFundedPairsForQuietBrands();
       await claimStuckCampaigns();
       await reRunDueCampaigns();

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -836,8 +836,10 @@ describe("planFunnelTurns", () => {
     mockFunnelBudgets([{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }]);
     mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
     mockFindFirst.mockResolvedValue({ id: "c-visit", name: "x", status: "ongoing" });
+    // Only the FUNDED campaign is ever asked what it spent — the unfunded one is out of the
+    // running before the question arises, so a second queued answer here would be a stale mock
+    // spilling into the next test.
     mockSpend("1200"); // the funded funnel is over its ceiling
-    mockSpend("0");    // the unfunded one has spent nothing, but has no ceiling to fill
 
     const now = new Date("2026-08-02T10:00:00Z");
     const deferred = await planFunnelTurns(
@@ -848,9 +850,84 @@ describe("planFunnelTurns", () => {
       now,
     );
 
-    // The funded-but-full one waits for the day rollover; the unfunded one is not waiting its
-    // TURN at all, it is waiting for money, so it re-checks on the funding cadence.
+    // The funded-but-full one waits on the funding cadence, not on its turn; the unfunded one is
+    // not waiting its TURN at all either, it is waiting for money — same cadence, same reason.
     expect(deferred.get("c-visit")!.getTime()).toBeGreaterThan(now.getTime() + FUNNEL_TURN_DEFER_MS);
     expect(deferred.get("c-unfunded")?.getTime()).toBe(now.getTime() + FUNDING_RECHECK_MS);
+  });
+
+  it("re-checks a brand whose every funded pair is at its ceiling on the funding cadence, not at the day rollover", async () => {
+    mockFunnelBudgets([
+      { funnelKey: "reply_meeting", dailyBudgetCents: "4000" },
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+    ]);
+    mockDeclaredFunnels([
+      { funnelKey: "sales_meetings_from_conversation" },
+      { funnelKey: "website_purchases" },
+    ]);
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "x", status: "ongoing" });
+    mockSpend("4000"); // c-reply: exactly at its ceiling
+    mockSpend("1200"); // c-visit: over its ceiling
+
+    const now = new Date("2026-08-23T16:24:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-reply", funnelKey: "sales_meetings_from_conversation" }),
+        claimed({ id: "c-visit", funnelKey: "website_purchases" }),
+      ],
+      now,
+    );
+
+    // Nothing runs — but the money that re-opens them can arrive at any hour, so the wake-up is
+    // bounded by the funding cadence. Parking on the day rollover is what left a raised ceiling
+    // unspent until midnight UTC.
+    expect(deferred.get("c-reply")?.getTime()).toBe(now.getTime() + FUNDING_RECHECK_MS);
+    expect(deferred.get("c-visit")?.getTime()).toBe(now.getTime() + FUNDING_RECHECK_MS);
+  });
+
+  it("never defers past the day rollover when the rollover is nearer than the funding cadence", async () => {
+    mockFunnelBudgets([{ funnelKey: "reply_meeting", dailyBudgetCents: "4000" }]);
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "x", status: "ongoing" });
+    mockSpend("4000");
+
+    // Three minutes to midnight (local, which is what the day-rollover helper works in).
+    const now = new Date();
+    now.setHours(23, 57, 0, 0);
+    const deferred = await planFunnelTurns(
+      [claimed({ id: "c-reply", funnelKey: "sales_meetings_from_conversation" })],
+      now,
+    );
+
+    const rollover = new Date(now.getTime());
+    rollover.setDate(rollover.getDate() + 1);
+    rollover.setHours(0, 0, 0, 0);
+    expect(deferred.get("c-reply")?.getTime()).toBe(rollover.getTime());
+  });
+
+  it("leaves the non-exhausted paths alone: the winner fires and the loser waits its turn", async () => {
+    mockFunnelBudgets([
+      { funnelKey: "reply_meeting", dailyBudgetCents: "4000" },
+      { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+    ]);
+    mockDeclaredFunnels([
+      { funnelKey: "sales_meetings_from_conversation" },
+      { funnelKey: "website_purchases" },
+    ]);
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "x", status: "ongoing" });
+    mockSpend("2000"); // c-reply: 50% full
+    mockSpend("900");  // c-visit: 90% full
+
+    const now = new Date("2026-08-23T16:24:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-reply", funnelKey: "sales_meetings_from_conversation" }),
+        claimed({ id: "c-visit", funnelKey: "website_purchases" }),
+      ],
+      now,
+    );
+
+    expect(deferred.has("c-reply")).toBe(false);
+    expect(deferred.get("c-visit")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
   });
 });


### PR DESCRIPTION
Automated by release.sh