### PR TITLE
feat(channels): a brand that funds Google Ads gets a Google Ads campaign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ legacy `campaign.goal`, which nothing writes any more.
 ## A test that pins FROZEN history against a GROWING constant fails the day the constant grows
 
 `tests/unit/funnel-owner-decision.test.ts` asserted both directions between a shipped migration's
-SQL and `SALES_OUTREACH_FEATURE_SLUGS`: every slug in the SQL is a sales one (true forever) AND
+SQL and `SALES_FUNNEL_FEATURE_SLUGS`: every slug in the SQL is a sales one (true forever) AND
 every sales slug appears in the SQL (true only until the family grows). Adding the second
 acquisition channel failed it, on a migration that is correct and can never mention a feature that
 did not exist when it ran. Assert the direction that stays true — what the frozen file names is
@@ -120,7 +120,7 @@ work ONE funnel through BOTH, and each is a campaign of its own.
 
 - **A CHANNEL IS A FEATURES-SERVICE FEATURE SLUG.** There is no channel table, enum or vocabulary
   in this service and none is to be introduced. Adding a further channel is one line in
-  `SALES_OUTREACH_FEATURE_SLUGS` (`src/lib/sales-outreach-campaign.ts`) plus its
+  `SALES_FUNNEL_FEATURE_SLUGS` (`src/lib/sales-outreach-campaign.ts`) plus its
   `CHANNEL_BY_FEATURE` token — a second offer on the same medium needs its OWN channel token
   (`feedback_request_email`, not `cold_email`), or the two campaigns of one funnel would collide on
   the identity index and only one could exist.
@@ -202,6 +202,52 @@ work ONE funnel through BOTH, and each is a campaign of its own.
 - Everything below — the turn-taking, the fail-closed hold, the per-brand serialization, which
   stopped campaigns funding may resume — is UNCHANGED and applies per campaign, so it applies per
   pair without a special case. (Set 2026-08-18.)
+
+## Google Ads is a channel like any other — PAID REACH joins the funnel-funded family, and only the three behaviours that are genuinely about MAILBOXES stay outbound-only
+
+A channel IS a features-service feature slug, so the first paid-reach channel is one line in the
+family constant plus its `CHANNEL_BY_FEATURE` token, and NOT a second mechanism. Everything already
+true of a provisioned campaign is true of it: it states its (offer, funnel, channel) identity at
+birth, is provisioned one per funded pair off billing's `channels`/`offers` grains, is HELD when the
+customer funds nothing for it, takes its turn on its own fill ratio, is gated and paced on the
+ceiling that binds IT, and refuses a `maxBudget*` of its own.
+
+- **Membership in `SALES_FUNNEL_FEATURE_SLUGS` is a MONEY statement, not a medium one** — "this
+  campaign's ceiling is billing's, per (funnel, channel, offer), read live on every plan." Google
+  Ads answers that identically to a cold email, which is why it is a member and not a family of its
+  own. `isSalesFunnelFeature` is what every gate keyed on that question tests (gate-check's
+  `isSalesFeature`, the `maxBudget*` refusal, the create-time funnel requirement, the turn planner,
+  the funding sweep).
+- **`OUTBOUND_SALES_FEATURE_SLUGS` is the narrower question — "does this share the brand's LEADS and
+  SENDING ACCOUNTS?"** — and exactly three behaviours ask it, because all three are about contacting
+  named people: the per-brand serialization cohort, the greedy workflow rotation (which prices a DAG
+  on send-tagged outcome evidence a paid channel does not produce), and the extend-audience
+  lifecycle email (which asks a customer for more PEOPLE to contact — nonsense for a campaign that
+  buys impressions). A fourth, the legacy per-campaign `daily_budget_cents` MIRROR written by
+  `PATCH /brands/:brandId/daily-budget`, is outbound-scoped for the same reason it exists at all:
+  stamping a brand-level number on a paid-reach row would bind it AHEAD of the offer ceiling it was
+  funded on, i.e. a second representation of one fact.
+- **WHICH funnels it may sell is features-service's statement, asked per feature, never held here.**
+  Google Ads states the three VISIT-led chains: an ad buys a click, and the conversation chain
+  starts with a reply it has no way to sell. A funded pair the channel may not sell gets no
+  campaign, exactly as before, and `tests/unit/no-legacy.test.ts` fails on a feature slug and a
+  funnel key on one line of code outside the client that ASKS.
+- **Only Google Ads.** features-service publishes a dozen paid-reach channels; workflow-service has
+  a dynasty for none of them, and `fetchActiveWorkflowSlugForFeature` fail-CLOSES on that, so
+  nothing would be provisioned even if they were swept in. They are still not swept in: a campaign
+  for a channel nothing can execute would sit ongoing and produce nothing forever. Adding the next
+  one is one line, once something can run it. **At the time of writing workflow-service has no
+  `google-ads` workflow either** — the provisioning says so per sweep and stands the campaign up the
+  moment the dynasty ships, which is the same fail-closed the feedback-request channel shipped under.
+- **Each candidate's spend is read under ITS OWN feature.** The turn planner used to ask
+  runs-service for every candidate's spend under the SEED's slug; the read filters on it, so a
+  campaign of another channel answered ZERO, read as perfectly empty and took every turn. Harmless
+  while a brand's campaigns were all cold email in practice, a live overspend the moment one brand
+  mixes channels.
+- **Nothing is special-cased anywhere else**: no new column, table, vocabulary or accumulator, and
+  no branch in gate-check, campaign-funding, the offer/funnel adoption or the resume sweep.
+
+(Set 2026-08-26.)
 
 ## A sales campaign row states the money that governs it — `maxBudget*` is REFUSED for the family
 
@@ -656,16 +702,27 @@ funnel set), and migration **0048** (the 45 stopped ancestors of the one live ca
 that a brand row is claimed by several orgs — the stopped campaigns other orgs hold on `f4d73dab`
 are other customers' and keep a NULL funnel, and 0048's rule joins on the org for the same reason.
 
-## Brand serialization counts SALES runs only — a brand's PR run is not its sales outreach's business
+## Brand serialization counts the runs of the SAME COHORT — a brand's PR run, and its ad run, are not its cold email's business
 
-`hasLiveSalesRunForBrand` asks runs-service campaign by campaign, over the brand's `ongoing`
-sales-family campaigns. It must NOT be a brand-wide `listRuns({ brandId })`: runs of the brand's PR,
+`hasLiveRunForBrandCohort` asks runs-service campaign by campaign, over the brand's `ongoing`
+sales-family campaigns **of one cohort**. It must NOT be a brand-wide `listRuns({ brandId })`: runs of the brand's PR,
 AI-visibility, hiring and VC campaigns carry the same brand, so a brand whose PR outreach ticks
 continuously (736 completed runs in one morning, one always in flight) reads as permanently busy and
 EVERY sales campaign of that brand is deferred 60s, every tick, forever. That is a full stop, and it
 appears in no log at all because the defer is the routine path. The candidate set is read from the
 DB, not from the campaigns claimed this tick — the one actually running is precisely the one NOT
 claimed (its `nextRunAt` is null while in flight). (Set 2026-08-02.)
+
+**A cohort is what genuinely SHARES something** (`serializationCohort`, funnel-campaigns.ts): the
+three OUTBOUND cold-email channels are one cohort — same lead population, same sending accounts, so
+two of their runs at once would contact the same people from the same mailboxes — and every other
+channel is its own, keyed on the acquisition channel it already states. A paid-reach campaign is
+therefore serial against ITSELF (one live run per external ad account per brand, the same
+conservatism) and against nothing else. Holding a funded Google Ads campaign behind a cold-email run
+would be the identical mistake one level down from the PR one above: a defer that fires every tick,
+for a reason that is not true of it, appearing in no log at all. The TURN is per cohort too, so a
+brand working one funnel by cold email and another by ads fires one of each rather than one in
+total. (Set 2026-08-26.)
 
 The per-campaign audience SUBSET (`campaigns.audience_ids`, Campaign v2) is a HARD filter on the audience bandit (`requiredAudienceIds` in `selectAudienceFromProjection`): a campaign never contacts an audience outside its targeted subset (no fallback). NULL/empty → inherit the brand's full active audience set. (The old workflow-conditioning `eligibleAudienceIds` soft-filter was REMOVED in v0.44.1 — see the single-endpoint note below.) Distinct from the singular `audienceId` column (per-campaign attribution; the per-RUN chosen audience is re-selected fresh at /start-run).
 
@@ -930,7 +987,7 @@ same branch.
   feature — and is `completed` immediately. Nothing per-execution, for two different reasons that
   both end in a silent full stop:
   - No **`campaignId`**: every campaign-scoped read here (gate-check's stale cleanup and lifetime
-    `completed` count, `hasLiveRunForCampaign`, `hasLiveSalesRunForBrand`) filters on it, so
+    `completed` count, `hasLiveRunForCampaign`, `hasLiveRunForBrandCohort`) filters on it, so
     tagging the anchor recreates exactly the orphan run that stopped this service creating runs at
     trigger time in the first place.
   - No **`workflowSlug`**: the workflow is re-picked EVERY run by the greedy bandit, and

--- a/src/lib/campaign-identity.ts
+++ b/src/lib/campaign-identity.ts
@@ -39,6 +39,12 @@ const CHANNEL_BY_FEATURE: Readonly<Record<string, string>> = Object.freeze({
   // token: a brand may work one funnel through both offers at once, and those are two campaigns,
   // so they must hold two identities or the unique index would let only one of them exist.
   "feedback-request-cold-email-outreach": "feedback_request_email",
+  // Paid reach. Bought impressions rather than an outbound message, so it shares no identity with
+  // any cold-email channel and a brand may work one funnel through both at once. Stated
+  // explicitly rather than left to the fallback below: the fallback is total by construction, so
+  // an upstream RENAME of this slug would file the campaign under a channel nothing else uses,
+  // silently, with no error and no failing test.
+  "google-ads": "google_ads",
 
   // Everything else. A sales funnel is not something these run — their funnel stays NULL — but
   // they still carry a channel so the identity key is enforceable for them too.

--- a/src/lib/features-workflow-projection-client.ts
+++ b/src/lib/features-workflow-projection-client.ts
@@ -1,7 +1,7 @@
 import { buildServiceHeaders, type DownstreamIdentity } from "./downstream-headers.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "./brand-runtime-client.js";
 import { thompsonArgminCost, type Arm, type Rng } from "./bandit.js";
-import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
+import { isOutboundSalesFeature } from "./sales-outreach-campaign.js";
 
 // Audience-grain, send-tagged evidence for one (audience × workflow dynasty) couple.
 // Present ONLY on audienceId != null rows whose audience actually spent under this couple
@@ -397,15 +397,18 @@ export function serveableAudienceIdsInProjection(
  * Whether the greedy workflow rotation applies to a given feature. When false, the
  * trigger keeps the campaign's configured workflowSlug (no features-service call).
  *
- * Scoped to the sales-outreach feature family (every acquisition CHANNEL that sells a sales
- * funnel) — those vary their workflow across runs. Every other feature
+ * Scoped to the OUTBOUND cold-email channels — those vary their workflow across runs, and the
+ * projection prices a DAG on the send-tagged outcome evidence only they produce. A paid-reach
+ * channel runs the workflow its campaign states, run after run: there is no second dynasty to
+ * rotate onto and no send evidence to rank one against another. Every other feature
  * always runs its campaign's configured workflowSlug, run after run, with no
  * features-service call and no rotation. (Product decision 2026-07-07: rotation is a
- * sales-outreach lever; extended to sales-crm-email-outreach 2026-07-24 and to every sales
- * channel since — a second channel is a second feature, and it rotates like the first.)
+ * sales-outreach lever; extended to sales-crm-email-outreach 2026-07-24 and to every OUTBOUND
+ * sales channel since — a second cold-email channel is a second feature, and it rotates like the
+ * first.)
  */
 export function isWorkflowRotationEnabled(featureSlug: string): boolean {
-  return isSalesOutreachFeature(featureSlug);
+  return isOutboundSalesFeature(featureSlug);
 }
 
 /**

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -17,7 +17,11 @@ import {
   fetchOfferSalesFunnels,
   type SalesFunnelsRead,
 } from "./brand-sales-funnels-client.js";
-import { isSalesOutreachFeature, SALES_OUTREACH_FEATURE_SLUGS } from "./sales-outreach-campaign.js";
+import {
+  isOutboundSalesFeature,
+  isSalesFunnelFeature,
+  SALES_FUNNEL_FEATURE_SLUGS,
+} from "./sales-outreach-campaign.js";
 import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 import { acquisitionChannelForFeature, campaignIdentityColumns } from "./campaign-identity.js";
 import { fundingFromBudgets } from "./campaign-funding.js";
@@ -135,7 +139,9 @@ export function selectLowestFillRatio(candidates: FunnelTurnCandidate[]): string
  *      the same runs-service liveness read the per-campaign guard already uses, asked of each of
  *      the brand's sales campaigns. It deliberately does NOT count the brand's PR / AI-visibility
  *      / hiring / VC runs — those share neither leads nor sending accounts, and counting them
- *      stopped a brand's sales outreach outright (see hasLiveSalesRunForBrand).
+ *      stopped a brand's sales outreach outright (see hasLiveRunForBrandCohort), and it counts
+ *      only the campaigns of the SAME cohort — a paid-reach run and a cold-email run share
+ *      neither leads nor mailboxes, so neither holds the other.
  *   3. Rank — the funded funnel with the lowest spent/ceiling ratio takes the turn.
  *
  * Turn-taking is fail-SOFT (it only reorders work already allowed); the HOLD is fail-CLOSED, and
@@ -151,7 +157,7 @@ export async function planFunnelTurns(
   // its own per-campaign serialization, untouched.
   const groups = new Map<string, ClaimedFunnelCampaign[]>();
   for (const c of claimed) {
-    if (!isSalesOutreachFeature(c.featureSlug)) continue;
+    if (!isSalesFunnelFeature(c.featureSlug)) continue;
     const brandId = c.brandIds?.[0];
     if (!brandId) continue;
     const key = `${c.orgId}::${brandId}`;
@@ -234,29 +240,76 @@ async function planOneBrand(
   // out because another one covers its funnel: each is ranked on what IT has already spent today
   // against the ceiling that actually binds IT, so nothing starves and nothing overspends.
   const candidates: FunnelTurnCandidate[] = [];
+  const cohortOf = new Map<string, string>();
   for (const c of group) {
     const verdict = fundingFromBudgets(c, budgets);
     if (!verdict.funded) {
       deferred.set(c.id, heldAt);
       continue;
     }
+    cohortOf.set(c.id, serializationCohort(c.featureSlug));
     // A row written before the rename still carries the pre-rename spelling until migration 0043
     // reaches it — and a mixed fleet must rank on one vocabulary or a funnel silently loses its
     // ceiling and never takes a turn.
     candidates.push({
       campaignId: c.id,
       funnelKey: toFunnelKey(c.funnelKey) ?? "",
-      spentCents: await spentTodayCents(orgId, c.id, featureSlug),
+      // The campaign's OWN feature, never the seed's: the spend read filters on it, so asking
+      // runs-service for a Google Ads campaign's spend under the seed's cold-email slug answers
+      // ZERO — the ad campaign then reads as perfectly empty and takes every turn, forever.
+      spentCents: await spentTodayCents(orgId, c.id, c.featureSlug ?? featureSlug),
       ceilingCents: verdict.ceilingCents,
     });
   }
 
   if (candidates.length === 0) return;
 
-  // Serial, for now: at most one SALES run in flight per brand. Running funnels concurrently needs
-  // an audit of lead de-duplication and of sending-account load that nobody has done, so it is
-  // deliberately out of scope — delete this block and the funnels run in parallel.
-  if (await hasLiveSalesRunForBrand(orgId, brandId, now)) {
+  // Serial WITHIN A COHORT, and a cohort is what actually shares something: the outbound
+  // cold-email channels share the brand's lead population and its sending accounts, so two of
+  // their runs at once would contact the same people from the same mailboxes. A paid-reach
+  // channel shares neither with them — it buys impressions — so serializing it behind cold email
+  // would hold a funded Google Ads campaign for a reason that is not true of it, every tick,
+  // showing up in no log at all. That is the same mistake `hasLiveRunForBrandCohort` was written to
+  // undo one level up, where a brand's PR runs were holding its sales outreach.
+  //
+  // Concurrency INSIDE a cohort still needs the lead-de-duplication and sending-account audit
+  // nobody has done, so it stays serial; a paid channel is serial against ITSELF for the same
+  // conservatism (one live run per external ad account per brand).
+  const cohorts = new Map<string, FunnelTurnCandidate[]>();
+  for (const c of candidates) {
+    const key = cohortOf.get(c.campaignId)!;
+    const bucket = cohorts.get(key);
+    if (bucket) bucket.push(c);
+    else cohorts.set(key, [c]);
+  }
+
+  for (const [cohort, members] of cohorts) {
+    await planOneCohort(orgId, brandId, cohort, members, now, deferred);
+  }
+}
+
+/**
+ * The runs that must not overlap this campaign's: the campaigns of the brand it genuinely shares
+ * something with.
+ *
+ * The three outbound cold-email channels are ONE cohort — same leads, same mailboxes, whichever
+ * offer they carry. Every other channel is its own, keyed on the acquisition channel it already
+ * states, so a paid-reach campaign is serial against itself and against nothing else.
+ */
+function serializationCohort(featureSlug: string | null | undefined): string {
+  if (isOutboundSalesFeature(featureSlug)) return "outbound_cold_email";
+  return acquisitionChannelForFeature(featureSlug) ?? "unknown_channel";
+}
+
+async function planOneCohort(
+  orgId: string,
+  brandId: string,
+  cohort: string,
+  candidates: FunnelTurnCandidate[],
+  now: Date,
+  deferred: Map<string, Date>,
+): Promise<void> {
+  if (await hasLiveRunForBrandCohort(orgId, brandId, cohort, now)) {
     for (const c of candidates) {
       deferred.set(c.campaignId, new Date(now.getTime() + FUNNEL_TURN_DEFER_MS));
     }
@@ -701,7 +754,7 @@ export async function provisionFundedPairsForQuietBrands(now: Date = new Date())
   if (now.getTime() - lastFundingSweepAt < FUNDING_SWEEP_INTERVAL_MS) return 0;
   lastFundingSweepAt = now.getTime();
 
-  const slugs = [...SALES_OUTREACH_FEATURE_SLUGS];
+  const slugs = [...SALES_FUNNEL_FEATURE_SLUGS];
 
   // A brand whose sales campaigns are in flight or due within the sweep interval is looked at by
   // the CLAIM path sooner than this sweep would look at it, so it is not examined here at all —
@@ -850,7 +903,7 @@ async function offerStatingCampaigns(
   const rows = await db.query.campaigns.findMany({
     where: and(
       eq(campaigns.orgId, orgId),
-      inArray(campaigns.featureSlug, [...SALES_OUTREACH_FEATURE_SLUGS]),
+      inArray(campaigns.featureSlug, [...SALES_FUNNEL_FEATURE_SLUGS]),
       arrayContains(campaigns.brandIds, [brandId]),
     ),
     columns: { offerId: true },
@@ -865,7 +918,7 @@ async function countOngoingSalesCampaigns(orgId: string, brandId: string): Promi
     where: and(
       eq(campaigns.orgId, orgId),
       eq(campaigns.status, "ongoing"),
-      inArray(campaigns.featureSlug, [...SALES_OUTREACH_FEATURE_SLUGS]),
+      inArray(campaigns.featureSlug, [...SALES_FUNNEL_FEATURE_SLUGS]),
       arrayContains(campaigns.brandIds, [brandId]),
     ),
     columns: { id: true },
@@ -903,7 +956,7 @@ async function spentTodayCents(orgId: string, campaignId: string, featureSlug: s
 const LIVE_RUN_FRESHNESS_MS = 15 * 60_000;
 
 /**
- * Is one of this brand's SALES campaigns running right now?
+ * Is one of this brand's campaigns OF THIS COHORT running right now?
  *
  * Asked campaign by campaign, and that is the whole point: a brand-wide `listRuns({ brandId })`
  * also counts the runs of the brand's PR, AI-visibility, hiring and VC campaigns, which are tagged
@@ -913,14 +966,22 @@ const LIVE_RUN_FRESHNESS_MS = 15 * 60_000;
  * shows up in no log at all because the defer is the routine path. It halted brand
  * f4d73dab-1f9d-49b2-b16e-63ecde76a5eb outright (prod, 2026-08-02).
  *
- * The constraint this serialization exists for is about SALES funnels sharing leads and sending
- * accounts. A PR pitch shares neither, so it was never meant to hold a sales funnel back.
+ * The constraint this serialization exists for is about channels sharing LEADS and SENDING
+ * ACCOUNTS. A PR pitch shares neither, so it was never meant to hold a sales funnel back — and
+ * neither is a paid-reach campaign, which buys impressions and touches no mailbox. So the question
+ * is asked per cohort (see serializationCohort), not per family: counting a cold-email run against
+ * a Google Ads campaign would be the same mistake one level down.
  *
  * The candidate set is read from the DB rather than from the campaigns claimed this tick: the one
  * that is actually running is precisely the one NOT claimed (its nextRunAt is null while in
  * flight), so a group-scoped check would be blind to it.
  */
-async function hasLiveSalesRunForBrand(orgId: string, brandId: string, now: Date): Promise<boolean> {
+async function hasLiveRunForBrandCohort(
+  orgId: string,
+  brandId: string,
+  cohort: string,
+  now: Date,
+): Promise<boolean> {
   const alive = await db.query.campaigns.findMany({
     where: and(
       eq(campaigns.orgId, orgId),
@@ -932,7 +993,8 @@ async function hasLiveSalesRunForBrand(orgId: string, brandId: string, now: Date
 
   const startedAfter = new Date(now.getTime() - LIVE_RUN_FRESHNESS_MS).toISOString();
   for (const c of alive) {
-    if (!isSalesOutreachFeature(c.featureSlug)) continue;
+    if (!isSalesFunnelFeature(c.featureSlug)) continue;
+    if (serializationCohort(c.featureSlug) !== cohort) continue;
     const { runs } = await listRuns({
       orgId,
       campaignId: c.id,

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -2,7 +2,7 @@ import { listRuns, updateRun, getStatsBudget, type Run, type BudgetWindow, type 
 import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { eq } from "drizzle-orm";
-import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
+import { isSalesFunnelFeature } from "./sales-outreach-campaign.js";
 import { channelCeilingCents, fetchFunnelBudgets, offerCeilingCents } from "./funnel-budget-client.js";
 import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 import { STOP_REASONS } from "./stop-reason.js";
@@ -20,7 +20,7 @@ const RUNNING_RUNS_LIMIT = 200;
 // The sales-outreach feature family (every acquisition channel that sells a sales funnel) is
 // paced by the brand daily budget (billing-service brand_daily_budgets) and held on brand pause.
 // Every other feature is paced by the campaign's own budget windows and runs through a pause.
-// See isSalesOutreachFeature (sales-outreach-campaign.ts) for membership.
+// See isSalesFunnelFeature (sales-outreach-campaign.ts) for membership.
 
 export interface GateCheckInput {
   campaignId: string;
@@ -119,7 +119,7 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   // paced by the brand daily budget (block 3c below) instead. For non-sales campaigns the
   // campaign's own configured caps govern at their cadence: daily (today's spend, resets at day
   // rollover), weekly, monthly, and total (one-off — auto-stops the campaign when hit).
-  const isSalesFeature = isSalesOutreachFeature(campaign.featureSlug);
+  const isSalesFeature = isSalesFunnelFeature(campaign.featureSlug);
 
   if (!isSalesFeature) {
     const budgetLimits: Array<{ limit: string; label: string; autoStop: boolean; nextRunAt?: Date }> = [];

--- a/src/lib/sales-outreach-campaign.ts
+++ b/src/lib/sales-outreach-campaign.ts
@@ -12,19 +12,66 @@ export const SALES_CRM_FEATURE_SLUG = "sales-crm-email-outreach";
  */
 export const SALES_FEEDBACK_REQUEST_FEATURE_SLUG = "feedback-request-cold-email-outreach";
 
-// The sales-outreach feature family. Every feature here shares the SAME runtime behaviour in this
-// service — the funding hold, per-pair pacing, greedy workflow rotation + Thompson audience
-// selection, brand serialization, and the extend-audience lifecycle email. Any per-feature gate
-// keyed on "is this a sales-outreach campaign?" MUST test membership here, not a single slug, so
-// the features stay byte-identical. (Adding a further sales channel = one line here.)
-export const SALES_OUTREACH_FEATURE_SLUGS: ReadonlySet<string> = new Set([
+/**
+ * The first PAID-REACH channel: bought impressions rather than an outbound message.
+ *
+ * A channel is still a feature slug, so this is one line and no new vocabulary — google-service
+ * wraps the Google Ads API and declares the spend an org's campaigns incur as that org's cost,
+ * features-service publishes the channel and states which funnels it may be sold through (the
+ * visit-led chains: an ad buys a click, and there is no reply in it to sell a conversation with),
+ * and billing states its per-(funnel, channel, offer) ceiling like any other. What was missing was
+ * the one thing that makes a funded channel happen at all: a campaign, provisioned and scheduled.
+ *
+ * Only THIS channel of the published paid-reach catalogue is here. The rest (meta-ads,
+ * linkedin-ads, …) are published but nothing can execute them yet, and a campaign for a channel
+ * with no workflow behind it would sit ongoing and produce nothing forever.
+ */
+export const GOOGLE_ADS_FEATURE_SLUG = "google-ads";
+
+/**
+ * The OUTBOUND cold-email channels — the three that reach a named person one at a time.
+ *
+ * They share what a paid-reach channel shares with nothing: the same lead population, the same
+ * sending accounts, the same "everybody in this audience has now been contacted" ending. So three
+ * behaviours are theirs alone and are keyed on THIS set rather than on the funnel-funded family:
+ * the per-brand serialization (one outbound run in flight per brand, because two of them would
+ * contact the same people from the same mailboxes), the greedy workflow rotation (which prices a
+ * DAG on send-tagged outcome evidence these channels produce), and the extend-audience lifecycle
+ * email (which asks a customer for more PEOPLE to contact).
+ */
+export const OUTBOUND_SALES_FEATURE_SLUGS: ReadonlySet<string> = new Set([
   SALES_OUTREACH_FEATURE_SLUG,
   SALES_CRM_FEATURE_SLUG,
   SALES_FEEDBACK_REQUEST_FEATURE_SLUG,
 ]);
 
-export function isSalesOutreachFeature(slug?: string | null): boolean {
-  return !!slug && SALES_OUTREACH_FEATURE_SLUGS.has(slug);
+export function isOutboundSalesFeature(slug?: string | null): boolean {
+  return !!slug && OUTBOUND_SALES_FEATURE_SLUGS.has(slug);
+}
+
+/**
+ * THE FUNNEL-FUNDED FAMILY: every acquisition channel that SELLS A SALES FUNNEL.
+ *
+ * Membership means one thing and it is a MONEY statement, not a medium one: this campaign's
+ * ceiling is billing's, stated per (sales funnel, acquisition channel, offer) and read live on
+ * every plan — so the campaign states its funnel at birth, is provisioned one per funded pair,
+ * is held when the customer funds nothing for it, takes its turn on its own fill ratio, and
+ * carries no per-campaign budget column of its own.
+ *
+ * A paid-reach channel answers all of that identically to a cold-email one, which is why Google
+ * Ads is a member and not a family of its own. Where it genuinely differs — it shares no leads
+ * and no mailboxes with an outbound channel — the narrower OUTBOUND set above is what is asked.
+ *
+ * Adding a further channel is one line here (plus its CHANNEL_BY_FEATURE token), once something
+ * can execute it.
+ */
+export const SALES_FUNNEL_FEATURE_SLUGS: ReadonlySet<string> = new Set([
+  ...OUTBOUND_SALES_FEATURE_SLUGS,
+  GOOGLE_ADS_FEATURE_SLUG,
+]);
+
+export function isSalesFunnelFeature(slug?: string | null): boolean {
+  return !!slug && SALES_FUNNEL_FEATURE_SLUGS.has(slug);
 }
 
 // The four per-campaign budget-window columns. gate-check enforces them for every OTHER feature
@@ -51,7 +98,7 @@ export function salesMaxBudgetRefusal(
   featureSlug: string | null | undefined,
   body: Record<string, unknown>,
 ): string | null {
-  if (!isSalesOutreachFeature(featureSlug)) return null;
+  if (!isSalesFunnelFeature(featureSlug)) return null;
   const stated = MAX_BUDGET_FIELDS.filter((field) => body?.[field] !== undefined);
   if (stated.length === 0) return null;
   return (

--- a/src/lib/transactional-email.ts
+++ b/src/lib/transactional-email.ts
@@ -7,7 +7,7 @@
 // EVERYTHING here is fire-and-forget: it must NEVER block, delay, or fail the outreach
 // loop / run finalization. Every path swallows its error (logged, not thrown).
 import type { Campaign } from "../db/schema.js";
-import { isSalesOutreachFeature } from "./sales-outreach-campaign.js";
+import { isOutboundSalesFeature } from "./sales-outreach-campaign.js";
 import { hasExhaustedAudience } from "./audience-exhaustion.js";
 import { fetchBrandRuntimeContext } from "./brand-runtime-client.js";
 
@@ -263,7 +263,10 @@ async function sendExtendAudienceEmail(campaign: Campaign, userId: string, runId
  */
 export async function maybeSendExtendAudienceEmail(campaign: Campaign, opts: { runId: string }): Promise<void> {
   try {
-    if (!isSalesOutreachFeature(campaign.featureSlug)) return;
+    // OUTBOUND only. This email asks the customer for more PEOPLE to contact, which is a request
+    // that means nothing to a paid-reach campaign: it buys impressions, it does not work its way
+    // through a list of names, and it has no audience to extend.
+    if (!isOutboundSalesFeature(campaign.featureSlug)) return;
 
     const userId = campaign.createdByUserId;
     if (!userId) return;

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -8,12 +8,17 @@ import { validateBody } from "../middleware/validate.js";
 import { SetBrandCampaignsDailyBudgetBody } from "../schemas.js";
 import { fetchFunnelBudgets } from "../lib/funnel-budget-client.js";
 import { brandHeldFromBudgets } from "../lib/campaign-funding.js";
-import { SALES_OUTREACH_FEATURE_SLUGS } from "../lib/sales-outreach-campaign.js";
+import { OUTBOUND_SALES_FEATURE_SLUGS } from "../lib/sales-outreach-campaign.js";
 
-// The daily budget is a sales-outreach pacing lever (the ONLY feature family the sales gate
-// enforces it for), so the brand-page propagation targets that family's campaigns
-// (every acquisition channel that sells a sales funnel).
-const SALES_FEATURE_SLUGS = [...SALES_OUTREACH_FEATURE_SLUGS];
+// The per-campaign `daily_budget_cents` MIRROR — the legacy brand-page lever, which gate-check
+// still prefers over every billing ceiling when it is set. Scoped to the OUTBOUND cold-email
+// channels, i.e. exactly the campaigns that carry it today.
+//
+// A paid-reach campaign is deliberately NOT stamped: its ceiling is billing's, stated per (funnel,
+// channel, offer) and read live on every plan, and writing a brand-level number onto its row would
+// bind it AHEAD of the offer ceiling it was funded on — a second representation of one fact, which
+// is the thing this service keeps deleting.
+const SALES_FEATURE_SLUGS = [...OUTBOUND_SALES_FEATURE_SLUGS];
 
 const router = Router();
 
@@ -67,8 +72,8 @@ router.get("/brands/:brandId/pause", requireApiKey, serviceAuth, async (req: Aut
  * on the brand page, that number must flow down to the brand's campaign(s) so per-campaign
  * pacing enforces it immediately. Org-scoped (only this org's campaigns for the brand are
  * touched). dailyBudgetCents:null clears each campaign's own budget → they fall back to the
- * brand daily budget again. Scoped to the sales-outreach feature family
- * (every acquisition channel that sells a sales funnel) — the only features the daily budget paces.
+ * brand daily budget again. Scoped to the OUTBOUND cold-email channels — see SALES_FEATURE_SLUGS
+ * for why a paid-reach campaign is left to the live billing ceiling instead.
  */
 router.patch("/brands/:brandId/daily-budget", requireApiKey, serviceAuth, validateBody(SetBrandCampaignsDailyBudgetBody), async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -11,7 +11,7 @@ import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { campaignIdentityColumns } from "../lib/campaign-identity.js";
 import { STOP_REASONS } from "../lib/stop-reason.js";
-import { isSalesOutreachFeature, salesMaxBudgetRefusal } from "../lib/sales-outreach-campaign.js";
+import { isSalesFunnelFeature, salesMaxBudgetRefusal } from "../lib/sales-outreach-campaign.js";
 import { acceptedFunnelKeys, toFunnelKey } from "../lib/sales-funnel-vocabulary.js";
 
 const router = Router();
@@ -148,10 +148,10 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     // the brand's declared set, not ever. A sales campaign with no funnel is what left a customer
     // funding a funnel and never getting a campaign for it, so this is a hard 400 rather than a
     // row nobody can attribute. Every other feature sells through no sales funnel and states none.
-    const funnelKey = isSalesOutreachFeature(resolvedFeatureSlug)
+    const funnelKey = isSalesFunnelFeature(resolvedFeatureSlug)
       ? toFunnelKey(bodyFunnelKey)
       : null;
-    if (isSalesOutreachFeature(resolvedFeatureSlug) && !funnelKey) {
+    if (isSalesFunnelFeature(resolvedFeatureSlug) && !funnelKey) {
       return res.status(400).json({
         error: bodyFunnelKey
           ? `Unknown sales funnel "${bodyFunnelKey}" — expected one of: ${acceptedFunnelKeys().join(", ")}`
@@ -357,7 +357,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     // Two creates raced the same identity. The loser does not get a second campaign for it — the
     // one that won IS this identity's campaign, so hand that one back rather than an error.
     if (error?.code === "23505" && constraint === "uniq_campaigns_org_brand_funnel_channel") {
-      const racedFunnelKey = isSalesOutreachFeature(req.featureSlug)
+      const racedFunnelKey = isSalesFunnelFeature(req.featureSlug)
         ? toFunnelKey(req.body.funnelKey)
         : null;
       const winner = await db.query.campaigns.findFirst({

--- a/tests/unit/bandit.test.ts
+++ b/tests/unit/bandit.test.ts
@@ -208,6 +208,13 @@ describe("isWorkflowRotationEnabled", () => {
     expect(isWorkflowRotationEnabled("sales-crm-email-outreach")).toBe(true);
   });
 
+  it("disables rotation for a PAID-REACH channel — there is no send evidence to rank a DAG on", () => {
+    // The projection prices a workflow on send-tagged outcome evidence only an outbound channel
+    // produces. A Google Ads campaign runs the workflow its campaign states, run after run, and
+    // makes no features-service call at all.
+    expect(isWorkflowRotationEnabled("google-ads")).toBe(false);
+  });
+
   it("disables rotation for pr-expert features", () => {
     expect(isWorkflowRotationEnabled("pr-expert-quote-outreach")).toBe(false);
     expect(isWorkflowRotationEnabled("pr-expert-quote-opportunities")).toBe(false);

--- a/tests/unit/campaign-identity.test.ts
+++ b/tests/unit/campaign-identity.test.ts
@@ -8,6 +8,11 @@ describe("acquisitionChannelForFeature", () => {
   it("names the medium for the features that state a sales funnel", () => {
     expect(acquisitionChannelForFeature("sales-cold-email-outreach")).toBe("cold_email");
     expect(acquisitionChannelForFeature("sales-crm-email-outreach")).toBe("crm_email");
+    expect(acquisitionChannelForFeature("feedback-request-cold-email-outreach")).toBe("feedback_request_email");
+    // Paid reach. Stated explicitly rather than left to the slug fallback: the fallback is total by
+    // construction, so an upstream RENAME would file the campaign under a channel nothing else
+    // uses — silently, with no error and no failing test.
+    expect(acquisitionChannelForFeature("google-ads")).toBe("google_ads");
   });
 
   it("never folds two different products onto one channel", () => {
@@ -20,6 +25,8 @@ describe("acquisitionChannelForFeature", () => {
       "hiring-cold-email-outreach",
       "vc-cold-email-outreach",
       "sales-crm-email-outreach",
+      "feedback-request-cold-email-outreach",
+      "google-ads",
       "pr-expert-quote-outreach",
       "pr-expert-quote-opportunities",
       "ai-visibility-scoring",

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -88,6 +88,7 @@ import {
 
 const SALES = "sales-cold-email-outreach";
 const FEEDBACK = "feedback-request-cold-email-outreach";
+const GOOGLE_ADS = "google-ads";
 const ANCESTOR_RUN_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -929,5 +930,197 @@ describe("planFunnelTurns", () => {
 
     expect(deferred.has("c-reply")).toBe(false);
     expect(deferred.get("c-visit")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
+  });
+  // ── Google Ads: the first PAID-REACH channel ──────────────────────────────────────────────────
+  // A channel is a feature slug, so nothing here is special-cased: the funded pair is provisioned,
+  // scheduled and paced by the same rules. What IS different is what it shares with a cold-email
+  // campaign — no leads, no mailboxes — so neither holds the other back.
+
+  it("gives a funded (funnel, google-ads) pair its own campaign, on that channel's own workflow", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "visit_signup", featureSlug: GOOGLE_ADS, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
+    mockFindFirst.mockResolvedValue(undefined); // the pair has no campaign yet
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(1);
+    const inserted = mockInsertValues.mock.calls[0][0];
+    expect(inserted.featureSlug).toBe(GOOGLE_ADS);
+    expect(inserted.funnelKey).toBe("website_purchases");
+    // The identity is (org, brand, funnel, CHANNEL) — a paid-reach campaign holds its own, so a
+    // brand may work one funnel through an ad and a cold email at the same time.
+    expect(inserted.acquisitionChannel).toBe("google_ads");
+    // A workflow belongs to a FEATURE: the seed's cold-email slug would run the wrong DAG.
+    expect(inserted.workflowSlug).toBe("google-ads-seed");
+    expect(inserted.status).toBe("ongoing");
+    // No per-campaign ceiling is ever written for this family: the money is billing's, read live.
+    expect(inserted.dailyBudgetCents).toBeUndefined();
+  });
+
+  it("provisions NO Google Ads campaign for a funnel that channel cannot sell", async () => {
+    // An ad buys a click. The conversation chain starts with a reply it has no way to sell, and
+    // features-service states that per channel rather than leaving it to be inferred here.
+    mockFetch.mockImplementation(async (input: URL | string) => {
+      const url = String(input);
+      if (url.includes("/features/")) {
+        const slug = new URL(url).pathname.split("/features/")[1];
+        return {
+          ok: true,
+          json: async () => ({
+            feature: {
+              slug,
+              salesFunnels: slug === GOOGLE_ADS
+                ? ["website_purchases", "sales_meetings_from_website", "form_magnet"]
+                : [...SALES_FUNNEL_KEYS],
+            },
+          }),
+        };
+      }
+      if (url.includes("/workflows")) {
+        return {
+          ok: true,
+          json: async () => ({
+            workflows: [{ workflowSlug: `${new URL(url).searchParams.get("featureSlug")}-seed`, createdAt: "2026-08-18T00:00:00.000Z" }],
+          }),
+        };
+      }
+      throw new Error(`unexpected fetch in test: ${url}`);
+    });
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: GOOGLE_ADS, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("a live cold-email run does NOT hold a funded Google Ads campaign, and neither holds the other", async () => {
+    // Serialization exists because two outbound runs would contact the same people from the same
+    // mailboxes. An ad shares neither, so counting a cold-email run against it would hold a funded
+    // channel every tick for a reason that is not true of it — and say so in no log at all.
+    mockFunnelBudgets(
+      [
+        { funnelKey: "reply_meeting", dailyBudgetCents: "2000" },
+        { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      ],
+      "3000",
+      [
+        { funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "2000" },
+        { funnelKey: "visit_signup", featureSlug: GOOGLE_ADS, dailyBudgetCents: "1000" },
+      ],
+    );
+    mockDeclaredFunnels([
+      { funnelKey: "sales_meetings_from_conversation" },
+      { funnelKey: "website_purchases" },
+    ]);
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "x", status: "ongoing", stopReason: null });
+    mockSpend("0"); // c-sales
+    mockSpend("0"); // c-ads
+
+    aliveBrandCampaigns = [
+      { id: "c-sales", featureSlug: SALES },
+      { id: "c-ads", featureSlug: GOOGLE_ADS },
+    ];
+    mockListRuns.mockImplementation(async ({ campaignId }: { campaignId?: string }) =>
+      campaignId === "c-sales" ? { runs: [{ id: "live-cold-email" }] } : { runs: [] },
+    );
+
+    const now = new Date("2026-08-26T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-sales", funnelKey: "sales_meetings_from_conversation", featureSlug: SALES }),
+        claimed({ id: "c-ads", funnelKey: "website_purchases", featureSlug: GOOGLE_ADS }),
+      ],
+      now,
+    );
+
+    expect(deferred.has("c-ads")).toBe(false); // takes its turn while cold email is mid-run
+    expect(deferred.get("c-sales")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
+  });
+
+  it("asks each campaign's spend under its OWN feature — the seed's slug would answer zero", async () => {
+    // The spend read filters on featureSlug. Asking for the ad campaign's spend under the seed's
+    // cold-email slug answers ZERO, so a campaign at its ceiling would read as perfectly empty and
+    // take every turn — overspending its own ceiling with nothing in any log.
+    mockFunnelBudgets(
+      [
+        { funnelKey: "reply_meeting", dailyBudgetCents: "2000" },
+        { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+      ],
+      "3000",
+      [
+        { funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "2000" },
+        { funnelKey: "visit_signup", featureSlug: GOOGLE_ADS, dailyBudgetCents: "1000" },
+      ],
+    );
+    mockDeclaredFunnels([
+      { funnelKey: "sales_meetings_from_conversation" },
+      { funnelKey: "website_purchases" },
+    ]);
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "x", status: "ongoing", stopReason: null });
+    mockSpend("0");
+    mockSpend("0");
+
+    aliveBrandCampaigns = [
+      { id: "c-sales", featureSlug: SALES },
+      { id: "c-ads", featureSlug: GOOGLE_ADS },
+    ];
+    await planFunnelTurns(
+      [
+        claimed({ id: "c-sales", funnelKey: "sales_meetings_from_conversation", featureSlug: SALES }),
+        claimed({ id: "c-ads", funnelKey: "website_purchases", featureSlug: GOOGLE_ADS }),
+      ],
+      new Date("2026-08-26T10:00:00Z"),
+    );
+
+    expect(mockGetStatsBudget).toHaveBeenCalledWith(
+      expect.objectContaining({ campaignId: "c-ads", featureSlug: GOOGLE_ADS }),
+    );
+    expect(mockGetStatsBudget).toHaveBeenCalledWith(
+      expect.objectContaining({ campaignId: "c-sales", featureSlug: SALES }),
+    );
+  });
+
+  it("two funded Google Ads funnels of one brand still take turns — one live run per ad account", async () => {
+    mockFunnelBudgets(
+      [
+        { funnelKey: "visit_signup", dailyBudgetCents: "1000" },
+        { funnelKey: "visit_form", dailyBudgetCents: "1000" },
+      ],
+      "2000",
+      [
+        { funnelKey: "visit_signup", featureSlug: GOOGLE_ADS, dailyBudgetCents: "1000" },
+        { funnelKey: "visit_form", featureSlug: GOOGLE_ADS, dailyBudgetCents: "1000" },
+      ],
+    );
+    mockDeclaredFunnels([{ funnelKey: "website_purchases" }, { funnelKey: "form_magnet" }]);
+    mockFindFirst.mockResolvedValue({ id: "existing", name: "x", status: "ongoing", stopReason: null });
+    mockSpend("900"); // c-purchases: 90% full
+    mockSpend("100"); // c-form: 10% full
+
+    aliveBrandCampaigns = [
+      { id: "c-purchases", featureSlug: GOOGLE_ADS },
+      { id: "c-form", featureSlug: GOOGLE_ADS },
+    ];
+    const now = new Date("2026-08-26T10:00:00Z");
+    const deferred = await planFunnelTurns(
+      [
+        claimed({ id: "c-purchases", funnelKey: "website_purchases", featureSlug: GOOGLE_ADS }),
+        claimed({ id: "c-form", funnelKey: "form_magnet", featureSlug: GOOGLE_ADS }),
+      ],
+      now,
+    );
+
+    expect(deferred.has("c-form")).toBe(false); // the emptiest relative to its own ceiling
+    expect(deferred.get("c-purchases")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
   });
 });

--- a/tests/unit/funnel-owner-decision.test.ts
+++ b/tests/unit/funnel-owner-decision.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { SALES_FUNNEL_KEYS } from "../../src/lib/sales-funnel-vocabulary.js";
-import { SALES_OUTREACH_FEATURE_SLUGS } from "../../src/lib/sales-outreach-campaign.js";
+import { SALES_FUNNEL_FEATURE_SLUGS } from "../../src/lib/sales-outreach-campaign.js";
 
 const TAG = "0045_owner_funnel_decision_f4d73dab";
 const SQL = readFileSync(join(process.cwd(), "drizzle", `${TAG}.sql`), "utf8");
@@ -34,7 +34,7 @@ describe("the funnel of a brand that sells through several is UNKNOWN until its 
     const quotedFeatureSlugs = STATEMENTS.match(/'[a-z]+(?:-[a-z]+)+'/g) ?? [];
     expect(quotedFeatureSlugs.length).toBeGreaterThan(0);
     for (const quoted of quotedFeatureSlugs) {
-      expect(SALES_OUTREACH_FEATURE_SLUGS.has(quoted.slice(1, -1))).toBe(true);
+      expect(SALES_FUNNEL_FEATURE_SLUGS.has(quoted.slice(1, -1))).toBe(true);
     }
   });
 

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -781,6 +781,59 @@ describe("Gate Check", () => {
       expect(result.reason).toBe("Funnel not funded for this channel");
     });
 
+    it("paces a Google Ads campaign on its own (funnel, channel) ceiling, like any other channel", async () => {
+      // A paid-reach campaign is in the funnel-funded family for exactly one reason: its money is
+      // billing's, per (funnel, channel, offer). So the same gate, the same precedence, the same
+      // fail-CLOSED — nothing about the medium reaches this block.
+      mockFunnelBudgets(
+        [{ funnelKey: "visit_signup", dailyBudgetCents: "3000" }],
+        "3000",
+        [
+          { funnelKey: "visit_signup", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: "2000" },
+          { funnelKey: "visit_signup", featureSlug: "google-ads", dailyBudgetCents: "1000" },
+        ],
+      );
+      mockGetStatsBudget.mockResolvedValue(
+        // Under the funnel TOTAL and under cold email's share, but AT the ad channel's own $10.
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "1000" }]),
+      );
+
+      const result = await runGateChecks(
+        makeCampaign({
+          brandIds: ["brand-1"],
+          funnelKey: "website_purchases",
+          featureSlug: "google-ads",
+        }),
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("Funnel daily budget reached");
+    });
+
+    it("never paces a Google Ads campaign on a per-campaign budget column", async () => {
+      // The whole campaign-budget-windows block runs under `if (!isSalesFeature)`. A legacy row
+      // carrying a dollar ceiling must not suddenly start binding a paid-reach campaign — its
+      // money is billing's, read live, and creation refuses a new one outright.
+      mockFunnelBudgets(
+        [{ funnelKey: "visit_signup", dailyBudgetCents: "3000" }],
+        "3000",
+        [{ funnelKey: "visit_signup", featureSlug: "google-ads", dailyBudgetCents: "3000" }],
+      );
+      mockGetStatsBudget.mockResolvedValue(
+        makeBudgetResponse([{ label: "today", totalCostInUsdCents: "500" }]),
+      );
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ affordable: true }) });
+
+      const result = await runGateChecks(
+        makeCampaign({
+          brandIds: ["brand-1"],
+          funnelKey: "website_purchases",
+          featureSlug: "google-ads",
+          maxBudgetDailyUsd: "1.00", // $1, long since exceeded by the $5 spent — and inert
+        }),
+      );
+      expect(result.allowed).toBe(true);
+    });
+
     it("a funnel funded through exactly ONE channel binds whatever feature the campaign states", async () => {
       // billing attributed some brands' single ceiling to the default channel while their campaign
       // runs another sales feature. Blocking those would break a brand that has funded one channel

--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -458,7 +458,9 @@ describe('No Legacy Patterns - CRITICAL', () => {
     // A channel IS a feature slug, and which funnels a feature may be SOLD THROUGH is
     // features-service's product statement — asked per feature, never copied here. A second copy
     // drifts the day a channel gains or loses a chain, and the customer's money is on the outcome.
-    // The one file allowed to name a funnel beside a feature slug is the one that ASKS.
+    // The one file allowed to name a funnel beside a feature slug is the one that ASKS. Every
+    // channel is covered, paid reach included — Google Ads sells the visit-led chains and not the
+    // conversation one, and that is features-service's sentence to say, not ours to copy.
     const files = getAllTsFiles(srcDir);
     const violations: { file: string; line: number; code: string }[] = [];
 
@@ -469,7 +471,7 @@ describe('No Legacy Patterns - CRITICAL', () => {
       content.split('\n').forEach((line, index) => {
         const code = line.replace(/\/\/.*$/, '').replace(/^\s*\*.*$/, '');
         // A feature slug and a funnel key on the same line of CODE is a matrix being written down.
-        if (/["'][a-z-]*sales-[a-z-]+["']/.test(code)
+        if (/["'](google-ads|[a-z-]*sales-[a-z-]+|feedback-request-[a-z-]+)["']/.test(code)
           && /["'](sales_meetings_from_\w+|website_purchases|form_magnet|reply_meeting|visit_\w+)["']/.test(code)) {
           violations.push({ file: relative, line: index + 1, code: line.trim().substring(0, 100) });
         }

--- a/tests/unit/sales-outreach-campaign.test.ts
+++ b/tests/unit/sales-outreach-campaign.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  isSalesOutreachFeature,
+  GOOGLE_ADS_FEATURE_SLUG,
+  isOutboundSalesFeature,
+  isSalesFunnelFeature,
   MAX_BUDGET_FIELDS,
   salesMaxBudgetRefusal,
   SALES_CRM_FEATURE_SLUG,
+  SALES_FEEDBACK_REQUEST_FEATURE_SLUG,
   SALES_OUTREACH_FEATURE_SLUG,
-  SALES_OUTREACH_WORKFLOW_SLUG,
 } from "../../src/lib/sales-outreach-campaign.js";
 import type { Campaign } from "../../src/db/schema.js";
 
@@ -17,7 +19,7 @@ function campaign(overrides: Partial<Campaign> = {}): Campaign {
     createdByUserId: "user-1",
     parentRunId: null,
     name: "Sales",
-    workflowSlug: SALES_OUTREACH_WORKFLOW_SLUG,
+    workflowSlug: "sales-email-cold-outreach",
     brandIds: ["brand-1"],
     featureSlug: SALES_OUTREACH_FEATURE_SLUG,
     featureInputs: null,
@@ -54,20 +56,50 @@ function mutation(returned: Campaign[]) {
   };
 }
 
-describe("isSalesOutreachFeature", () => {
+describe("isSalesFunnelFeature", () => {
+  it("includes every acquisition channel that sells a sales funnel — paid reach included", () => {
+    // Membership is a MONEY statement, not a medium one: this campaign's ceiling is billing's,
+    // per (funnel, channel, offer). Google Ads answers that identically to a cold email.
+    expect(isSalesFunnelFeature(GOOGLE_ADS_FEATURE_SLUG)).toBe(true);
+    expect(isSalesFunnelFeature("google-ads")).toBe(true);
+  });
+
+  it("does NOT sweep in the rest of the published paid-reach catalogue", () => {
+    // Published by features-service, executable by nothing — a campaign for one would sit ongoing
+    // and produce nothing forever.
+    for (const slug of ["meta-ads", "linkedin-ads", "tiktok-ads", "bing-ads", "cold-call-outreach"]) {
+      expect(isSalesFunnelFeature(slug)).toBe(false);
+    }
+  });
+
   it("includes both cold and CRM sales-outreach features (full parity)", () => {
-    expect(isSalesOutreachFeature(SALES_OUTREACH_FEATURE_SLUG)).toBe(true);
-    expect(isSalesOutreachFeature(SALES_CRM_FEATURE_SLUG)).toBe(true);
-    expect(isSalesOutreachFeature("sales-cold-email-outreach")).toBe(true);
-    expect(isSalesOutreachFeature("sales-crm-email-outreach")).toBe(true);
+    expect(isSalesFunnelFeature(SALES_OUTREACH_FEATURE_SLUG)).toBe(true);
+    expect(isSalesFunnelFeature(SALES_CRM_FEATURE_SLUG)).toBe(true);
+    expect(isSalesFunnelFeature("sales-cold-email-outreach")).toBe(true);
+    expect(isSalesFunnelFeature("sales-crm-email-outreach")).toBe(true);
   });
 
   it("excludes non-sales features and empty/nullish slugs", () => {
-    expect(isSalesOutreachFeature("pr-expert-quote-outreach")).toBe(false);
-    expect(isSalesOutreachFeature("hiring-cold-email-outreach")).toBe(false);
-    expect(isSalesOutreachFeature("")).toBe(false);
-    expect(isSalesOutreachFeature(null)).toBe(false);
-    expect(isSalesOutreachFeature(undefined)).toBe(false);
+    expect(isSalesFunnelFeature("pr-expert-quote-outreach")).toBe(false);
+    expect(isSalesFunnelFeature("hiring-cold-email-outreach")).toBe(false);
+    expect(isSalesFunnelFeature("")).toBe(false);
+    expect(isSalesFunnelFeature(null)).toBe(false);
+    expect(isSalesFunnelFeature(undefined)).toBe(false);
+  });
+});
+
+describe("isOutboundSalesFeature", () => {
+  it("is the cold-email subset — the channels that share leads and sending accounts", () => {
+    expect(isOutboundSalesFeature(SALES_OUTREACH_FEATURE_SLUG)).toBe(true);
+    expect(isOutboundSalesFeature(SALES_CRM_FEATURE_SLUG)).toBe(true);
+    expect(isOutboundSalesFeature(SALES_FEEDBACK_REQUEST_FEATURE_SLUG)).toBe(true);
+  });
+
+  it("EXCLUDES paid reach — an ad shares no lead population and no mailbox", () => {
+    // Three behaviours key on this and must not reach a Google Ads campaign: the per-brand
+    // serialization, the greedy workflow rotation, and the extend-audience lifecycle email.
+    expect(isOutboundSalesFeature(GOOGLE_ADS_FEATURE_SLUG)).toBe(false);
+    expect(isOutboundSalesFeature(null)).toBe(false);
   });
 });
 
@@ -76,7 +108,7 @@ describe("salesMaxBudgetRefusal", () => {
   const NON_SALES = "pr-expert-quote-outreach";
 
   it("refuses each per-campaign budget window on a sales-family campaign, naming where the ceiling belongs", () => {
-    for (const slug of [SALES, "sales-crm-email-outreach", "feedback-request-cold-email-outreach"]) {
+    for (const slug of [SALES, "sales-crm-email-outreach", "feedback-request-cold-email-outreach", "google-ads"]) {
       for (const field of MAX_BUDGET_FIELDS) {
         const message = salesMaxBudgetRefusal(slug, { [field]: "10.00" });
         expect(message).toContain(field);

--- a/tests/unit/transactional-email.test.ts
+++ b/tests/unit/transactional-email.test.ts
@@ -3,7 +3,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("../../src/lib/sales-outreach-campaign.js", () => ({
   SALES_OUTREACH_FEATURE_SLUG: "sales-cold-email-outreach",
   SALES_CRM_FEATURE_SLUG: "sales-crm-email-outreach",
-  isSalesOutreachFeature: (s?: string | null) =>
+  isSalesFunnelFeature: (s?: string | null) =>
+    s === "sales-cold-email-outreach" || s === "sales-crm-email-outreach" || s === "google-ads",
+  // OUTBOUND only: this email asks for more PEOPLE to contact, which means nothing to a channel
+  // that buys impressions.
+  isOutboundSalesFeature: (s?: string | null) =>
     s === "sales-cold-email-outreach" || s === "sales-crm-email-outreach",
 }));
 
@@ -169,6 +173,13 @@ describe("maybeSendExtendAudienceEmail", () => {
 
   it("does NOT send for a non-sales feature", async () => {
     await maybeSendExtendAudienceEmail(makeCampaign({ featureSlug: "pr-expert-quote-outreach" }), { runId: "r" });
+    expect(sendCall()).toBeUndefined();
+  });
+
+  it("does NOT send for a PAID-REACH campaign — it has no audience to extend", async () => {
+    // Google Ads is in the funnel-funded family (its money is billing's, same as cold email) but
+    // it works no list of names: asking its owner for more people to contact would be nonsense.
+    await maybeSendExtendAudienceEmail(makeCampaign({ featureSlug: "google-ads" }), { runId: "r" });
     expect(sendCall()).toBeUndefined();
   });
 


### PR DESCRIPTION
## What

A customer who funds Google Ads on a funnel that channel sells now ends up with a Google Ads campaign this service provisions, schedules, gates and paces — exactly as funding cold email produces a cold-email campaign today. Before this, provisioning was limited to a closed set of cold-email features: the money was stated and no campaign was ever created, with nothing logged and nothing charged.

## How

A channel IS a features-service feature slug, so this is one line in the family constant plus its `CHANNEL_BY_FEATURE` token (`google_ads`), not a second mechanism. No new column, table, vocabulary, accumulator or migration.

The family constant is renamed to what membership actually means — a MONEY statement: *this campaign's ceiling is billing's, per (funnel, channel, offer), read live on every plan*. `SALES_FUNNEL_FEATURE_SLUGS` / `isSalesFunnelFeature` is what every gate keyed on that question tests (gate-check's sales branch, the `maxBudget*` refusal, the create-time funnel requirement, the turn planner, the funding sweep).

`OUTBOUND_SALES_FEATURE_SLUGS` / `isOutboundSalesFeature` is the narrower question — *does this share the brand's leads and sending accounts?* Exactly four things ask it, and all four are about contacting named people:

- the per-brand serialization cohort,
- the greedy workflow rotation (it prices a DAG on send-tagged outcome evidence a paid channel does not produce),
- the extend-audience lifecycle email (it asks a customer for more PEOPLE to contact),
- the legacy per-campaign `daily_budget_cents` mirror written by `PATCH /brands/:brandId/daily-budget` — stamping a brand-level number on a paid-reach row would bind it AHEAD of the offer ceiling it was funded on.

Serialization is now per COHORT rather than per family (`serializationCohort`): the three outbound cold-email channels are one cohort — same leads, same mailboxes — and every other channel is its own, so a paid-reach campaign is serial against itself (one live run per ad account per brand) and against nothing else. Holding a funded Google Ads campaign behind a cold-email run would be the same mistake the brand-wide liveness read made one level up: a defer firing every tick for a reason that is not true of it, appearing in no log at all.

Which funnels the channel may sell stays features-service's statement, asked per feature (`GET /features/google-ads` → `feature.salesFunnels`): the three visit-led chains, not the conversation one — an ad buys a click and there is no reply in it to sell a conversation with. Nothing is hardcoded here, and `no-legacy` now fails on a `google-ads` slug beside a funnel key too.

## Also fixed

The turn planner asked runs-service for every candidate's spend under the SEED campaign's feature slug. That read filters on it, so a campaign of another channel answered ZERO, read as perfectly empty and took every turn — harmless while a brand's campaigns were all cold email, a live overspend the moment one brand mixes channels.

## Not in scope, deliberately

- **The rest of the published paid-reach catalogue** (meta-ads, linkedin-ads, tiktok-ads …). A campaign for a channel nothing can execute would sit ongoing and produce nothing forever. Adding the next one is one line, once something can run it.
- ⚠️ **workflow-service has no `google-ads` workflow today** (verified in prod: 11 feature slugs carry dynasties, none of them this one). `fetchActiveWorkflowSlugForFeature` fail-CLOSES on that, so the first funded pair is logged per sweep and the campaign is stood up the moment the dynasty ships — the same fail-closed the feedback-request channel shipped under. Nothing here needs to change when it does.

## Acceptance criteria

| AC | Where |
|----|-------|
| A funded (offer, funnel, google-ads) pair gets exactly one ongoing campaign on the normal tick, on that channel's own workflow and channel token | `funnel-campaigns.test.ts` — "gives a funded (funnel, google-ads) pair its own campaign" |
| Scheduled, gated and paced by the same funding rules | `gate-check.test.ts` — paces on its own (funnel, channel) ceiling; never paced on a per-campaign budget column |
| Funding a funnel through cold email is unchanged | every pre-existing test in `funnel-campaigns` / `gate-check` / `transactional-email` / `bandit`, untouched and green |
| A funnel that channel cannot sell gets no campaign | `funnel-campaigns.test.ts` — "provisions NO Google Ads campaign for a funnel that channel cannot sell" |

428 unit tests green, 20 integration files green, `tsc` + OpenAPI build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
