### PR TITLE
fix(build): pin pnpm to 10 in both Docker stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20-slim AS builder
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 
 # Copy package files
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
@@ -28,7 +28,7 @@ FROM node:20-slim
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 
 # Copy package files
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./


### PR DESCRIPTION
## Problem

The image installed pnpm without a version:

```
RUN npm install -g pnpm
```

`latest` has moved to pnpm 11, which refuses this repo's lockfile (`lockfileVersion: '9.0'`). Nothing in the repo changed; a tag outside it moved.

This is the quietest possible outage: the deploy host builds, fails, and returns the clone to the previous commit while leaving the container untouched. The service keeps answering, nothing alerts, the release gets tagged, and the code never runs. Same break that stopped brand-service deploying on 2026-08-25.

## Fix

Pin both build stages to pnpm 10 — the version `.github/workflows/ci.yml` (`pnpm/action-setup@v4`, `version: 10`) already uses, and the one that writes `lockfileVersion: 9.0`. No `packageManager` field exists in `package.json`, so CI is the agreement.

Two lines. No dependency bump, no lockfile regeneration, no restructuring.

## Verification

Built on the deploy host against `/root/distribute/repos/campaign-service` (copied to a temp dir so the live clone was untouched):

- **Unpinned** — fails at `RUN pnpm install --frozen-lockfile || pnpm install`, exit 1.
- **Pinned to 10** — both stages complete, image exported.

`main` and `staging` are at the same commit (`89cd424`), so there is no divergence to carry the pin to.