### PR TITLE
hotfix: A sales campaign states the money that governs it — refuse maxBudget*, null the legacy values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,33 @@ work ONE funnel through BOTH, and each is a campaign of its own.
   stopped campaigns funding may resume — is UNCHANGED and applies per campaign, so it applies per
   pair without a special case. (Set 2026-08-18.)
 
+## A sales campaign row states the money that governs it — `maxBudget*` is REFUSED for the family
+
+`gate-check` runs the whole campaign-budget-windows block under `if (!isSalesFeature)`, so a
+`max_budget_daily_usd` / `weekly` / `monthly` / `total` on a sales-family row is inert BY
+CONSTRUCTION: the family paces on billing's per-(funnel, channel, offer) ceiling, read live on
+every plan. Correct behaviour, silent presentation — the row shows a dollar ceiling that decides
+nothing, and it already cost a live diagnosis a detour (#396: `max_budget_daily_usd | 10.00` on a
+campaign whose real ceiling was $50 read as a stale mirror).
+
+- **`POST /campaigns` and `PATCH /campaigns/:id` 400 a sales-family campaign that STATES one**
+  (`salesMaxBudgetRefusal`, `src/lib/sales-outreach-campaign.ts`), naming every field stated and
+  where the ceiling belongs. The update leg tests the feature the update LEAVES the campaign on
+  (the body's when it restates one, the row's otherwise). Presence is what is refused — the
+  schema does not accept null there, so there is no "clear it" spelling to allow.
+- **NON-sales campaigns are untouched and the columns are NEVER dropped**: every other feature
+  family paces on them and `gate-check` enforces them. The `!isSalesFeature` branch is correct
+  and is not to be touched.
+- **No per-campaign ceiling is ever introduced for the sales family.** `daily_budget_cents` is a
+  different thing (the funding mirror `fundingFromBudgets` prefers over billing) and is untouched
+  by any of this — it was verified null on all 22 live sales campaigns.
+- **Migration 0053** nulls the legacy values, scoped to the three sales slugs, auditing each row's
+  previous four values in `campaign_max_budget_decisions` with the migration tag. It touched 20
+  ongoing and 348 stopped rows in prod. Idempotent (a second run selects nothing) and reversible
+  by the audit table. The values were legacy from before the funnel model: provisioning inserts
+  sales campaigns with the columns null and the dashboard writes billing, so nothing was writing
+  them even before the guard. (Set 2026-08-24, issue #398.)
+
 ## The ceiling a campaign paces on is its OWN OFFER's — the pair figure holds a sibling's money too
 
 billing states daily ceilings at THREE grains on one read (`GET /internal/brands/:id/funnel-budgets`):

--- a/drizzle/0053_null_inert_sales_max_budgets.sql
+++ b/drizzle/0053_null_inert_sales_max_budgets.sql
@@ -1,0 +1,77 @@
+-- A sales campaign row states the money that actually governs it, and nothing else.
+--
+-- gate-check runs the whole campaign-budget-windows block under `if (!isSalesFeature)`, so a
+-- `max_budget_*` on a sales-family row is inert BY CONSTRUCTION: the sales family paces on
+-- billing's per-(funnel, channel, offer) ceiling, read live on every plan. Correct behaviour,
+-- silent presentation — the column shows a dollar ceiling that decides nothing.
+--
+-- It already misled a live diagnosis (#396): `max_budget_daily_usd | 10.00` on a campaign whose
+-- real ceiling was $50 read as a stale mirror and cost a detour before `fundingFromBudgets`
+-- confirmed billing was authoritative. The next person reading a sales row hits the same thing.
+--
+-- The values are LEGACY, from before the funnel model: nothing writes them today (provisioning
+-- inserts sales campaigns with the columns null, the dashboard writes billing), and since the
+-- code half of this fix the create/update routes REFUSE them for the sales family, so no new one
+-- can appear. `daily_budget_cents` — the mirror `fundingFromBudgets` prefers over billing — is
+-- untouched here and was verified null on all 22 live sales campaigns; this changes no pacing.
+--
+-- Measured on prod, 2026-08-24, scoped to the three sales-family feature slugs:
+--
+--   status    rows   max_budget_daily_usd set   weekly/monthly/total set
+--   ongoing     22                         18                          2
+--   stopped    358                        117                        231
+--
+-- NON-SALES campaigns are left exactly alone: for them the column is live and gate-check enforces
+-- it. The column itself is never dropped for the same reason.
+--
+-- IDEMPOTENT: a second run selects nothing (every sales row is already null on all four).
+-- REVERSIBLE by the previous values the audit table records, per campaign.
+
+CREATE TABLE IF NOT EXISTS campaign_max_budget_decisions (
+  id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id               text NOT NULL,
+  feature_slug              text,
+  status                    text,
+  previous_daily_usd        numeric(10, 2),
+  previous_weekly_usd       numeric(10, 2),
+  previous_monthly_usd      numeric(10, 2),
+  previous_total_usd        numeric(10, 2),
+  migration_tag             text NOT NULL,
+  decided_at                timestamptz NOT NULL DEFAULT now()
+);
+
+WITH inert AS (
+  SELECT id, feature_slug, status,
+         max_budget_daily_usd, max_budget_weekly_usd, max_budget_monthly_usd, max_budget_total_usd
+  FROM campaigns
+  WHERE feature_slug IN (
+          'sales-cold-email-outreach',
+          'sales-crm-email-outreach',
+          'feedback-request-cold-email-outreach'
+        )
+    AND (
+          max_budget_daily_usd IS NOT NULL
+       OR max_budget_weekly_usd IS NOT NULL
+       OR max_budget_monthly_usd IS NOT NULL
+       OR max_budget_total_usd IS NOT NULL
+        )
+), audited AS (
+  INSERT INTO campaign_max_budget_decisions (
+    campaign_id, feature_slug, status,
+    previous_daily_usd, previous_weekly_usd, previous_monthly_usd, previous_total_usd,
+    migration_tag
+  )
+  SELECT id::text, feature_slug, status,
+         max_budget_daily_usd, max_budget_weekly_usd, max_budget_monthly_usd, max_budget_total_usd,
+         '0053_null_inert_sales_max_budgets'
+  FROM inert
+  RETURNING campaign_id
+)
+UPDATE campaigns c
+SET max_budget_daily_usd   = NULL,
+    max_budget_weekly_usd  = NULL,
+    max_budget_monthly_usd = NULL,
+    max_budget_total_usd   = NULL,
+    updated_at             = now()
+FROM audited a
+WHERE c.id::text = a.campaign_id;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1777700000000,
       "tag": "0052_unpark_never_served_exhaustion_stops",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1777800000000,
+      "tag": "0053_null_inert_sales_max_budgets",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/sales-outreach-campaign.ts
+++ b/src/lib/sales-outreach-campaign.ts
@@ -26,3 +26,37 @@ export const SALES_OUTREACH_FEATURE_SLUGS: ReadonlySet<string> = new Set([
 export function isSalesOutreachFeature(slug?: string | null): boolean {
   return !!slug && SALES_OUTREACH_FEATURE_SLUGS.has(slug);
 }
+
+// The four per-campaign budget-window columns. gate-check enforces them for every OTHER feature
+// family (`if (!isSalesFeature)`), which is why they stay on the row and are never dropped.
+export const MAX_BUDGET_FIELDS = [
+  "maxBudgetDailyUsd",
+  "maxBudgetWeeklyUsd",
+  "maxBudgetMonthlyUsd",
+  "maxBudgetTotalUsd",
+] as const;
+
+/**
+ * A sales campaign's money is BILLING's, per (funnel, channel, offer) — read live on every plan.
+ * gate-check runs the whole campaign-budget-windows block under `if (!isSalesFeature)`, so a
+ * `maxBudget*` on a sales row is inert BY CONSTRUCTION: correct behaviour, silent presentation.
+ * A row that states a dollar ceiling nothing reads is what misled a live diagnosis (#396 —
+ * `max_budget_daily_usd | 10.00` on a campaign whose real ceiling was $50).
+ *
+ * So a create or update that states one on a sales-family campaign is REFUSED, naming where the
+ * ceiling actually belongs. Returns the refusal message, or null when there is nothing to refuse.
+ * Non-sales campaigns are untouched: for them the column is live.
+ */
+export function salesMaxBudgetRefusal(
+  featureSlug: string | null | undefined,
+  body: Record<string, unknown>,
+): string | null {
+  if (!isSalesOutreachFeature(featureSlug)) return null;
+  const stated = MAX_BUDGET_FIELDS.filter((field) => body?.[field] !== undefined);
+  if (stated.length === 0) return null;
+  return (
+    `A ${featureSlug} campaign cannot state ${stated.join(", ")} — nothing reads a per-campaign ` +
+    `budget ceiling for the sales family. Its money is billing's, stated per (sales funnel, ` +
+    `acquisition channel, offer) on the brand's daily ceilings; set it there instead.`
+  );
+}

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -11,7 +11,7 @@ import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { campaignIdentityColumns } from "../lib/campaign-identity.js";
 import { STOP_REASONS } from "../lib/stop-reason.js";
-import { isSalesOutreachFeature } from "../lib/sales-outreach-campaign.js";
+import { isSalesOutreachFeature, salesMaxBudgetRefusal } from "../lib/sales-outreach-campaign.js";
 import { acceptedFunnelKeys, toFunnelKey } from "../lib/sales-funnel-vocabulary.js";
 
 const router = Router();
@@ -158,6 +158,13 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
           : `Cannot create a ${resolvedFeatureSlug} campaign without stating its sales funnel — ` +
             `funnelKey is required (one of: ${acceptedFunnelKeys().join(", ")})`,
       });
+    }
+
+    // A sales campaign paces on billing's ceiling, never on a column of its own — see
+    // salesMaxBudgetRefusal. Refused at the door so no new inert value can appear.
+    const createMaxBudgetRefusal = salesMaxBudgetRefusal(resolvedFeatureSlug, req.body);
+    if (createMaxBudgetRefusal) {
+      return res.status(400).json({ error: createMaxBudgetRefusal });
     }
 
     // Validate all required workflow fields BEFORE creating the campaign
@@ -385,6 +392,16 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
 
     if (!existing) {
       return res.status(404).json({ error: "Campaign not found" });
+    }
+
+    // Same refusal as the create leg, against the feature this update LEAVES the campaign on
+    // (the body's when it restates one, the row's otherwise).
+    const updateMaxBudgetRefusal = salesMaxBudgetRefusal(
+      req.body.featureSlug ?? existing.featureSlug,
+      req.body,
+    );
+    if (updateMaxBudgetRefusal) {
+      return res.status(400).json({ error: updateMaxBudgetRefusal });
     }
 
     // Validate required workflow fields BEFORE activating

--- a/tests/integration/campaign-crud.test.ts
+++ b/tests/integration/campaign-crud.test.ts
@@ -520,4 +520,74 @@ describe("Campaign CRUD", () => {
       expect(stopped.body.campaign.funnelKey).toBe("form_magnet");
     });
   });
+  // A sales campaign's money is billing's, per (funnel, channel, offer). gate-check runs the
+  // campaign-budget-windows block under `if (!isSalesFeature)`, so a `maxBudget*` on a sales row
+  // decides nothing — and a row stating a ceiling nothing reads is what misled a live diagnosis.
+  describe("per-campaign budget windows on the sales family", () => {
+    const SALES = "sales-cold-email-outreach";
+    const NON_SALES = "pr-expert-quote-outreach";
+
+    it("refuses a sales create that states one, naming where the ceiling belongs", async () => {
+      const res = await createCampaign(
+        {
+          ...validBody,
+          name: "Sales campaign stating a dead ceiling",
+          brandIds: freshBrand(),
+          funnelKey: "sales_meetings_from_conversation",
+          maxBudgetDailyUsd: "10.00",
+        },
+        "org_test_crud",
+        SALES,
+      ).expect(400);
+
+      expect(res.body.error).toContain("maxBudgetDailyUsd");
+      expect(res.body.error).toContain("billing");
+    });
+
+    it("refuses a sales update that states one", async () => {
+      const created = await createCampaign(
+        {
+          ...validBody,
+          name: "Sales campaign updated later",
+          brandIds: freshBrand(),
+          funnelKey: "sales_meetings_from_conversation",
+        },
+        "org_test_crud",
+        SALES,
+      ).expect(201);
+
+      const res = await request(app)
+        .patch(`/campaigns/${created.body.campaign.id}`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .send({ maxBudgetWeeklyUsd: "70.00" })
+        .expect(400);
+
+      expect(res.body.error).toContain("maxBudgetWeeklyUsd");
+    });
+
+    it("leaves a NON-sales campaign alone — the column is live for it", async () => {
+      const created = await createCampaign(
+        {
+          ...validBody,
+          name: "PR campaign pacing on its own ceiling",
+          brandIds: freshBrand(),
+          maxBudgetDailyUsd: "10.00",
+        },
+        "org_test_crud",
+        NON_SALES,
+      ).expect(201);
+
+      expect(created.body.campaign.maxBudgetDailyUsd).toBe("10.00");
+
+      const patched = await request(app)
+        .patch(`/campaigns/${created.body.campaign.id}`)
+        .set("x-api-key", API_KEY)
+        .set("x-org-id", "org_test_crud")
+        .send({ maxBudgetTotalUsd: "500.00" })
+        .expect(200);
+
+      expect(patched.body.campaign.maxBudgetTotalUsd).toBe("500.00");
+    });
+  });
 });

--- a/tests/integration/null-inert-sales-max-budgets-migration.test.ts
+++ b/tests/integration/null-inert-sales-max-budgets-migration.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { db, sql } from "../../src/db/index.js";
+import { campaigns } from "../../src/db/schema.js";
+import { cleanTestData, closeDb, insertTestCampaign, randomId } from "../helpers/test-db.js";
+
+/**
+ * The migration is applied here exactly as prod will apply it — the file itself, against a
+ * database seeded with the shape prod holds — so both halves are measured: WHICH rows it selects
+ * (sales family only, whatever their status), and that a second run changes nothing.
+ */
+const TAG = "0053_null_inert_sales_max_budgets";
+const MIGRATION = readFileSync(join(process.cwd(), "drizzle", `${TAG}.sql`), "utf8");
+
+async function applyMigration() {
+  await sql.unsafe(MIGRATION);
+}
+
+async function rowOf(id: string) {
+  const [row] = await db.select().from(campaigns).where(eq(campaigns.id, id));
+  return row!;
+}
+
+async function auditCount(): Promise<number> {
+  const rows = await sql<{ n: string }[]>`
+    SELECT count(*)::text AS n FROM campaign_max_budget_decisions WHERE migration_tag = ${TAG}
+  `;
+  return Number(rows[0]!.n);
+}
+
+describe(`migration ${TAG}`, () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    // The audit table is created BY the migration, so it may not exist on the first run.
+    await sql.unsafe(`DELETE FROM campaign_max_budget_decisions WHERE true`).catch(() => {});
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("nulls the inert windows on sales campaigns of every status and leaves non-sales rows alone", async () => {
+    const org = randomId();
+
+    const liveSales = await insertTestCampaign(org, {
+      status: "ongoing",
+      brandId: randomId(),
+      funnelKey: "sales_meetings_from_conversation",
+      acquisitionChannel: "cold_email",
+      featureSlug: "sales-cold-email-outreach",
+      maxBudgetDailyUsd: "10.00",
+      dailyBudgetCents: 5000,
+    });
+
+    const stoppedSales = await insertTestCampaign(org, {
+      status: "stopped",
+      brandId: randomId(),
+      funnelKey: "website_purchases",
+      acquisitionChannel: "crm_email",
+      featureSlug: "sales-crm-email-outreach",
+      maxBudgetDailyUsd: "3.00",
+      maxBudgetWeeklyUsd: "21.00",
+      maxBudgetMonthlyUsd: "90.00",
+      maxBudgetTotalUsd: "900.00",
+    });
+
+    // Non-sales: the column is live for it and gate-check enforces it. Untouched.
+    const pr = await insertTestCampaign(org, {
+      status: "ongoing",
+      brandId: randomId(),
+      acquisitionChannel: "pr_cold_email",
+      featureSlug: "pr-expert-quote-outreach",
+      maxBudgetDailyUsd: "10.00",
+      maxBudgetTotalUsd: "500.00",
+    });
+
+    await applyMigration();
+
+    const live = await rowOf(liveSales.id);
+    expect(live.maxBudgetDailyUsd).toBeNull();
+    // The funding path is untouched: daily_budget_cents is not a budget WINDOW.
+    expect(live.dailyBudgetCents).toBe(5000);
+    expect(live.status).toBe("ongoing");
+
+    const stopped = await rowOf(stoppedSales.id);
+    expect(stopped.maxBudgetDailyUsd).toBeNull();
+    expect(stopped.maxBudgetWeeklyUsd).toBeNull();
+    expect(stopped.maxBudgetMonthlyUsd).toBeNull();
+    expect(stopped.maxBudgetTotalUsd).toBeNull();
+    expect(stopped.status).toBe("stopped");
+
+    const untouched = await rowOf(pr.id);
+    expect(untouched.maxBudgetDailyUsd).toBe("10.00");
+    expect(untouched.maxBudgetTotalUsd).toBe("500.00");
+
+    // One audit row per campaign written, holding what it replaced.
+    expect(await auditCount()).toBe(2);
+
+    // Idempotent — a second run selects nothing, because every sales row is already null.
+    await applyMigration();
+    expect(await auditCount()).toBe(2);
+    expect((await rowOf(liveSales.id)).maxBudgetDailyUsd).toBeNull();
+    expect((await rowOf(pr.id)).maxBudgetDailyUsd).toBe("10.00");
+  });
+});

--- a/tests/unit/sales-outreach-campaign.test.ts
+++ b/tests/unit/sales-outreach-campaign.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   isSalesOutreachFeature,
+  MAX_BUDGET_FIELDS,
+  salesMaxBudgetRefusal,
   SALES_CRM_FEATURE_SLUG,
   SALES_OUTREACH_FEATURE_SLUG,
   SALES_OUTREACH_WORKFLOW_SLUG,
@@ -66,5 +68,43 @@ describe("isSalesOutreachFeature", () => {
     expect(isSalesOutreachFeature("")).toBe(false);
     expect(isSalesOutreachFeature(null)).toBe(false);
     expect(isSalesOutreachFeature(undefined)).toBe(false);
+  });
+});
+
+describe("salesMaxBudgetRefusal", () => {
+  const SALES = "sales-cold-email-outreach";
+  const NON_SALES = "pr-expert-quote-outreach";
+
+  it("refuses each per-campaign budget window on a sales-family campaign, naming where the ceiling belongs", () => {
+    for (const slug of [SALES, "sales-crm-email-outreach", "feedback-request-cold-email-outreach"]) {
+      for (const field of MAX_BUDGET_FIELDS) {
+        const message = salesMaxBudgetRefusal(slug, { [field]: "10.00" });
+        expect(message).toContain(field);
+        expect(message).toContain("billing");
+        expect(message).toMatch(/funnel/i);
+      }
+    }
+  });
+
+  it("names every stated field in one refusal", () => {
+    const message = salesMaxBudgetRefusal(SALES, {
+      maxBudgetDailyUsd: "10.00",
+      maxBudgetTotalUsd: "500.00",
+    });
+    expect(message).toContain("maxBudgetDailyUsd");
+    expect(message).toContain("maxBudgetTotalUsd");
+  });
+
+  it("allows a NON-sales campaign to state one — the column is live for it and gate-check enforces it", () => {
+    for (const field of MAX_BUDGET_FIELDS) {
+      expect(salesMaxBudgetRefusal(NON_SALES, { [field]: "10.00" })).toBeNull();
+      expect(salesMaxBudgetRefusal("hiring-cold-email-outreach", { [field]: "10.00" })).toBeNull();
+      expect(salesMaxBudgetRefusal(null, { [field]: "10.00" })).toBeNull();
+    }
+  });
+
+  it("has nothing to refuse when a sales campaign states no budget window", () => {
+    expect(salesMaxBudgetRefusal(SALES, {})).toBeNull();
+    expect(salesMaxBudgetRefusal(SALES, { dailyBudgetCents: 5000, name: "x" })).toBeNull();
   });
 });


### PR DESCRIPTION
Automated by release.sh