### PR TITLE
feat(brands): serve configured vs actually-running daily budget

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -555,6 +555,242 @@
           "transitionedAt"
         ]
       },
+      "SpendableBudgetResponse": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string"
+          },
+          "brandId": {
+            "type": "string"
+          },
+          "grain": {
+            "type": "string",
+            "enum": [
+              "offer",
+              "channel",
+              "funnel",
+              "brand",
+              "none"
+            ]
+          },
+          "configuredDailyBudgetCents": {
+            "type": "integer"
+          },
+          "runningDailyBudgetCents": {
+            "type": "integer"
+          },
+          "offers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpendableBudgetOffer"
+            }
+          },
+          "campaigns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpendableBudgetCampaign"
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpendableBudgetRow"
+            }
+          }
+        },
+        "required": [
+          "orgId",
+          "brandId",
+          "grain",
+          "configuredDailyBudgetCents",
+          "runningDailyBudgetCents",
+          "offers",
+          "campaigns",
+          "rows"
+        ]
+      },
+      "SpendableBudgetOffer": {
+        "type": "object",
+        "properties": {
+          "offerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "configuredDailyBudgetCents": {
+            "type": "integer"
+          },
+          "runningDailyBudgetCents": {
+            "type": "integer"
+          },
+          "campaignIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "offerId",
+          "configuredDailyBudgetCents",
+          "runningDailyBudgetCents",
+          "campaignIds"
+        ]
+      },
+      "SpendableBudgetCampaign": {
+        "type": "object",
+        "properties": {
+          "campaignId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "running": {
+            "type": "boolean"
+          },
+          "funnelKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "featureSlug": {
+            "type": "string",
+            "nullable": true
+          },
+          "offerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "configuredDailyBudgetCents": {
+            "type": "integer"
+          },
+          "runningDailyBudgetCents": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "campaignId",
+          "status",
+          "running",
+          "funnelKey",
+          "featureSlug",
+          "offerId",
+          "configuredDailyBudgetCents",
+          "runningDailyBudgetCents"
+        ]
+      },
+      "SpendableBudgetRow": {
+        "type": "object",
+        "properties": {
+          "funnelKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "featureSlug": {
+            "type": "string",
+            "nullable": true
+          },
+          "offerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "resolvedOfferId": {
+            "type": "string",
+            "nullable": true
+          },
+          "dailyBudgetCents": {
+            "type": "integer"
+          },
+          "running": {
+            "type": "boolean"
+          },
+          "campaignId": {
+            "type": "string",
+            "nullable": true
+          },
+          "campaignStatus": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "funnelKey",
+          "featureSlug",
+          "offerId",
+          "resolvedOfferId",
+          "dailyBudgetCents",
+          "running",
+          "campaignId",
+          "campaignStatus"
+        ]
+      },
+      "BatchSpendableBudgetResponse": {
+        "type": "object",
+        "properties": {
+          "brands": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpendableBudgetResponse"
+            }
+          },
+          "unavailable": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "orgId": {
+                  "type": "string"
+                },
+                "brandId": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "orgId",
+                "brandId",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "brands",
+          "unavailable"
+        ]
+      },
+      "BatchSpendableBudgetBody": {
+        "type": "object",
+        "properties": {
+          "brands": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "orgId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "brandId": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "orgId",
+                "brandId"
+              ]
+            },
+            "minItems": 1,
+            "maxItems": 500
+          }
+        },
+        "required": [
+          "brands"
+        ]
+      },
       "StatsResponse": {
         "type": "object",
         "properties": {
@@ -1395,6 +1631,127 @@
           },
           "400": {
             "description": "Missing x-org-id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/brands/{brandId}/spendable-budget": {
+      "get": {
+        "tags": [
+          "Brands"
+        ],
+        "summary": "Configured vs actually-running daily budget for a brand",
+        "description": "Answers, for one (org, brand), BOTH figures: configuredDailyBudgetCents (every ceiling the customer set in billing-service) and runningDailyBudgetCents (the part of it attached to a campaign that is ongoing right now). Both are always served — a paused campaign's settings screen must still show the amount the customer set. The answer is decomposed in the SAME response by offer (`offers`), by campaign (`campaigns`) and by individual ceiling (`rows`, each naming the campaign standing behind it and whether it is running), so a consumer never sums anything and can tell which campaigns contributed and which did not. `grain` names which billing width the figures were computed at (offer | channel | funnel | brand | none) — exactly one is ever counted, since the coarser ones are billing's own sums of the finer. A ceiling written before the offer level (offerId null) still counts as running when a campaign on its funnel and channel is ongoing. 502 when billing cannot be read — never a smaller figure. Org-scoped via x-org-id.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Configured and running daily budget",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpendableBudgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing x-org-id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Billing could not be read",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/brands/spendable-budget": {
+      "post": {
+        "tags": [
+          "Brands"
+        ],
+        "summary": "Configured vs actually-running daily budget for MANY brands",
+        "description": "The same answer as GET /brands/{brandId}/spendable-budget, for up to 500 (org, brand) pairs in one request — a staff audit walks every account and cannot afford one request per brand. The pairs are stated in the body because the answer is per (org, brand): one brand row is claimed by several orgs and each claim configures its own money. A pair whose billing ceilings cannot be read is listed in `unavailable` and carries NO figures at all — never a zero, which would silently shrink a fleet total. Same computation as the per-brand route, so the two cannot disagree.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchSpendableBudgetBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Configured and running daily budget per brand",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchSpendableBudgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
             "content": {
               "application/json": {
                 "schema": {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -24,6 +24,9 @@ import {
   SetBrandCampaignsDailyBudgetBody,
   SetBrandCampaignsDailyBudgetResponse,
   BrandPauseHistoryResponse,
+  SpendableBudgetResponse,
+  BatchSpendableBudgetBody,
+  BatchSpendableBudgetResponse,
 } from "../src/schemas.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -186,6 +189,39 @@ registry.registerPath({
   responses: {
     200: { description: "Brand pause transition timeline", content: { "application/json": { schema: BrandPauseHistoryResponse } } },
     400: { description: "Missing x-org-id", content: { "application/json": { schema: ErrorResponse } } },
+    401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+// === SPENDABLE BUDGET (configured vs running) ===
+
+registry.registerPath({
+  method: "get",
+  path: "/brands/{brandId}/spendable-budget",
+  tags: ["Brands"],
+  summary: "Configured vs actually-running daily budget for a brand",
+  description: "Answers, for one (org, brand), BOTH figures: configuredDailyBudgetCents (every ceiling the customer set in billing-service) and runningDailyBudgetCents (the part of it attached to a campaign that is ongoing right now). Both are always served — a paused campaign's settings screen must still show the amount the customer set. The answer is decomposed in the SAME response by offer (`offers`), by campaign (`campaigns`) and by individual ceiling (`rows`, each naming the campaign standing behind it and whether it is running), so a consumer never sums anything and can tell which campaigns contributed and which did not. `grain` names which billing width the figures were computed at (offer | channel | funnel | brand | none) — exactly one is ever counted, since the coarser ones are billing's own sums of the finer. A ceiling written before the offer level (offerId null) still counts as running when a campaign on its funnel and channel is ongoing. 502 when billing cannot be read — never a smaller figure. Org-scoped via x-org-id.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: { params: z.object({ brandId: z.string() }) },
+  responses: {
+    200: { description: "Configured and running daily budget", content: { "application/json": { schema: SpendableBudgetResponse } } },
+    400: { description: "Missing x-org-id", content: { "application/json": { schema: ErrorResponse } } },
+    401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
+    502: { description: "Billing could not be read", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/brands/spendable-budget",
+  tags: ["Brands"],
+  summary: "Configured vs actually-running daily budget for MANY brands",
+  description: "The same answer as GET /brands/{brandId}/spendable-budget, for up to 500 (org, brand) pairs in one request — a staff audit walks every account and cannot afford one request per brand. The pairs are stated in the body because the answer is per (org, brand): one brand row is claimed by several orgs and each claim configures its own money. A pair whose billing ceilings cannot be read is listed in `unavailable` and carries NO figures at all — never a zero, which would silently shrink a fleet total. Same computation as the per-brand route, so the two cannot disagree.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: { body: { content: { "application/json": { schema: BatchSpendableBudgetBody } } } },
+  responses: {
+    200: { description: "Configured and running daily budget per brand", content: { "application/json": { schema: BatchSpendableBudgetResponse } } },
+    400: { description: "Validation error", content: { "application/json": { schema: ErrorResponse } } },
     401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
   },
 });

--- a/src/lib/spendable-budget.ts
+++ b/src/lib/spendable-budget.ts
@@ -1,0 +1,321 @@
+import {
+  toFunnelKey,
+  type SalesFunnelKey,
+} from "./sales-funnel-vocabulary.js";
+import type { FunnelBudgetsRead } from "./funnel-budget-client.js";
+
+/**
+ * "Of the money this brand has CONFIGURED, how much is attached to a campaign that is actually
+ * RUNNING?"
+ *
+ * Nobody could answer that from one service: billing-service knows what every ceiling is worth and
+ * campaign-service is the only place that knows whether a campaign exists for it and whether that
+ * campaign is ongoing. Every consumer was therefore reading billing's brand daily-budget figure —
+ * the SUM of every configured ceiling regardless of whether anything is running behind it — so the
+ * staff MRR figure read ~28% high (measured 2026-08-27: $138/day configured across 9 brands, ~$25
+ * of it on funnels whose campaign is stopped or was never created, two brands with no campaign at
+ * all), and "is this account active" was decided by a brand-level pause flag with no writer since
+ * July. The dashboard patched it by fetching the campaign list and the per-funnel budgets and
+ * joining them in the browser — duplicated in one app, absent in the other, unreachable from
+ * features-service. The join belongs here.
+ *
+ * BOTH figures are served, never one. A campaign's own settings screen must still show the amount
+ * the customer set even while it is paused, or it reads as zero and looks like the setting was
+ * lost.
+ *
+ * NOTHING IS LEFT FOR A CONSUMER TO SUM. The brand total, each offer's total and each campaign's
+ * total are all stated, alongside the individual ceiling rows that produced them — so a consumer
+ * answers the same question for one offer or one campaign out of the SAME response, and can say
+ * which campaigns contributed and which did not.
+ */
+
+/** A campaign of the (org, brand) pair, as this computation needs it. */
+export interface SpendableCampaign {
+  id: string;
+  status: string;
+  funnelKey: string | null;
+  featureSlug: string | null;
+  offerId: string | null;
+  createdAt: Date;
+}
+
+/**
+ * WHICH billing grain the figures were computed at.
+ *
+ * billing serves the same money at four widths — per (funnel, channel, offer), per (funnel,
+ * channel), per funnel, and one brand pot — and the coarser three are SUMS of the finer, so
+ * exactly ONE of them may be counted or the same dollar is counted twice. The finest one billing
+ * actually states is chosen, once, here.
+ */
+export type SpendableGrain = "offer" | "channel" | "funnel" | "brand" | "none";
+
+/** One configured ceiling, and the campaign (if any) standing behind it. */
+export interface SpendableRow {
+  /** Canonical funnel key, or null at brand grain (one undifferentiated pot). */
+  funnelKey: SalesFunnelKey | null;
+  /** The acquisition channel this ceiling funds — a features-service feature slug — or null. */
+  featureSlug: string | null;
+  /** The offer billing SCOPED this ceiling to, or null for a ceiling written before offers. */
+  offerId: string | null;
+  /**
+   * The offer this money actually works for: billing's when it states one, else the offer of the
+   * campaign standing behind it. Production still carries ceilings written before the offer level
+   * while every running campaign carries an offer, so grouping on `offerId` alone would file real,
+   * running money under "no offer" and it would appear on nobody's offer page.
+   */
+  resolvedOfferId: string | null;
+  dailyBudgetCents: number;
+  /** True ⟺ a campaign for this ceiling exists AND is ongoing. */
+  running: boolean;
+  /** The campaign standing behind this ceiling — ongoing when there is one, else the stopped one. */
+  campaignId: string | null;
+  campaignStatus: string | null;
+}
+
+export interface SpendableCampaignLine {
+  campaignId: string;
+  status: string;
+  running: boolean;
+  funnelKey: string | null;
+  featureSlug: string | null;
+  offerId: string | null;
+  configuredDailyBudgetCents: number;
+  runningDailyBudgetCents: number;
+}
+
+export interface SpendableOfferLine {
+  offerId: string | null;
+  configuredDailyBudgetCents: number;
+  runningDailyBudgetCents: number;
+  campaignIds: string[];
+}
+
+export interface SpendableBudget {
+  orgId: string;
+  brandId: string;
+  grain: SpendableGrain;
+  /** Everything the customer has configured for this brand, at `grain`. */
+  configuredDailyBudgetCents: number;
+  /** The part of it attached to a campaign that is ongoing right now. */
+  runningDailyBudgetCents: number;
+  offers: SpendableOfferLine[];
+  campaigns: SpendableCampaignLine[];
+  rows: SpendableRow[];
+}
+
+interface RawRow {
+  funnelKey: SalesFunnelKey | null;
+  featureSlug: string | null;
+  offerId: string | null;
+  dailyBudgetCents: number;
+}
+
+/**
+ * The finest grain billing actually states, and its rows. Exactly one grain is ever counted — the
+ * coarser fields are billing's own sums of the finer ones, so mixing them double-counts.
+ */
+function rowsAtFinestGrain(
+  budgets: Extract<FunnelBudgetsRead, { ok: true }>,
+): { grain: SpendableGrain; rows: RawRow[] } {
+  const offers = budgets.offers ?? [];
+  if (offers.length > 0) {
+    return {
+      grain: "offer",
+      rows: offers.map((o) => ({
+        funnelKey: o.funnelKey,
+        featureSlug: o.featureSlug,
+        offerId: o.offerId,
+        dailyBudgetCents: o.dailyBudgetCents,
+      })),
+    };
+  }
+
+  const channels = budgets.channels ?? [];
+  if (channels.length > 0) {
+    return {
+      grain: "channel",
+      rows: channels.map((c) => ({
+        funnelKey: c.funnelKey,
+        featureSlug: c.featureSlug,
+        offerId: null,
+        dailyBudgetCents: c.dailyBudgetCents,
+      })),
+    };
+  }
+
+  if (budgets.funnels.length > 0) {
+    return {
+      grain: "funnel",
+      rows: budgets.funnels.map((f) => ({
+        funnelKey: f.funnelKey,
+        featureSlug: null,
+        offerId: null,
+        dailyBudgetCents: f.dailyBudgetCents,
+      })),
+    };
+  }
+
+  if (budgets.brandDailyBudgetCents !== null) {
+    return {
+      grain: "brand",
+      rows: [
+        {
+          funnelKey: null,
+          featureSlug: null,
+          offerId: null,
+          dailyBudgetCents: budgets.brandDailyBudgetCents,
+        },
+      ],
+    };
+  }
+
+  return { grain: "none", rows: [] };
+}
+
+/**
+ * The campaign standing behind ONE ceiling, or null.
+ *
+ * The matching rules are billing's own, mirrored from `channelCeilingCents` / `offerCeilingCents`
+ * so that a campaign counts as running here exactly when the gate would let it spend that ceiling:
+ *
+ *   - the funnel must match (canonicalised on both sides — billing still emits the pre-rename
+ *     spellings to this day, so comparing raw tokens reads a fully funded funnel as unfunded);
+ *   - the channel must match, EXCEPT where the funnel is worked through exactly one channel, which
+ *     binds whatever feature the campaign states;
+ *   - a ceiling that NAMES an offer belongs to that offer's campaign; an UNSCOPED ceiling (every
+ *     ceiling written before offers existed, and most of production today) belongs to the campaign
+ *     on its (funnel, channel) whatever offer that campaign states — dropping those would report a
+ *     running figure of zero for brands that are demonstrably spending.
+ *
+ * An ONGOING campaign always wins over a stopped one, whatever their creation dates: the stopped
+ * row is history, the ongoing one is what spends the money. Ties break on the oldest campaign so
+ * the answer is stable between calls.
+ */
+function campaignForRow(row: RawRow, all: SpendableCampaign[], rowsOfGrain: RawRow[]): SpendableCampaign | null {
+  const byFunnel = all.filter((c) => {
+    if (row.funnelKey === null) return true; // brand grain — one pot, every campaign draws on it
+    return c.funnelKey ? toFunnelKey(c.funnelKey) === row.funnelKey : false;
+  });
+  if (byFunnel.length === 0) return null;
+
+  let candidates = byFunnel;
+  if (row.featureSlug) {
+    const exact = byFunnel.filter((c) => c.featureSlug === row.featureSlug);
+    if (exact.length > 0) {
+      candidates = exact;
+    } else {
+      // billing's sole-channel rule: a funnel funded through exactly one channel binds whatever
+      // feature the campaign states. A funnel SPLIT across channels funds only what it names.
+      const channelsOfFunnel = new Set(
+        rowsOfGrain.filter((r) => r.funnelKey === row.funnelKey).map((r) => r.featureSlug),
+      );
+      if (channelsOfFunnel.size !== 1) return null;
+    }
+  }
+
+  if (row.offerId) {
+    candidates = candidates.filter((c) => c.offerId === row.offerId);
+  }
+  if (candidates.length === 0) return null;
+
+  const rank = (c: SpendableCampaign) => (c.status === "ongoing" ? 0 : 1);
+  return [...candidates].sort(
+    (a, b) => rank(a) - rank(b) || a.createdAt.getTime() - b.createdAt.getTime(),
+  )[0]!;
+}
+
+/**
+ * Answer both figures for one (org, brand), from ceilings and campaigns ALREADY read — so a
+ * fleet-wide caller judges every brand with one read each rather than one request per brand.
+ *
+ * `campaigns` must be the pair's sales-family campaigns (ongoing AND stopped): a stopped campaign
+ * is what makes "configured but not running" legible, and it is named rather than merely absent.
+ */
+export function computeSpendableBudget(
+  orgId: string,
+  brandId: string,
+  budgets: Extract<FunnelBudgetsRead, { ok: true }>,
+  campaigns: SpendableCampaign[],
+): SpendableBudget {
+  const { grain, rows: rawRows } = rowsAtFinestGrain(budgets);
+
+  const configuredByCampaign = new Map<string, number>();
+  const runningByCampaign = new Map<string, number>();
+  const seenCampaign = new Map<string, SpendableCampaign>();
+
+  const rows: SpendableRow[] = rawRows.map((raw) => {
+    const campaign = campaignForRow(raw, campaigns, rawRows);
+    const running = campaign?.status === "ongoing";
+    if (campaign) {
+      seenCampaign.set(campaign.id, campaign);
+      configuredByCampaign.set(
+        campaign.id,
+        (configuredByCampaign.get(campaign.id) ?? 0) + raw.dailyBudgetCents,
+      );
+      if (running) {
+        runningByCampaign.set(
+          campaign.id,
+          (runningByCampaign.get(campaign.id) ?? 0) + raw.dailyBudgetCents,
+        );
+      }
+    }
+    return {
+      funnelKey: raw.funnelKey,
+      featureSlug: raw.featureSlug,
+      offerId: raw.offerId,
+      resolvedOfferId: raw.offerId ?? campaign?.offerId ?? null,
+      dailyBudgetCents: raw.dailyBudgetCents,
+      running,
+      campaignId: campaign?.id ?? null,
+      campaignStatus: campaign?.status ?? null,
+    };
+  });
+
+  // Every ONGOING campaign is named even when no ceiling stands behind it — a running campaign
+  // funded at nothing is exactly what a consumer needs to see, and its absence would read as
+  // "there is no such campaign".
+  for (const c of campaigns) {
+    if (c.status === "ongoing") seenCampaign.set(c.id, c);
+  }
+
+  const campaignLines: SpendableCampaignLine[] = [...seenCampaign.values()]
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+    .map((c) => ({
+      campaignId: c.id,
+      status: c.status,
+      running: c.status === "ongoing",
+      funnelKey: c.funnelKey,
+      featureSlug: c.featureSlug,
+      offerId: c.offerId,
+      configuredDailyBudgetCents: configuredByCampaign.get(c.id) ?? 0,
+      runningDailyBudgetCents: runningByCampaign.get(c.id) ?? 0,
+    }));
+
+  const offerMap = new Map<string | null, SpendableOfferLine>();
+  for (const row of rows) {
+    const key = row.resolvedOfferId;
+    const line = offerMap.get(key) ?? {
+      offerId: key,
+      configuredDailyBudgetCents: 0,
+      runningDailyBudgetCents: 0,
+      campaignIds: [],
+    };
+    line.configuredDailyBudgetCents += row.dailyBudgetCents;
+    if (row.running) line.runningDailyBudgetCents += row.dailyBudgetCents;
+    if (row.campaignId && !line.campaignIds.includes(row.campaignId)) {
+      line.campaignIds.push(row.campaignId);
+    }
+    offerMap.set(key, line);
+  }
+
+  return {
+    orgId,
+    brandId,
+    grain,
+    configuredDailyBudgetCents: rows.reduce((sum, r) => sum + r.dailyBudgetCents, 0),
+    runningDailyBudgetCents: rows.reduce((sum, r) => sum + (r.running ? r.dailyBudgetCents : 0), 0),
+    offers: [...offerMap.values()],
+    campaigns: campaignLines,
+    rows,
+  };
+}

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -1,14 +1,22 @@
 import { Router } from "express";
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, or } from "drizzle-orm";
 import { arrayContains } from "drizzle-orm/sql/expressions/conditions";
 import { db } from "../db/index.js";
 import { brandPauseTransitions, campaigns } from "../db/schema.js";
 import { serviceAuth, requireApiKey, AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
-import { SetBrandCampaignsDailyBudgetBody } from "../schemas.js";
+import { BatchSpendableBudgetBody, SetBrandCampaignsDailyBudgetBody } from "../schemas.js";
 import { fetchFunnelBudgets } from "../lib/funnel-budget-client.js";
 import { brandHeldFromBudgets } from "../lib/campaign-funding.js";
-import { OUTBOUND_SALES_FEATURE_SLUGS } from "../lib/sales-outreach-campaign.js";
+import {
+  OUTBOUND_SALES_FEATURE_SLUGS,
+  SALES_FUNNEL_FEATURE_SLUGS,
+} from "../lib/sales-outreach-campaign.js";
+import {
+  computeSpendableBudget,
+  type SpendableBudget,
+  type SpendableCampaign,
+} from "../lib/spendable-budget.js";
 
 // The per-campaign `daily_budget_cents` MIRROR — the legacy brand-page lever, which gate-check
 // still prefers over every billing ceiling when it is set. Scoped to the OUTBOUND cold-email
@@ -135,6 +143,126 @@ router.get("/brands/:brandId/pause-history", requireApiKey, serviceAuth, async (
     });
   } catch (error) {
     console.error("[campaign-service] Get brand pause history error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * The sales-family campaigns of one (org, brand) pair — ongoing AND stopped.
+ *
+ * A stopped campaign is what makes "configured but not running" legible: naming it is the
+ * difference between "this funnel's money is idle because the campaign is stopped" and "there is
+ * no such campaign", which are different things to a customer and to a staff audit.
+ *
+ * The brand is matched on the scalar identity column AND on the historical `brand_ids` array: the
+ * scalar is written at creation and nothing re-derives it, but rows older than migration 0044
+ * carry only the array, and a brand whose campaigns are all older would otherwise report nothing
+ * running while it spends.
+ */
+async function loadSalesCampaigns(orgId: string, brandId: string): Promise<SpendableCampaign[]> {
+  const rows = await db
+    .select({
+      id: campaigns.id,
+      status: campaigns.status,
+      funnelKey: campaigns.funnelKey,
+      featureSlug: campaigns.featureSlug,
+      offerId: campaigns.offerId,
+      createdAt: campaigns.createdAt,
+    })
+    .from(campaigns)
+    .where(and(
+      eq(campaigns.orgId, orgId),
+      or(eq(campaigns.brandId, brandId), arrayContains(campaigns.brandIds, [brandId])),
+      inArray(campaigns.featureSlug, [...SALES_FUNNEL_FEATURE_SLUGS]),
+    ));
+  return rows;
+}
+
+/** Read billing once for the pair, join the pair's campaigns onto it, and answer both figures. */
+async function spendableBudgetFor(
+  orgId: string,
+  brandId: string,
+  userId?: string,
+): Promise<{ ok: true; budget: SpendableBudget } | { ok: false; reason: string }> {
+  const budgets = await fetchFunnelBudgets(brandId, { orgId, userId });
+  // Fail LOUD. A brand whose ceilings cannot be read is not a brand funding nothing, and
+  // reporting it as a smaller figure is exactly the silent under-count this endpoint exists to
+  // remove from the staff numbers.
+  if (!budgets.ok) return { ok: false, reason: "billing did not answer the brand's budget" };
+
+  const campaignRows = await loadSalesCampaigns(orgId, brandId);
+  return { ok: true, budget: computeSpendableBudget(orgId, brandId, budgets, campaignRows) };
+}
+
+/**
+ * GET /brands/:brandId/spendable-budget — of the money configured for this brand, how much is
+ * attached to a campaign that is currently RUNNING?
+ *
+ * Both figures, always: `configuredDailyBudgetCents` is what the customer set (a paused campaign's
+ * settings screen must still show it, or it reads as lost), `runningDailyBudgetCents` is the part
+ * of it a live campaign stands behind. `offers`, `campaigns` and `rows` decompose the same answer
+ * per offer, per campaign and per ceiling, so a consumer never adds anything up and can say which
+ * campaigns contributed and which did not.
+ *
+ * 502 when billing cannot be read — never a smaller figure. Org-scoped via x-org-id.
+ */
+router.get("/brands/:brandId/spendable-budget", requireApiKey, serviceAuth, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId } = req.params;
+    const orgId = req.orgId!;
+
+    const result = await spendableBudgetFor(orgId, brandId, req.userId ?? undefined);
+    if (!result.ok) {
+      res.status(502).json({ error: "Brand funding unavailable" });
+      return;
+    }
+    res.json(result.budget);
+  } catch (error) {
+    console.error("[campaign-service] Get brand spendable budget error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * POST /brands/spendable-budget — the same answer for MANY (org, brand) pairs in one request.
+ *
+ * A staff audit walks every account, so one request per brand is not an option. The pairs come in
+ * the body because the answer is per (org, brand) — the same brand row is claimed by several orgs
+ * and each claim configures its own money — and because a staff caller crosses orgs, which no
+ * single `x-org-id` can express.
+ *
+ * A pair billing cannot be read for is named in `unavailable` and carries NO figures at all: a
+ * zero would silently shrink a fleet total, which is the very failure this endpoint removes.
+ * Every brand answered here is answered by the same code as the per-brand route above, so the two
+ * cannot drift.
+ */
+router.post("/brands/spendable-budget", requireApiKey, validateBody(BatchSpendableBudgetBody), async (req, res) => {
+  try {
+    const { brands } = req.body as { brands: Array<{ orgId: string; brandId: string }> };
+
+    const answered: SpendableBudget[] = [];
+    const unavailable: Array<{ orgId: string; brandId: string; reason: string }> = [];
+
+    // Bounded fan-out: one billing read per pair, a few at a time, so a fleet sweep does not open
+    // 500 sockets at once against billing.
+    const CONCURRENCY = 8;
+    let cursor = 0;
+    await Promise.all(
+      Array.from({ length: Math.min(CONCURRENCY, brands.length) }, async () => {
+        for (;;) {
+          const index = cursor++;
+          const pair = brands[index];
+          if (!pair) return;
+          const result = await spendableBudgetFor(pair.orgId, pair.brandId);
+          if (result.ok) answered.push(result.budget);
+          else unavailable.push({ orgId: pair.orgId, brandId: pair.brandId, reason: result.reason });
+        }
+      }),
+    );
+
+    res.json({ brands: answered, unavailable });
+  } catch (error) {
+    console.error("[campaign-service] Batch brand spendable budget error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -334,3 +334,79 @@ export const DeleteCampaignsByOrgResponse = z.object({
     count: z.number().int(),
   })),
 }).openapi("DeleteCampaignsByOrgResponse");
+
+// --- Brand spendable budget (configured vs running) ---
+
+/**
+ * "Of the money configured for this brand, how much is attached to a campaign that is actually
+ * running?" Both figures are always served: a paused campaign's own settings screen must still
+ * show the amount the customer set, or it reads as zero and looks like the setting was lost.
+ *
+ * Nothing is left for a consumer to add up — the brand total, each offer's total and each
+ * campaign's total are all stated, alongside the ceiling rows that produced them.
+ */
+export const SpendableBudgetRow = z.object({
+  funnelKey: z.string().nullable(),
+  featureSlug: z.string().nullable(),
+  offerId: z.string().nullable(),
+  resolvedOfferId: z.string().nullable(),
+  dailyBudgetCents: z.number().int(),
+  running: z.boolean(),
+  campaignId: z.string().nullable(),
+  campaignStatus: z.string().nullable(),
+}).openapi("SpendableBudgetRow");
+
+export const SpendableBudgetOffer = z.object({
+  offerId: z.string().nullable(),
+  configuredDailyBudgetCents: z.number().int(),
+  runningDailyBudgetCents: z.number().int(),
+  campaignIds: z.array(z.string()),
+}).openapi("SpendableBudgetOffer");
+
+export const SpendableBudgetCampaign = z.object({
+  campaignId: z.string(),
+  status: z.string(),
+  running: z.boolean(),
+  funnelKey: z.string().nullable(),
+  featureSlug: z.string().nullable(),
+  offerId: z.string().nullable(),
+  configuredDailyBudgetCents: z.number().int(),
+  runningDailyBudgetCents: z.number().int(),
+}).openapi("SpendableBudgetCampaign");
+
+export const SpendableBudgetResponse = z.object({
+  orgId: z.string(),
+  brandId: z.string(),
+  grain: z.enum(["offer", "channel", "funnel", "brand", "none"]),
+  configuredDailyBudgetCents: z.number().int(),
+  runningDailyBudgetCents: z.number().int(),
+  offers: z.array(SpendableBudgetOffer),
+  campaigns: z.array(SpendableBudgetCampaign),
+  rows: z.array(SpendableBudgetRow),
+}).openapi("SpendableBudgetResponse");
+
+/**
+ * The fleet-wide ask. A staff audit walks every account, so one request per brand is not an
+ * option — the pairs come in a body because the answer is per (org, brand) and a staff caller
+ * crosses orgs.
+ */
+export const BatchSpendableBudgetBody = z.object({
+  brands: z.array(z.object({
+    orgId: z.string().min(1),
+    brandId: z.string().min(1),
+  })).min(1).max(500),
+}).openapi("BatchSpendableBudgetBody");
+
+export const BatchSpendableBudgetResponse = z.object({
+  brands: z.array(SpendableBudgetResponse),
+  /**
+   * The pairs whose ceilings billing could not be read for. They carry NO figures at all — never
+   * a zero, which would silently shrink a fleet total — and are named here so a caller knows its
+   * sweep is incomplete.
+   */
+  unavailable: z.array(z.object({
+    orgId: z.string(),
+    brandId: z.string(),
+    reason: z.string(),
+  })),
+}).openapi("BatchSpendableBudgetResponse");

--- a/tests/integration/spendable-budget-routes.test.ts
+++ b/tests/integration/spendable-budget-routes.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+
+vi.mock("@distribute/runs-client", () => ({
+  listRuns: vi.fn(),
+  createRun: vi.fn(),
+  updateRun: vi.fn(),
+  getStatsBudget: vi.fn(),
+}));
+
+import app from "../../src/index.js";
+import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+const BRAND = "11111111-1111-4111-8111-111111111111";
+const BRAND_2 = "22222222-2222-4222-8222-222222222222";
+
+/** billing-service's per-funnel budget read, as it comes off the wire. */
+function billingPayload(body: unknown) {
+  return { ok: true, json: async () => body } as unknown as Response;
+}
+
+describe("Brand spendable budget", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(async () => {
+    await cleanTestData();
+    vi.clearAllMocks();
+    process.env.BILLING_SERVICE_URL = "http://billing.test";
+    process.env.BILLING_SERVICE_API_KEY = "billing-key";
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterAll(async () => {
+    vi.unstubAllGlobals();
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("reports configured money with nothing running when the funded funnel has no campaign", async () => {
+    fetchMock.mockResolvedValue(billingPayload({
+      brandId: BRAND,
+      dailyBudgetCents: "5000",
+      funnels: [{ funnelKey: "reply_meeting", dailyBudgetCents: "5000" }],
+    }));
+
+    const res = await request(app)
+      .get(`/brands/${BRAND}/spendable-budget`)
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", "org-nothing-running")
+      .expect(200);
+
+    expect(res.body.configuredDailyBudgetCents).toBe(5000);
+    expect(res.body.runningDailyBudgetCents).toBe(0);
+    expect(res.body.campaigns).toEqual([]);
+  });
+
+  it("counts only the funnel whose campaign is ongoing", async () => {
+    const orgId = "org-partly-running";
+    await insertTestCampaign(orgId, {
+      brandIds: [BRAND],
+      brandId: BRAND,
+      featureSlug: "sales-cold-email-outreach",
+      acquisitionChannel: "cold_email",
+      funnelKey: "sales_meetings_from_conversation",
+      status: "ongoing",
+    });
+    await insertTestCampaign(orgId, {
+      brandIds: [BRAND],
+      brandId: BRAND,
+      featureSlug: "sales-cold-email-outreach",
+      acquisitionChannel: "cold_email",
+      funnelKey: "website_purchases",
+      status: "stopped",
+    });
+
+    fetchMock.mockResolvedValue(billingPayload({
+      brandId: BRAND,
+      dailyBudgetCents: "9000",
+      funnels: [
+        { funnelKey: "reply_meeting", dailyBudgetCents: "4000" },
+        { funnelKey: "visit_signup", dailyBudgetCents: "5000" },
+      ],
+    }));
+
+    const res = await request(app)
+      .get(`/brands/${BRAND}/spendable-budget`)
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", orgId)
+      .expect(200);
+
+    expect(res.body.configuredDailyBudgetCents).toBe(9000);
+    expect(res.body.runningDailyBudgetCents).toBe(4000);
+    expect(res.body.campaigns).toHaveLength(2);
+  });
+
+  it("fails LOUD when billing cannot be read, never a smaller figure", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as unknown as Response);
+
+    await request(app)
+      .get(`/brands/${BRAND}/spendable-budget`)
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", "org-billing-down")
+      .expect(502);
+  });
+
+  it("requires an org", async () => {
+    await request(app)
+      .get(`/brands/${BRAND}/spendable-budget`)
+      .set("x-api-key", API_KEY)
+      .expect(400);
+  });
+
+  it("answers many pairs in one request, with the same numbers as the per-brand route", async () => {
+    const orgA = "org-fleet-a";
+    const orgB = "org-fleet-b";
+    await insertTestCampaign(orgA, {
+      brandIds: [BRAND],
+      brandId: BRAND,
+      featureSlug: "sales-cold-email-outreach",
+      acquisitionChannel: "cold_email",
+      funnelKey: "sales_meetings_from_conversation",
+      status: "ongoing",
+    });
+
+    fetchMock.mockImplementation(async (url: string, init: { headers: Record<string, string> }) => {
+      const orgId = init.headers["x-org-id"];
+      if (orgId === orgA) {
+        return billingPayload({
+          dailyBudgetCents: "4000",
+          funnels: [{ funnelKey: "reply_meeting", dailyBudgetCents: "4000" }],
+        });
+      }
+      return billingPayload({
+        dailyBudgetCents: "3000",
+        funnels: [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+      });
+    });
+
+    const batch = await request(app)
+      .post("/brands/spendable-budget")
+      .set("x-api-key", API_KEY)
+      .send({ brands: [{ orgId: orgA, brandId: BRAND }, { orgId: orgB, brandId: BRAND_2 }] })
+      .expect(200);
+
+    const single = await request(app)
+      .get(`/brands/${BRAND}/spendable-budget`)
+      .set("x-api-key", API_KEY)
+      .set("x-org-id", orgA)
+      .expect(200);
+
+    const fromBatch = batch.body.brands.find((b: { orgId: string }) => b.orgId === orgA);
+    expect(fromBatch).toEqual(single.body);
+    expect(batch.body.unavailable).toEqual([]);
+
+    const other = batch.body.brands.find((b: { orgId: string }) => b.orgId === orgB);
+    expect(other.configuredDailyBudgetCents).toBe(3000);
+    expect(other.runningDailyBudgetCents).toBe(0);
+  });
+
+  it("names a brand billing could not answer for, and gives it NO figures at all", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, json: async () => ({}) } as unknown as Response);
+
+    const res = await request(app)
+      .post("/brands/spendable-budget")
+      .set("x-api-key", API_KEY)
+      .send({ brands: [{ orgId: "org-down", brandId: BRAND }] })
+      .expect(200);
+
+    expect(res.body.brands).toEqual([]);
+    expect(res.body.unavailable).toHaveLength(1);
+    expect(res.body.unavailable[0]).toMatchObject({ orgId: "org-down", brandId: BRAND });
+  });
+});

--- a/tests/unit/spendable-budget.test.ts
+++ b/tests/unit/spendable-budget.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import { computeSpendableBudget, type SpendableCampaign } from "../../src/lib/spendable-budget.js";
+import type { FunnelBudgetsRead } from "../../src/lib/funnel-budget-client.js";
+
+const ORG = "org-1";
+const BRAND = "brand-1";
+
+function budgets(partial: Partial<Extract<FunnelBudgetsRead, { ok: true }>>): Extract<FunnelBudgetsRead, { ok: true }> {
+  return {
+    ok: true,
+    brandDailyBudgetCents: null,
+    funnels: [],
+    channels: [],
+    offers: [],
+    ...partial,
+  };
+}
+
+function campaign(over: Partial<SpendableCampaign> & { id: string }): SpendableCampaign {
+  return {
+    status: "ongoing",
+    funnelKey: "sales_meetings_from_conversation",
+    featureSlug: "sales-cold-email-outreach",
+    offerId: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    ...over,
+  };
+}
+
+describe("computeSpendableBudget", () => {
+  it("reports a running figure of ZERO and a non-zero configured figure when a funded funnel has no campaign", () => {
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({
+        brandDailyBudgetCents: 5000,
+        funnels: [{ funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 5000 }],
+      }),
+      [],
+    );
+
+    expect(result.configuredDailyBudgetCents).toBe(5000);
+    expect(result.runningDailyBudgetCents).toBe(0);
+    expect(result.grain).toBe("funnel");
+    expect(result.rows[0]).toMatchObject({ running: false, campaignId: null });
+  });
+
+  it("excludes ONLY the stopped funnel when several funnels are funded", () => {
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({
+        brandDailyBudgetCents: 9000,
+        funnels: [
+          { funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 4000 },
+          { funnelKey: "website_purchases", dailyBudgetCents: 5000 },
+        ],
+      }),
+      [
+        campaign({ id: "c-live" }),
+        campaign({ id: "c-stopped", status: "stopped", funnelKey: "website_purchases" }),
+      ],
+    );
+
+    expect(result.configuredDailyBudgetCents).toBe(9000);
+    expect(result.runningDailyBudgetCents).toBe(4000);
+    // The stopped campaign is NAMED, not merely absent: "configured but not running" has to be
+    // legible, and a missing row reads as "there is no such campaign".
+    const stopped = result.campaigns.find((c) => c.campaignId === "c-stopped")!;
+    expect(stopped.running).toBe(false);
+    expect(stopped.configuredDailyBudgetCents).toBe(5000);
+    expect(stopped.runningDailyBudgetCents).toBe(0);
+  });
+
+  it("counts an UNSCOPED (no-offer) ceiling as running when a campaign on that funnel and channel is ongoing", () => {
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({
+        brandDailyBudgetCents: 4000,
+        funnels: [{ funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 4000 }],
+        channels: [{ funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: 4000 }],
+        offers: [{ funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-cold-email-outreach", offerId: null, dailyBudgetCents: 4000 }],
+      }),
+      [campaign({ id: "c-live", offerId: "offer-a" })],
+    );
+
+    expect(result.grain).toBe("offer");
+    expect(result.runningDailyBudgetCents).toBe(4000);
+    // And that money is filed under the offer the CAMPAIGN sells, so it appears on that offer's
+    // page rather than under "no offer".
+    expect(result.offers).toEqual([
+      { offerId: "offer-a", configuredDailyBudgetCents: 4000, runningDailyBudgetCents: 4000, campaignIds: ["c-live"] },
+    ]);
+  });
+
+  it("counts exactly ONE grain — the finest billing states — so a dollar is never counted twice", () => {
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({
+        brandDailyBudgetCents: 6000,
+        funnels: [{ funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 6000 }],
+        channels: [
+          { funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: 4000 },
+          { funnelKey: "sales_meetings_from_conversation", featureSlug: "feedback-request-cold-email-outreach", dailyBudgetCents: 2000 },
+        ],
+      }),
+      [campaign({ id: "c-live" })],
+    );
+
+    expect(result.grain).toBe("channel");
+    expect(result.configuredDailyBudgetCents).toBe(6000);
+    // The funnel is SPLIT across two channels, so the channel the campaign does not work is not
+    // its money — the exact rule the gate paces on.
+    expect(result.runningDailyBudgetCents).toBe(4000);
+  });
+
+  it("binds a single-channel funnel to whatever feature the campaign states", () => {
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({
+        channels: [{ funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-cold-email-outreach", dailyBudgetCents: 3000 }],
+      }),
+      [campaign({ id: "c-live", featureSlug: "feedback-request-cold-email-outreach" })],
+    );
+
+    expect(result.runningDailyBudgetCents).toBe(3000);
+  });
+
+  it("canonicalises billing's pre-rename funnel spellings against the campaign's", () => {
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({ funnels: [{ funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 2500 }] }),
+      [campaign({ id: "c-live", funnelKey: "reply_meeting" })],
+    );
+
+    expect(result.runningDailyBudgetCents).toBe(2500);
+  });
+
+  it("names an ongoing campaign that no ceiling stands behind, at zero", () => {
+    const result = computeSpendableBudget(ORG, BRAND, budgets({}), [campaign({ id: "c-live" })]);
+
+    expect(result.grain).toBe("none");
+    expect(result.configuredDailyBudgetCents).toBe(0);
+    expect(result.campaigns).toEqual([
+      {
+        campaignId: "c-live",
+        status: "ongoing",
+        running: true,
+        funnelKey: "sales_meetings_from_conversation",
+        featureSlug: "sales-cold-email-outreach",
+        offerId: null,
+        configuredDailyBudgetCents: 0,
+        runningDailyBudgetCents: 0,
+      },
+    ]);
+  });
+
+  it("prefers the ONGOING campaign over a stopped one on the same identity, whatever the creation dates", () => {
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({ funnels: [{ funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 1000 }] }),
+      [
+        campaign({ id: "c-stopped", status: "stopped", createdAt: new Date("2026-06-01T00:00:00Z") }),
+        campaign({ id: "c-live", createdAt: new Date("2026-01-01T00:00:00Z") }),
+      ],
+    );
+
+    expect(result.rows[0]!.campaignId).toBe("c-live");
+    expect(result.runningDailyBudgetCents).toBe(1000);
+  });
+
+  it("paces a brand with one undifferentiated pot on that pot", () => {
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({ brandDailyBudgetCents: 1500 }),
+      [campaign({ id: "c-live", funnelKey: null })],
+    );
+
+    expect(result.grain).toBe("brand");
+    expect(result.configuredDailyBudgetCents).toBe(1500);
+    expect(result.runningDailyBudgetCents).toBe(1500);
+  });
+
+  it("never leaves a consumer to add anything up: brand, offer and campaign totals all agree", () => {
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({
+        offers: [
+          { funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-cold-email-outreach", offerId: "offer-a", dailyBudgetCents: 4000 },
+          { funnelKey: "website_purchases", featureSlug: "google-ads", offerId: "offer-b", dailyBudgetCents: 2000 },
+        ],
+      }),
+      [
+        campaign({ id: "c-a", offerId: "offer-a" }),
+        campaign({ id: "c-b", status: "stopped", funnelKey: "website_purchases", featureSlug: "google-ads", offerId: "offer-b" }),
+      ],
+    );
+
+    expect(result.configuredDailyBudgetCents).toBe(
+      result.offers.reduce((s, o) => s + o.configuredDailyBudgetCents, 0),
+    );
+    expect(result.runningDailyBudgetCents).toBe(
+      result.offers.reduce((s, o) => s + o.runningDailyBudgetCents, 0),
+    );
+    expect(result.runningDailyBudgetCents).toBe(4000);
+  });
+});


### PR DESCRIPTION
## Why

Of the money a brand has configured, how much can actually be spent today? Only billing-service knows what each ceiling is worth; only campaign-service knows whether a campaign exists behind it and whether it is ongoing. Consumers read billing's brand total instead — the sum of every configured ceiling regardless of what runs — so the staff MRR figure reads ~28% high ($138/day configured across 9 brands, ~$25 of it on funnels whose campaign is stopped or never created; two brands have never had a campaign). The dashboard's browser-side join is duplicated in one app, absent in the other, and unreachable from features-service.

## What

- `GET /brands/:brandId/spendable-budget` — both figures for one (org, brand): `configuredDailyBudgetCents` and `runningDailyBudgetCents`. Both always served, so a paused campaign's settings screen still shows what the customer set.
- Decomposed in the same response — `offers[]`, `campaigns[]`, `rows[]` (each row names the campaign behind it and whether it runs). No consumer sums anything; no second request.
- `POST /brands/spendable-budget` — up to 500 (org, brand) pairs for a fleet-wide staff audit, same computation as the per-brand route.
- Exactly one billing grain is counted (offer → channel → funnel → brand pot); the coarser ones are billing's own sums.
- Offer-less ceilings (most of production) count as running when a campaign on the same funnel and channel is ongoing, and are filed under that campaign's offer. Matching mirrors billing's own `channelCeilingCents` / `offerCeilingCents` rules.
- Fail loud: 502 per-brand, named `unavailable` entries with no figures on the fleet route.

## Tests

710 passing (54 files) — 10 new unit tests on the computation, 6 new integration tests on both routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)