### PR TITLE
fix(offers): adopt an existing campaign onto its pair's offer, on the tick

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,6 +544,41 @@ attribution and on the customer's screen.
   and a pair with no single offer. Only the SECOND exits non-zero: a campaign that names no single
   brand is the permanent honest answer and never changes, so failing the run on it would make this
   job red forever and teach everyone to ignore its exit code.
+- **A campaign that ALREADY EXISTS with no offer is ADOPTED on the tick — the script is not the
+  loop.** A campaign attributed to no offer is invisible on every offer-scoped surface: the
+  dashboard's offer page lists the campaigns OF THAT OFFER, so an unattributed one belongs to none
+  of them and appears nowhere, while it runs and spends. Provisioning found a live campaign for the
+  triple and moved on, so the row stayed unattributed forever and only a hand-run script closed it.
+  Prod 2026-08-24: org `100ed4eb` / brand `fbe3ce77`, campaign `16705a37` ongoing on
+  `sales_meetings_from_conversation`, no offer — the pair's one offer `231bb036` was created 28
+  minutes BEFORE it. Resolvable at create time, resolvable now, and nothing on this service's own
+  cadence was ever going to state it. `adoptOfferForPairSafely`
+  (`src/lib/campaign-offer-adoption.ts`) applies the SAME rule the script states, from
+  `ensureFundedFunnelCampaigns` — asked FIRST, before every early return there, because a pair whose
+  funnel declaration is empty or unreadable still has a live campaign the customer cannot see.
+  Same argument as the funnel-less-ancestor adoption (#377): an invariant a migration can only ever
+  state once is not an invariant, so this is NOT shipped as a one-shot migration and adds no table,
+  column or accumulator.
+  - **The rule is NOT widened**: exactly one offer on the (org, brand) PAIR, or nothing is written.
+    `x-org-id` on `GET /internal/brands/{brandId}/offers` (`src/lib/brand-offers-client.ts`) and
+    `org_id` on both statements are load-bearing — a brand row carries one offer per claiming org,
+    so resolving by brand alone writes another org's offer onto this org's campaign, inside the very
+    grouping the column exists to make correct. Pinned by `tests/unit/no-legacy.test.ts`.
+  - **Nothing is read unless something is missing.** The pre-check selects the pair's offer-less
+    campaigns; none → no brand-service read, no log, on every tick of every brand. A pair that IS
+    missing one is asked at most once per `OFFER_ADOPTION_RECHECK_MS` (10 min, the same figure and
+    argument as `FUNDING_RECHECK_MS` — an offer comes into being when a person creates one).
+  - **Zero or several offers is SAID, not silent — but only when a LIVE campaign is affected.** A
+    live campaign nobody can see on their offer page is the customer-visible harm. A pair whose only
+    unattributed rows are stopped is the pre-offers population the script proved permanently
+    unattributable (145 rows, most belonging to orgs brand-service does not know at all), and
+    repeating that every ten minutes forever would bury the signal.
+  - **A stopped row IS written when its own pair genuinely resolves** — it decides whose offer
+    totals its history lands in, exactly as its funnel does. Only `offer_id` moves: status, stop
+    reason, funnel, schedule and budget are untouched, and the offer still decides no money
+    question. Idempotent (the `offer_id IS NULL` guard is restated in the UPDATE, so a re-run
+    writes nothing and a race with a live create cannot overwrite it) and fail-SOFT (an attribution
+    correction must never hold up the provisioning that called it).
 
 ## "Which funnels are sold here?" is asked of the OFFER — the only grain with ONE answer
 

--- a/src/lib/brand-offers-client.ts
+++ b/src/lib/brand-offers-client.ts
@@ -1,0 +1,72 @@
+import type { IdentityHeaders } from "@distribute/runs-client";
+
+/**
+ * The offers ONE (org, brand) pair holds, as brand-service reports them.
+ *
+ * AN OFFER BELONGS TO THE PAIR, NOT TO THE BRAND. A `brands` row is a shared global identity that
+ * several orgs legitimately claim, and everything a customer configures on top of it — the goal,
+ * the funnels, the offers — belongs to the (org, brand) pair. brand-service resolves that org from
+ * `x-org-id`, so naming the org is load-bearing rather than tracking: reading the brand's offers
+ * without it would answer with ANOTHER org's offer, i.e. a cross-org write into the very per-offer
+ * grouping the column exists to make correct.
+ *
+ * The three outcomes are kept apart for the same reason `SalesFunnelsRead` keeps its own apart: a
+ * refusal collapsed onto "this pair holds no offer" is indistinguishable from a truthful empty
+ * answer, and the consequence is silent — a campaign that COULD be attributed simply never is.
+ */
+export type BrandOffersRead =
+  | { ok: true; offerIds: string[] }
+  | { ok: false; reason: "unavailable"; detail: string };
+
+/**
+ * Read the offers of one (org, brand) pair.
+ *
+ * Contract (brand-service): GET /internal/brands/{brandId}/offers  (x-api-key + x-org-id)
+ *   -> { offers: [{ offerId, brandId, name, createdAt, updatedAt }] }
+ *
+ * There is no `active` on an offer — an offer is a proposition a brand states, and it is the
+ * FUNNELS underneath it that are switched on and off. An offer's existence IS the answer.
+ */
+export async function fetchPairOffers(
+  brandId: string,
+  identity: IdentityHeaders,
+): Promise<BrandOffersRead> {
+  const baseUrl = process.env.BRAND_SERVICE_URL;
+  const apiKey = process.env.BRAND_SERVICE_API_KEY;
+  if (!baseUrl || !apiKey) {
+    return { ok: false, reason: "unavailable", detail: "brand-service not configured" };
+  }
+
+  const headers: Record<string, string> = {
+    "x-api-key": apiKey,
+    "x-org-id": identity.orgId,
+    "x-brand-id": brandId,
+  };
+  if (identity.userId) headers["x-user-id"] = identity.userId;
+  if (identity.runId) headers["x-run-id"] = identity.runId;
+
+  try {
+    const res = await fetch(
+      `${baseUrl.replace(/\/$/, "")}/internal/brands/${encodeURIComponent(brandId)}/offers`,
+      { headers },
+    );
+    if (!res.ok) {
+      return { ok: false, reason: "unavailable", detail: `brand ${brandId}: HTTP ${res.status}` };
+    }
+    const data = (await res.json()) as { offers?: Array<{ offerId?: string | null }> };
+    if (!Array.isArray(data?.offers)) {
+      return { ok: false, reason: "unavailable", detail: `brand ${brandId}: unparseable payload` };
+    }
+    const offerIds = [
+      ...new Set(
+        data.offers
+          .map((o) => o?.offerId)
+          .filter((id): id is string => typeof id === "string" && id.length > 0),
+      ),
+    ];
+    return { ok: true, offerIds };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: "unavailable", detail: `brand ${brandId}: ${message}` };
+  }
+}

--- a/src/lib/campaign-offer-adoption.ts
+++ b/src/lib/campaign-offer-adoption.ts
@@ -1,0 +1,201 @@
+import { sql } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { fetchPairOffers } from "./brand-offers-client.js";
+import type { ProvisioningIdentity } from "./provisioning-identity.js";
+
+/**
+ * A campaign that states no offer is invisible on every offer-scoped surface.
+ *
+ * Org > Brand > Offer > Campaign. The dashboard's offer page lists the campaigns OF THE OFFER
+ * being viewed, so a campaign attributed to no offer belongs to none of them and appears nowhere —
+ * while it runs and spends. A customer opens their offer and reads an empty page.
+ *
+ * `offer_id` is stated by the CREATOR (migration 0050 makes it optional, deliberately and
+ * temporarily, so a caller that has not migrated behaves exactly as it did before the column
+ * existed). What was missing is the other half: a campaign that ALREADY EXISTS with no offer was
+ * never adopted afterwards. Provisioning finds a live campaign for the triple and moves on, so an
+ * unattributed row stayed unattributed forever and only a hand-run script
+ * (`scripts/backfill-campaign-offer.ts`) ever closed it.
+ *
+ *   Prod 2026-08-24 — org 100ed4eb / brand fbe3ce77, campaign 16705a37 ongoing since 21:12Z on
+ *   sales_meetings_from_conversation, no offer. The pair's ONE offer 231bb036 was created at
+ *   20:44Z, 28 minutes BEFORE the campaign. The attribution was resolvable at create time and is
+ *   still resolvable now; nothing on this service's own cadence was ever going to state it.
+ *
+ * So the rule lives on the TICK, exactly as the funnel-less-ancestor adoption does and for the
+ * same reason: an invariant a migration can only ever state once is not an invariant. See
+ * funnel-ancestor-adoption.ts.
+ *
+ * THE RULE, byte-for-byte the one the backfill script states, and it is NOT widened:
+ * a campaign carrying no offer is written the offer of its (org, brand) PAIR, and ONLY when that
+ * pair resolves to EXACTLY ONE offer. Zero offers, several offers, or an unreadable answer leaves
+ * every campaign of the pair exactly as it is. Nothing is ever derived from the funnel, the goal
+ * or the workflow — several offers legitimately sell through one funnel, which is the entire
+ * reason the dimension exists.
+ *
+ * NEVER by brand alone. A brand row is claimed by many orgs and carries one offer per claiming
+ * org, frequently all named the same thing, so "this brand has an offer" is not a question that
+ * can be acted on: `x-org-id` is what makes the answer this org's. Every write is scoped to the
+ * campaign's own `org_id` as well, so no campaign can be attributed to another org's offer.
+ *
+ * What it never touches: any campaign that already STATES an offer (this only ever fills an
+ * absence), and any column other than `offer_id`. Status, funnel, schedule, budget and history are
+ * untouched — the offer decides no money question, it is the grain the customer reads their
+ * campaigns at.
+ */
+
+/**
+ * How often one pair is asked. Same figure and same argument as `FUNDING_RECHECK_MS`: an offer
+ * comes into being when a person creates one, hours or days apart, so asking on the turn cadence
+ * would be one brand-service read per minute per brand answering "still nothing". This IS the
+ * latency between an offer existing and a live campaign of that pair reading it.
+ */
+export const OFFER_ADOPTION_RECHECK_MS = 10 * 60_000; // 10 min
+
+/** The (org, brand) pair a campaign's offer is resolved at. Never the brand on its own. */
+export interface OfferAdoptionScope {
+  orgId: string;
+  brandId: string;
+}
+
+interface OfferlessCampaign extends Record<string, unknown> {
+  id: string;
+  status: string;
+}
+
+const lastAskedAt = new Map<string, number>();
+
+/** Test seam: forget the per-pair throttle so a test can run consecutive adoptions. */
+export function resetOfferAdoptionThrottle(): void {
+  lastAskedAt.clear();
+}
+
+/**
+ * The campaigns of this pair that state no offer.
+ *
+ * `brand_id` is the stored half of the campaign identity (migration 0044); the historical rows
+ * only carry the array, so it is the fallback — but ONLY when it names exactly ONE brand. Taking
+ * `brand_ids[1]` unconditionally reads a campaign of several brands as a campaign of its first,
+ * which is precisely the guess this must never make.
+ */
+async function offerlessCampaignsOfPair(scope: OfferAdoptionScope): Promise<OfferlessCampaign[]> {
+  const rows = await db.execute<OfferlessCampaign>(sql`
+    SELECT "id", "status"
+    FROM "campaigns"
+    WHERE "org_id" = ${scope.orgId}
+      AND "offer_id" IS NULL
+      AND (
+        "brand_id" = ${scope.brandId}
+        OR (
+          "brand_id" IS NULL
+          AND coalesce(array_length("brand_ids", 1), 0) = 1
+          AND "brand_ids"[1] = ${scope.brandId}
+        )
+      )
+  `);
+  return Array.from(rows as unknown as Iterable<OfferlessCampaign>);
+}
+
+/**
+ * Write the pair's single offer onto every campaign of the pair that states none.
+ *
+ * Returns how many rows were written — zero on every ordinary tick, because the pair is only ever
+ * asked about when one of its campaigns states no offer.
+ *
+ * IDEMPOTENT: the `offer_id IS NULL` guard is restated in the UPDATE, not only in the SELECT, so a
+ * second call writes nothing and a call racing a live create can never overwrite an offer a caller
+ * just stated.
+ *
+ * REVERSIBLE: the previous value is NULL by construction, so the reverse of a run is exactly the
+ * ids it logs.
+ */
+export async function adoptOfferForPair(
+  scope: OfferAdoptionScope,
+  identity: ProvisioningIdentity,
+  now: Date = new Date(),
+): Promise<number> {
+  const offerless = await offerlessCampaignsOfPair(scope);
+  // The routine path for every attributed brand: nothing to ask, nothing read, nothing logged.
+  if (offerless.length === 0) return 0;
+
+  const key = `${scope.orgId}::${scope.brandId}`;
+  const askedAt = lastAskedAt.get(key) ?? 0;
+  if (now.getTime() - askedAt < OFFER_ADOPTION_RECHECK_MS) return 0;
+  lastAskedAt.set(key, now.getTime());
+
+  // A LIVE campaign nobody can see on their offer page is the customer-visible harm and is worth
+  // a line every time the answer is not one offer. A pair whose only unattributed rows are STOPPED
+  // is the pre-offers population #371 proved permanently unattributable (145 rows, most of them
+  // belonging to orgs brand-service does not know at all) — saying so every ten minutes forever
+  // would bury the signal it exists for.
+  const live = offerless.filter((c) => c.status === "ongoing");
+  const say = (message: string) => {
+    if (live.length > 0) console.warn(message);
+  };
+
+  const read = await fetchPairOffers(scope.brandId, identity);
+  if (!read.ok) {
+    say(
+      `[campaign-service] Could not attribute ${live.length} live campaign(s) of brand ${scope.brandId} (org ${scope.orgId}) to an offer — brand-service would not answer: ${read.detail}`,
+    );
+    return 0;
+  }
+
+  if (read.offerIds.length !== 1) {
+    say(
+      read.offerIds.length === 0
+        ? `[campaign-service] ${live.length} live campaign(s) of brand ${scope.brandId} (org ${scope.orgId}) state no offer and this (org, brand) pair holds none — nothing is attributed, and they stay invisible on every offer surface until it does`
+        : `[campaign-service] ${live.length} live campaign(s) of brand ${scope.brandId} (org ${scope.orgId}) state no offer and this (org, brand) pair holds ${read.offerIds.length} — none outranks another, so nothing is attributed`,
+    );
+    return 0;
+  }
+
+  const offerId = read.offerIds[0];
+  const applied = await db.execute<{ id: string }>(sql`
+    UPDATE "campaigns"
+    SET "offer_id" = ${offerId}, "updated_at" = now()
+    WHERE "org_id" = ${scope.orgId}
+      AND "offer_id" IS NULL
+      AND (
+        "brand_id" = ${scope.brandId}
+        OR (
+          "brand_id" IS NULL
+          AND coalesce(array_length("brand_ids", 1), 0) = 1
+          AND "brand_ids"[1] = ${scope.brandId}
+        )
+      )
+    RETURNING "id"
+  `);
+
+  const written = Array.from(applied as unknown as Iterable<{ id: string }>);
+  if (written.length > 0) {
+    console.log(
+      `[campaign-service] ${written.length} campaign(s) of brand ${scope.brandId} (org ${scope.orgId}) now state offer ${offerId} — they were attributed to none and showed on no offer surface: ${written.map((r) => r.id).join(", ")}`,
+    );
+  }
+  return written.length;
+}
+
+/**
+ * Fail-SOFT wrapper for the provisioning tick.
+ *
+ * Adoption is an ATTRIBUTION correction: it decides which offer page a campaign appears on, and it
+ * spends nothing, starts nothing and stops nothing. A failure must never hold up the provisioning
+ * that called it — the funded pair still needs its campaign — so it is said out loud once and the
+ * next sweep tries again.
+ */
+export async function adoptOfferForPairSafely(
+  scope: OfferAdoptionScope,
+  identity: ProvisioningIdentity,
+  now: Date = new Date(),
+): Promise<number> {
+  try {
+    return await adoptOfferForPair(scope, identity, now);
+  } catch (err) {
+    console.warn(
+      `[campaign-service] Could not attribute the offer-less campaigns of brand ${scope.brandId} (org ${scope.orgId}) to their pair's offer:`,
+      err,
+    );
+    return 0;
+  }
+}

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -22,6 +22,7 @@ import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 import { acquisitionChannelForFeature, campaignIdentityColumns } from "./campaign-identity.js";
 import { fundingFromBudgets } from "./campaign-funding.js";
 import { adoptFunnellessAncestorsSafely } from "./funnel-ancestor-adoption.js";
+import { adoptOfferForPairSafely } from "./campaign-offer-adoption.js";
 
 // A campaign that did not get this brand's turn re-checks on the next active tick. The turn is
 // re-ranked from scratch every tick, so this is a "wait your turn", not a backoff. EVERY alive
@@ -456,6 +457,14 @@ async function ensureFundedFunnelCampaigns({
   identity: ProvisioningIdentity;
   now: Date;
 }): Promise<void> {
+  // A campaign that already exists with NO offer is invisible on every offer-scoped surface, and
+  // provisioning is the one thing that looks at this pair on this service's own cadence. Asked
+  // FIRST, before any early return below: a pair whose funnel declaration is empty or unreadable
+  // still has a live campaign the customer cannot see, and that is exactly the pair this closes.
+  // Fail-soft and a no-op on every ordinary tick (nothing is read at all unless a campaign of the
+  // pair states no offer). See campaign-offer-adoption.ts for the rule and why it is not a script.
+  await adoptOfferForPairSafely({ orgId: seed.orgId, brandId }, identity, now);
+
   // No readable funnel declaration → nothing says the brand still sells through these funnels.
   // Provisioning waits; whatever campaigns already exist keep running.
   if (declared.offerByFunnel.size === 0) return;

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -42,6 +42,8 @@ export async function insertTestCampaign(
     // WHY it stopped — only `audience_exhausted` is resumable (src/lib/stop-reason.ts).
     stopReason?: string | null;
     funnelKey?: string | null;
+    /** The offer the campaign sells — brand-service's id, carried and never derived. */
+    offerId?: string | null;
     // The two identity columns the partial unique index is built on. Written at creation by
     // campaignIdentityColumns in the routes; stated explicitly here so a test can build the
     // (org, brand, funnel, channel) collision the resume must refuse.
@@ -78,6 +80,7 @@ export async function insertTestCampaign(
       parentRunId: data.parentRunId || null,
       stopReason: data.stopReason ?? null,
       funnelKey: data.funnelKey ?? null,
+      offerId: data.offerId ?? null,
       brandId: data.brandId ?? null,
       acquisitionChannel: data.acquisitionChannel ?? null,
       ...(data.updatedAt ? { updatedAt: data.updatedAt } : {}),

--- a/tests/integration/campaign-offer-adoption.test.ts
+++ b/tests/integration/campaign-offer-adoption.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import { campaigns } from "../../src/db/schema.js";
+import { cleanTestData, closeDb, insertTestCampaign, randomId } from "../helpers/test-db.js";
+import {
+  adoptOfferForPair,
+  resetOfferAdoptionThrottle,
+} from "../../src/lib/campaign-offer-adoption.js";
+import type { ProvisioningIdentity } from "../../src/lib/provisioning-identity.js";
+
+/**
+ * The rule against a real database: a campaign that already exists with no offer becomes
+ * attributed on this service's own cadence, and ONLY where its own (org, brand) pair resolves to
+ * exactly one offer.
+ *
+ * The prod shape it is seeded from (2026-08-24): org 100ed4eb / brand fbe3ce77 holds ONE offer
+ * 231bb036, created 28 minutes before campaign 16705a37 — which is ongoing, spending, and shows on
+ * no offer page because the caller that created it never stated the offer.
+ */
+const ORG = randomId();
+const OTHER_ORG = randomId();
+const BRAND = randomId();
+const OFFER = randomId();
+const OTHER_ORG_OFFER = randomId();
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function identityFor(orgId: string): ProvisioningIdentity {
+  return { orgId, userId: randomId(), runId: randomId(), brandId: BRAND };
+}
+
+/** brand-service answers per (org, brand) pair — the org is what selects the answer. */
+function brandServiceHolds(offersByOrg: Record<string, string[]>) {
+  mockFetch.mockImplementation(async (_url: string, init: { headers: Record<string, string> }) => {
+    const offers = offersByOrg[init.headers["x-org-id"]] ?? [];
+    return { ok: true, json: async () => ({ offers: offers.map((offerId) => ({ offerId })) }) };
+  });
+}
+
+async function offerOf(id: string): Promise<string | null> {
+  const [row] = await db.select().from(campaigns).where(eq(campaigns.id, id));
+  return row?.offerId ?? null;
+}
+
+describe("campaign offer adoption (integration)", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+    resetOfferAdoptionThrottle();
+    mockFetch.mockReset();
+    process.env.BRAND_SERVICE_URL = "https://brand.test";
+    process.env.BRAND_SERVICE_API_KEY = "brand-key";
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("attributes the live campaign of a pair holding exactly one offer", async () => {
+    const live = await insertTestCampaign(ORG, {
+      status: "ongoing",
+      brandId: BRAND,
+      brandIds: [BRAND],
+      acquisitionChannel: "cold_email",
+      funnelKey: "sales_meetings_from_conversation",
+      featureSlug: "sales-cold-email-outreach",
+    });
+    brandServiceHolds({ [ORG]: [OFFER] });
+
+    expect(await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identityFor(ORG))).toBe(1);
+    expect(await offerOf(live.id)).toBe(OFFER);
+  });
+
+  it("NEVER attributes a campaign to another org's offer on the same brand row", async () => {
+    // A brand row is a shared global identity: it carries one offer per claiming org. Reading the
+    // brand's offers without naming the org is the cross-org write this scoping closes.
+    const mine = await insertTestCampaign(ORG, { status: "ongoing", brandId: BRAND, brandIds: [BRAND] });
+    const theirs = await insertTestCampaign(OTHER_ORG, { status: "ongoing", brandId: BRAND, brandIds: [BRAND] });
+    brandServiceHolds({ [ORG]: [OFFER], [OTHER_ORG]: [OTHER_ORG_OFFER] });
+
+    await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identityFor(ORG));
+
+    expect(await offerOf(mine.id)).toBe(OFFER);
+    expect(await offerOf(theirs.id)).toBeNull();
+  });
+
+  it("leaves every campaign alone when the pair holds several offers", async () => {
+    const live = await insertTestCampaign(ORG, { status: "ongoing", brandId: BRAND, brandIds: [BRAND] });
+    brandServiceHolds({ [ORG]: [OFFER, randomId()] });
+
+    expect(await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identityFor(ORG))).toBe(0);
+    expect(await offerOf(live.id)).toBeNull();
+  });
+
+  it("leaves every campaign alone when the pair holds no offer", async () => {
+    const live = await insertTestCampaign(ORG, { status: "ongoing", brandId: BRAND, brandIds: [BRAND] });
+    brandServiceHolds({ [ORG]: [] });
+
+    expect(await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identityFor(ORG))).toBe(0);
+    expect(await offerOf(live.id)).toBeNull();
+  });
+
+  it("never overwrites an offer a campaign already states", async () => {
+    const stated = await insertTestCampaign(ORG, {
+      status: "ongoing",
+      brandId: BRAND,
+      brandIds: [BRAND],
+      offerId: OTHER_ORG_OFFER,
+    });
+    const bare = await insertTestCampaign(ORG, { status: "ongoing", brandId: BRAND, brandIds: [BRAND] });
+    brandServiceHolds({ [ORG]: [OFFER] });
+
+    expect(await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identityFor(ORG))).toBe(1);
+    expect(await offerOf(stated.id)).toBe(OTHER_ORG_OFFER);
+    expect(await offerOf(bare.id)).toBe(OFFER);
+  });
+
+  it("adopts a stopped ancestor of the same pair, and only through the pair's own answer", async () => {
+    const stopped = await insertTestCampaign(ORG, {
+      status: "stopped",
+      brandId: BRAND,
+      brandIds: [BRAND],
+      stopReason: "audience_exhausted",
+    });
+    brandServiceHolds({ [ORG]: [OFFER] });
+
+    await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identityFor(ORG));
+
+    const [row] = await db.select().from(campaigns).where(eq(campaigns.id, stopped.id));
+    expect(row.offerId).toBe(OFFER);
+    // Nothing else moves: the offer decides no money question and no lifecycle one.
+    expect(row.status).toBe("stopped");
+    expect(row.stopReason).toBe("audience_exhausted");
+  });
+
+  it("resolves the historical row that carries only the brand ARRAY, never a multi-brand one", async () => {
+    const single = await insertTestCampaign(ORG, {
+      status: "ongoing",
+      brandId: null,
+      brandIds: [BRAND],
+    });
+    const several = await insertTestCampaign(ORG, {
+      status: "ongoing",
+      brandId: null,
+      brandIds: [BRAND, randomId()],
+    });
+    brandServiceHolds({ [ORG]: [OFFER] });
+
+    await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identityFor(ORG));
+
+    expect(await offerOf(single.id)).toBe(OFFER);
+    // A campaign naming several brands is the permanent honest NULL — it is never guessed at.
+    expect(await offerOf(several.id)).toBeNull();
+  });
+
+  it("is idempotent — a second pass reads nothing and writes nothing", async () => {
+    const live = await insertTestCampaign(ORG, { status: "ongoing", brandId: BRAND, brandIds: [BRAND] });
+    brandServiceHolds({ [ORG]: [OFFER] });
+
+    const now = new Date();
+    expect(await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identityFor(ORG), now)).toBe(1);
+    const reads = mockFetch.mock.calls.length;
+
+    // Past the throttle: the pre-check finds nothing left to attribute, so brand-service is not
+    // even asked.
+    const later = new Date(now.getTime() + 60 * 60_000);
+    expect(await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identityFor(ORG), later)).toBe(0);
+    expect(mockFetch.mock.calls.length).toBe(reads);
+    expect(await offerOf(live.id)).toBe(OFFER);
+  });
+});

--- a/tests/unit/campaign-offer-adoption.test.ts
+++ b/tests/unit/campaign-offer-adoption.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockExecute } = vi.hoisted(() => ({ mockExecute: vi.fn() }));
+
+vi.mock("../../src/db/index.js", () => ({ db: { execute: mockExecute } }));
+
+vi.mock("drizzle-orm", () => ({
+  // The raw-`sql` seam. These tests pin WHICH question is asked of brand-service and WHETHER a
+  // write is attempted; what the SQL writes is measured against a real database in
+  // tests/integration/campaign-offer-adoption.test.ts.
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings: [...strings],
+    values,
+    text: strings.join("?"),
+  }),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import {
+  adoptOfferForPair,
+  adoptOfferForPairSafely,
+  resetOfferAdoptionThrottle,
+  OFFER_ADOPTION_RECHECK_MS,
+} from "../../src/lib/campaign-offer-adoption.js";
+import type { ProvisioningIdentity } from "../../src/lib/provisioning-identity.js";
+
+const ORG = "100ed4eb-f10e-42bf-aa58-054014392141";
+const BRAND = "fbe3ce77-8890-48a7-9e19-7f67fecdac05";
+const CAMPAIGN = "16705a37-f95e-420c-b6a1-c91b436631b0";
+const OFFER = "231bb036-1fa4-4e0d-82a9-600b4f744e32";
+
+const identity: ProvisioningIdentity = {
+  orgId: ORG,
+  userId: "user-1",
+  runId: "3f6d2f2e-0a5a-4e1e-9a4f-1a2b3c4d5e6f",
+  brandId: BRAND,
+};
+
+/** The pre-check answer, then the UPDATE's RETURNING. */
+function db(offerless: Array<{ id: string; status: string }>, written: string[] = []) {
+  mockExecute.mockReset();
+  mockExecute.mockResolvedValueOnce(offerless);
+  mockExecute.mockResolvedValueOnce(written.map((id) => ({ id })));
+}
+
+function brandServiceAnswers(offerIds: string[]) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ offers: offerIds.map((offerId) => ({ offerId })) }),
+  });
+}
+
+describe("campaign offer adoption — a live campaign attributed to no offer appears on no offer page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetOfferAdoptionThrottle();
+    process.env.BRAND_SERVICE_URL = "https://brand.test";
+    process.env.BRAND_SERVICE_API_KEY = "brand-key";
+  });
+
+  it("writes the pair's single offer onto the campaign that states none", async () => {
+    db([{ id: CAMPAIGN, status: "ongoing" }], [CAMPAIGN]);
+    brandServiceAnswers([OFFER]);
+
+    const written = await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity);
+
+    expect(written).toBe(1);
+    // The offer id reaches the UPDATE.
+    expect(mockExecute.mock.calls[1][0].values).toContain(OFFER);
+  });
+
+  it("NAMES THE ORG on the brand-service read — an offer belongs to the (org, brand) pair", async () => {
+    // A brand row is a shared global identity many orgs claim, each with its own offers. Reading
+    // the brand's offers without naming the org would attribute this org's campaign to ANOTHER
+    // org's offer, inside the very per-offer grouping the column exists to make correct.
+    db([{ id: CAMPAIGN, status: "ongoing" }], [CAMPAIGN]);
+    brandServiceAnswers([OFFER]);
+
+    await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity);
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(`https://brand.test/internal/brands/${BRAND}/offers`);
+    expect(init.headers["x-org-id"]).toBe(ORG);
+  });
+
+  it("scopes the write to the campaign's own org", async () => {
+    db([{ id: CAMPAIGN, status: "ongoing" }], [CAMPAIGN]);
+    brandServiceAnswers([OFFER]);
+
+    await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity);
+
+    for (const call of mockExecute.mock.calls) {
+      expect(call[0].text).toContain('"org_id" =');
+      expect(call[0].values).toContain(ORG);
+    }
+  });
+
+  it("writes NOTHING when the pair holds several offers, and says so", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    db([{ id: CAMPAIGN, status: "ongoing" }]);
+    brandServiceAnswers([OFFER, "a-second-offer"]);
+
+    const written = await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity);
+
+    expect(written).toBe(0);
+    expect(mockExecute).toHaveBeenCalledTimes(1); // the pre-check only — no UPDATE
+    expect(warn.mock.calls.flat().join(" ")).toContain("2");
+  });
+
+  it("writes NOTHING when the pair holds no offer, and says so", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    db([{ id: CAMPAIGN, status: "ongoing" }]);
+    brandServiceAnswers([]);
+
+    const written = await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity);
+
+    expect(written).toBe(0);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("writes NOTHING when brand-service will not answer, and says so", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    db([{ id: CAMPAIGN, status: "ongoing" }]);
+    mockFetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({}) });
+
+    const written = await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity);
+
+    expect(written).toBe(0);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("asks NOTHING when every campaign of the pair already states an offer", async () => {
+    db([]);
+
+    const written = await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity);
+
+    expect(written).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockExecute).toHaveBeenCalledTimes(1); // the pre-check, nothing more
+  });
+
+  it("stays SILENT for a pair whose unattributed rows are all stopped", async () => {
+    // The pre-offers population: 145 stopped rows, most belonging to orgs brand-service does not
+    // know at all. Saying so every ten minutes forever buries the live case this exists for.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    db([{ id: "old-1", status: "stopped" }]);
+    brandServiceAnswers([]);
+
+    await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("still ADOPTS a stopped row when its own pair genuinely resolves", async () => {
+    db([{ id: "old-1", status: "stopped" }], ["old-1"]);
+    brandServiceAnswers([OFFER]);
+
+    expect(await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity)).toBe(1);
+  });
+
+  it("asks one pair at most once per recheck interval", async () => {
+    const t0 = new Date("2026-08-24T10:00:00Z");
+    db([{ id: CAMPAIGN, status: "ongoing" }]);
+    brandServiceAnswers([]);
+    await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity, t0);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    db([{ id: CAMPAIGN, status: "ongoing" }]);
+    await adoptOfferForPair({ orgId: ORG, brandId: BRAND }, identity, new Date(t0.getTime() + 60_000));
+    expect(mockFetch).toHaveBeenCalledTimes(1); // throttled
+
+    db([{ id: CAMPAIGN, status: "ongoing" }]);
+    await adoptOfferForPair(
+      { orgId: ORG, brandId: BRAND },
+      identity,
+      new Date(t0.getTime() + OFFER_ADOPTION_RECHECK_MS + 1),
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("is fail-SOFT — a failure never holds up the provisioning that called it", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExecute.mockReset();
+    mockExecute.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(adoptOfferForPairSafely({ orgId: ORG, brandId: BRAND }, identity)).resolves.toBe(0);
+  });
+});

--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -71,6 +71,27 @@ describe('No Legacy Patterns - CRITICAL', () => {
     expect(code).not.toMatch(/\bcurrentGoal\b/);
   });
 
+  it('should NEVER resolve a campaign offer by BRAND alone', () => {
+    // An offer belongs to the (org, brand) PAIR: a brand row is a shared global identity and
+    // carries one offer per claiming org, frequently all named the same thing. Reading the brand's
+    // offers without naming the org attributes this org's campaign to ANOTHER org's offer, inside
+    // the very per-offer grouping the column exists to make correct. `x-org-id` on the read and
+    // `org_id` on the write are load-bearing, not tracking.
+    const client = fs.readFileSync(path.join(srcDir, 'lib/brand-offers-client.ts'), 'utf-8');
+    expect(client).toMatch(/"x-org-id": identity\.orgId/);
+    expect(client).not.toMatch(/if \(identity\.orgId\)/);
+
+    const adoption = fs.readFileSync(path.join(srcDir, 'lib/campaign-offer-adoption.ts'), 'utf-8');
+    // Every statement this rule makes about campaigns is scoped to the campaign's own org.
+    const statements = adoption.split(/db\.execute/).slice(1);
+    expect(statements.length).toBeGreaterThan(0);
+    for (const statement of statements) {
+      expect(statement).toMatch(/"org_id" = \$\{scope\.orgId\}/);
+    }
+    // And the offer is never derived from the funnel, the goal or the workflow.
+    expect(adoption).not.toMatch(/funnelKey\s*[:=]/);
+  });
+
   it('should NOT collapse a sales-funnels refusal back onto a nullable answer', () => {
     // The three outcomes — a truthful answer (possibly EMPTY), a refusal to answer at this grain,
     // and a transport failure — were one `null`, and that is what made the offer level silent: the


### PR DESCRIPTION
## The bug

A customer opens their offer page and sees no campaign, although one is running and spending for that offer.

A campaign attributed to no offer is invisible on every offer-scoped surface: the dashboard lists the campaigns **of the offer being viewed**, so a campaign attributed to none belongs to none of them and appears nowhere.

Prod, 2026-08-24:

- org `100ed4eb` / brand `fbe3ce77`, campaign `16705a37` — `ongoing`, funnel `sales_meetings_from_conversation`, created 21:12Z, **no offer**.
- brand-service already answers who sells that funnel: the pair's one offer `231bb036` was created at 20:44Z, **28 minutes before the campaign**. Resolvable at create time, still resolvable now.
- Fleet-wide 146 campaigns carry no offer; 145 are stopped (the pre-offers population #371 proved permanently unattributable) and exactly one is ongoing — that one.

The caller that created it never states the offer; that half is fixed in parallel in distribute.you. What was missing **here** is that a campaign which ALREADY EXISTS is never adopted afterwards: provisioning finds a live campaign for the triple and moves on, so the row stays unattributed forever and only a hand-run script closes it.

## The fix

`adoptOfferForPairSafely` (`src/lib/campaign-offer-adoption.ts`), called from `ensureFundedFunnelCampaigns` **before every early return there** — a pair whose funnel declaration is empty or unreadable still has a live campaign the customer cannot see. Same reasoning as #377: an invariant a migration can only ever state once is not an invariant, so this lives on the tick, not in a migration or a script.

The rule is the one `scripts/backfill-campaign-offer.ts` already states, and it is **not widened**: a campaign carrying no offer is written the offer of its **(org, brand) pair**, and only where that pair resolves to **exactly one**. Zero, several, or an unreadable answer leaves every campaign of the pair exactly as it is. Nothing is derived from the funnel, the goal or the workflow.

- **Never by brand alone.** A brand row carries one offer per claiming org, so `x-org-id` on `GET /internal/brands/{brandId}/offers` and `org_id` on both statements are load-bearing. Pinned by `tests/unit/no-legacy.test.ts`.
- **Nothing is read unless something is missing.** The pre-check finds the pair's offer-less campaigns; a pair with none is never asked about, on any tick. A pair that is missing one is asked at most once per `OFFER_ADOPTION_RECHECK_MS` (10 min, the same figure and argument as `FUNDING_RECHECK_MS`).
- **Zero or several offers is said out loud, not silent — but only when a LIVE campaign is affected.** A pair whose unattributed rows are all stopped is the permanently-unattributable population; repeating that every ten minutes forever would bury the signal.
- **A stopped row is still written when its own pair genuinely resolves.** Only `offer_id` moves — status, stop reason, funnel, schedule and budget are untouched, and the offer decides no money question. Idempotent (the `offer_id IS NULL` guard is restated in the UPDATE, so a re-run writes nothing and a race with a live create cannot overwrite it) and fail-soft.

## AC

1. `16705a37` reads offer `231bb036` after this ships, with no hand-run script — the pair holds exactly one offer and the campaign is claimed and provisioned every tick.
2. A pair resolving to zero or several offers is left alone, and says so when a live campaign is affected.
3. No campaign is ever attributed to another org's offer: both statements scope on `org_id` and the read names `x-org-id` (integration test seeds two orgs on one brand row).
4. The 145 stopped unattributed rows are untouched unless their own pair genuinely resolves.

## No-gos honoured

No new table, no new column, no accumulator, never by brand alone, not a one-shot migration.

## Tests

`pnpm test` — 52 files green, including 11 new unit tests and 8 new integration tests against a real database (cross-org isolation, multi-brand rows, the brand-array fallback, idempotence, throttle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)