### PR TITLE
hotfix: A funded channel the customer operates gets its campaign, without a workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,51 @@ work ONE funnel through BOTH, and each is a campaign of its own.
   stopped campaigns funding may resume — is UNCHANGED and applies per campaign, so it applies per
   pair without a special case. (Set 2026-08-18.)
 
+## A channel the CUSTOMER operates gets its campaign with NO workflow — the absence of a DAG is the statement
+
+A sales chain is sold LEG BY LEG, and the legs the platform does not automate are performed by a
+human at the customer's side: they work the replies, they run the meeting, they close the deal.
+There is no DAG for that and there must not be one — the work happens off-platform and the customer
+reports what happened, lead by lead (declared per lead against lead-service). So provisioning's rule
+"a channel with no active workflow is not provisioned, because a campaign with no DAG would sit
+ongoing and produce nothing" is right for a channel the PLATFORM operates and wrong for one the
+CUSTOMER operates, where funding used to produce nothing at all, forever, with nothing erroring.
+
+- **WHO operates a channel is features-service's statement, asked and never held.** Its public
+  acquisition-channel catalogue (`GET /public/channels` -> `channels[].operatedBy`,
+  `src/lib/channel-operator-client.ts`) publishes `platform` | `customer` for every channel, and a
+  customer-operated one states a daily operating cost of 0 because the platform spends nothing on
+  it. No list of manual slugs exists here and none is to be introduced: the ninth customer-operated
+  channel published upstream works with no change in this repo. `tests/unit/no-legacy.test.ts` fails
+  on such a literal in src and on a second reader of `operatedBy`.
+- **The read carries NO identity, because that path carries none** — the marketing site is generated
+  from the same catalogue. It is made at most once per provisioning pass, and only when a pair
+  actually needs deciding.
+- **A slug the catalogue does not publish, and a catalogue that cannot be READ, both answer
+  "platform"** — i.e. today's behaviour exactly. That direction is deliberate in both halves: an
+  outage of this read must never stop a platform channel being provisioned, and it must never stand
+  up a workflow-less campaign on a guess. The customer-operated pair waits for the next sweep, and
+  the failure warns rather than passing in silence.
+- **`campaigns.workflow_slug` is NULLABLE (migration 0054)**, and NULL means "this campaign has no
+  DAG". Inventing a no-op workflow to satisfy the old NOT NULL would be a second, false
+  representation of the same fact — the same translation table this service keeps deleting. The
+  create/update API still REQUIRES a slug: only provisioning writes NULL, for a channel the
+  catalogue states the customer operates.
+- **Such a campaign is never scheduled, never triggered and never spends.** The scheduler states it
+  on the ROW, not on a list of slugs: `workflow_slug IS NOT NULL` on the due-campaign claim, on
+  `claimStuckCampaigns` (whose `(ongoing, nextRunAt=NULL)` is this campaign's PERMANENT resting
+  state — nothing is stuck) and on the cadence snapshot (or it would read as in-flight and pin the
+  60s active cadence forever). Never claimed means never planned, so it takes no turn either.
+  `/start-run` 400s for it, and activation makes it ongoing and triggers nothing.
+- **It exists so the customer's own work has something to be attributed to**: a budget line, a scope
+  for stats, a thing they can pause. It holds its own (org, brand, funnel, channel) identity, so it
+  never collides with the platform campaign working the same funnel.
+- **A PLATFORM channel with no active workflow still produces nothing, with the same log line.**
+  Nothing else changed: the funnels a channel may sell, the funding, the ceilings, the turn planner,
+  the identity and the existing campaigns are all untouched.
+
+(Set 2026-08-27.)
+
 ## Google Ads is a channel like any other — PAID REACH joins the funnel-funded family, and only the three behaviours that are genuinely about MAILBOXES stay outbound-only
 
 A channel IS a features-service feature slug, so the first paid-reach channel is one line in the

--- a/drizzle/0054_campaign_workflow_slug_nullable.sql
+++ b/drizzle/0054_campaign_workflow_slug_nullable.sql
@@ -1,0 +1,19 @@
+-- A campaign whose channel the CUSTOMER operates has NO workflow, and that absence is the point.
+--
+-- The product sells a sales chain one leg at a time. The legs the platform does not automate are
+-- performed by a human at the customer's side: they work the replies, they run the meeting, they
+-- close the deal. There is no DAG for that and there must not be one — the work happens
+-- off-platform and the customer reports what happened, lead by lead. features-service publishes
+-- WHO operates each channel (`operatedBy` on the public acquisition-channel catalogue), which is
+-- what tells that case apart from a platform channel nothing can execute yet.
+--
+-- So `workflow_slug` stops being NOT NULL. NULL states "this campaign has no DAG" rather than
+-- naming an invented no-op workflow, which would be a second, false representation of the same
+-- fact. Such a campaign is never claimed by the scheduler, never triggered and never spends: it
+-- exists so the customer's own work has something to be attributed to — a budget line, a scope
+-- for stats, a thing they can pause.
+--
+-- Nothing is written by this migration: every existing row keeps the slug it states, and the
+-- create/update API still requires one. Idempotent — dropping a NOT NULL that is already dropped
+-- is a no-op in Postgres.
+ALTER TABLE "campaigns" ALTER COLUMN "workflow_slug" DROP NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1777800000000,
       "tag": "0053_null_inert_sales_max_budgets",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1777900000000,
+      "tag": "0054_campaign_workflow_slug_nullable",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -42,7 +42,8 @@
             "type": "string"
           },
           "workflowSlug": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "brandIds": {
             "type": "array",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,8 +14,15 @@ export const campaigns = pgTable(
 
     name: text("name").notNull(),
 
-    // Workflow slug — resolved by workflow-service, passed at campaign creation
-    workflowSlug: text("workflow_slug").notNull(),
+    // Workflow slug — resolved by workflow-service, passed at campaign creation.
+    //
+    // NULL means this campaign has NO DAG, and that is a statement rather than a gap: its channel
+    // is operated by the CUSTOMER's own team (they work the replies, run the meeting, close the
+    // deal), so the work happens off-platform and there is nothing here to execute. Such a
+    // campaign is never claimed, never triggered and never spends — it exists so the customer's
+    // own work has something to be attributed to. Every platform-operated campaign states one,
+    // and the create/update API still requires one.
+    workflowSlug: text("workflow_slug"),
 
     // Brand IDs from brand-service (CSV in x-brand-id header, stored as array)
     // Nullable initially, populated when brands are created/found in brand-service

--- a/src/lib/campaign-resume.ts
+++ b/src/lib/campaign-resume.ts
@@ -125,7 +125,13 @@ async function resumeOneCampaign(
     featureSlug,
   };
 
-  const funding = await fundingCeiling(campaign, brandId, identity);
+  const funding = await fundingCeiling(
+    campaign,
+    brandId,
+    // runs-client states the header as optional; a campaign with no workflow simply does not send
+    // one, which is what `undefined` means on the wire.
+    { ...identity, workflowSlug: identity.workflowSlug ?? undefined },
+  );
   if (funding !== null) return skip(campaign, funding);
 
   const serveableAudienceIds = await serveableAudienceIdsForCampaign(campaign, featureSlug, identity);

--- a/src/lib/channel-operator-client.ts
+++ b/src/lib/channel-operator-client.ts
@@ -1,0 +1,70 @@
+/**
+ * WHO OPERATES AN ACQUISITION CHANNEL — features-service's statement, asked rather than held.
+ *
+ * A chain is sold LEG BY LEG, and the legs the platform does not automate are performed by a human
+ * at the CUSTOMER's side: they work the replies, they run the meeting, they close the deal. There
+ * is no DAG for that and there must not be one — the work happens off-platform and the customer
+ * reports what happened, lead by lead. So "this channel has no active workflow" means two opposite
+ * things depending on who operates it: for a PLATFORM channel it means nothing can run it yet
+ * (skip, exactly as before), and for a CUSTOMER-operated one it is the point.
+ *
+ * features-service publishes the answer on its PUBLIC acquisition-channel catalogue, which is why
+ * this read carries no identity at all: no customer identity ever appears on that path (the
+ * marketing site is generated from it). It is also why nothing here holds a list of manual slugs —
+ * a ninth customer-operated channel published upstream works with no change in this repo, the same
+ * posture this service holds for the goal, the funnel and the channel vocabularies.
+ *
+ * Contract (features-service): GET /public/channels (no auth, no identity)
+ *   -> { channels: [{ slug, operatedBy: "platform" | "customer", ... }], steps: [...] }
+ *
+ * A channel the catalogue does not publish, and a catalogue that cannot be READ, both resolve to
+ * "platform" at the call site — i.e. to today's behaviour exactly. That direction is deliberate:
+ * an outage of this read must never stop a platform channel being provisioned, and it must never
+ * stand up a workflow-less campaign on a guess. The customer-operated pair simply waits for the
+ * next sweep.
+ */
+export type ChannelOperator = "platform" | "customer";
+
+export type ChannelCatalogueRead =
+  | { ok: true; operatorBySlug: Map<string, ChannelOperator> }
+  | { ok: false; detail: string };
+
+export async function fetchChannelOperators(): Promise<ChannelCatalogueRead> {
+  const baseUrl = process.env.FEATURES_SERVICE_URL;
+  if (!baseUrl) {
+    return { ok: false, detail: "FEATURES_SERVICE_URL not configured" };
+  }
+
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/$/, "")}/public/channels`);
+    if (!res.ok) {
+      let body = "";
+      try {
+        body = (await res.text()).slice(0, 200);
+      } catch {
+        body = "";
+      }
+      return { ok: false, detail: `HTTP ${res.status}${body ? ` ${body}` : ""}` };
+    }
+
+    const data = await res.json() as {
+      channels?: Array<{ slug?: unknown; operatedBy?: unknown }>;
+    };
+    if (!Array.isArray(data.channels)) {
+      return { ok: false, detail: "response states no channels array" };
+    }
+
+    const operatorBySlug = new Map<string, ChannelOperator>();
+    for (const channel of data.channels) {
+      if (typeof channel?.slug !== "string" || channel.slug.length === 0) continue;
+      // Only the two published values are read. A third one this service has never heard of is
+      // NOT guessed at: it is left out of the map, so the call site treats that channel exactly
+      // as it treats one the catalogue does not publish.
+      if (channel.operatedBy !== "platform" && channel.operatedBy !== "customer") continue;
+      operatorBySlug.set(channel.slug, channel.operatedBy);
+    }
+    return { ok: true, operatorBySlug };
+  } catch (err) {
+    return { ok: false, detail: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/lib/downstream-headers.ts
+++ b/src/lib/downstream-headers.ts
@@ -4,12 +4,17 @@ export interface DownstreamIdentity {
   runId: string;
   campaignId: string;
   brandId: string;
-  workflowSlug: string;
+  /**
+   * The DAG this campaign runs, when it runs one. NULL for a campaign whose channel the CUSTOMER
+   * operates: the work happens off-platform, so there is no workflow to name and the header is
+   * simply not sent rather than carrying an invented value.
+   */
+  workflowSlug: string | null;
   featureSlug: string;
 }
 
 export function buildServiceHeaders(apiKey: string, identity: DownstreamIdentity): Record<string, string> {
-  return {
+  const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "x-api-key": apiKey,
     "x-org-id": identity.orgId,
@@ -17,7 +22,8 @@ export function buildServiceHeaders(apiKey: string, identity: DownstreamIdentity
     "x-run-id": identity.runId,
     "x-brand-id": identity.brandId,
     "x-campaign-id": identity.campaignId,
-    "x-workflow-slug": identity.workflowSlug,
     "x-feature-slug": identity.featureSlug,
   };
+  if (identity.workflowSlug) headers["x-workflow-slug"] = identity.workflowSlug;
+  return headers;
 }

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -10,6 +10,11 @@ import {
 } from "./funnel-budget-client.js";
 import { fetchFeatureSalesFunnels, type FeatureSalesFunnelsRead } from "./feature-sales-funnels-client.js";
 import { fetchActiveWorkflowSlugForFeature, type ActiveWorkflowRead } from "./feature-workflow-client.js";
+import {
+  fetchChannelOperators,
+  type ChannelCatalogueRead,
+  type ChannelOperator,
+} from "./channel-operator-client.js";
 import { buildProvisioningIdentity, type ProvisioningIdentity } from "./provisioning-identity.js";
 import type { SalesFunnelKey } from "./sales-funnel-vocabulary.js";
 import {
@@ -63,7 +68,12 @@ export interface ClaimedFunnelCampaign {
    * minted uuid, which runs-service refuses.
    */
   parentRunId: string | null;
-  workflowSlug: string;
+  /**
+   * The DAG this campaign runs. NULL for a campaign whose channel the CUSTOMER operates — there is
+   * none, on purpose. The scheduler never claims such a row, so one never reaches the planner; the
+   * type states the absence rather than pretending every campaign has a workflow.
+   */
+  workflowSlug: string | null;
   brandIds: string[] | null;
   featureSlug: string | null;
   funnelKey: string | null;
@@ -196,7 +206,7 @@ async function planOneBrand(
     userId: seed.createdByUserId ?? undefined,
     campaignId: seed.id,
     brandId,
-    workflowSlug: seed.workflowSlug,
+    workflowSlug: seed.workflowSlug ?? undefined,
   };
 
   const heldAt = new Date(now.getTime() + FUNDING_RECHECK_MS);
@@ -527,6 +537,26 @@ async function ensureFundedFunnelCampaigns({
   const sellableByFeature = new Map<string, FeatureSalesFunnelsRead>();
   const workflowByFeature = new Map<string, ActiveWorkflowRead>();
 
+  // WHO operates a channel — one read for the WHOLE catalogue, made at most once per pass and
+  // only when a pair actually needs deciding. A slug the catalogue does not publish, and a
+  // catalogue that cannot be read, both answer "platform", which IS today's behaviour: a read
+  // that is down must never stop a platform channel being provisioned, and must never stand up a
+  // workflow-less campaign on a guess. The customer-operated pair waits for the next sweep, and
+  // the failure says so rather than passing in silence.
+  let catalogue: ChannelCatalogueRead | null = null;
+  const operatorFor = async (slug: string): Promise<ChannelOperator> => {
+    if (catalogue === null) {
+      catalogue = await fetchChannelOperators();
+      if (!catalogue.ok) {
+        console.warn(
+          `[campaign-service] Could not read features-service's channel catalogue (brand ${brandId}, org ${seed.orgId}) — ${catalogue.detail}. Every channel is treated as platform-operated this sweep, which is the behaviour that predates customer-operated channels.`,
+        );
+      }
+    }
+    if (!catalogue.ok) return "platform";
+    return catalogue.operatorBySlug.get(slug) ?? "platform";
+  };
+
   // The (org, brand, acquisition channel) triples a funnel campaign is provisioned for on this
   // tick. Collected rather than acted on inline BECAUSE the existing-campaign check below returns
   // early with `continue`: a brand whose twin already exists — which is precisely the brand this
@@ -622,8 +652,21 @@ async function ensureFundedFunnelCampaigns({
     // A workflow belongs to a FEATURE, so the seed's slug is only right for the seed's own
     // channel. Every other channel is asked for its own; a channel with no active workflow is not
     // provisioned, because a campaign with no DAG to run would sit ongoing and produce nothing.
+    //
+    // That reasoning is right for a channel the PLATFORM operates and wrong for one the CUSTOMER
+    // operates: their own founder or team works the replies, runs the meeting and closes the deal,
+    // and there is no DAG for that — the absence is the point, not a gap waiting on a dynasty. So
+    // WHO operates the channel is asked first (features-service's public catalogue, never a list
+    // of slugs here), and a customer-operated channel gets its campaign with NO workflow at all.
     let workflowSlug: string | null = seed.workflowSlug;
-    if (featureSlug !== seed.featureSlug) {
+    const customerOperated =
+      featureSlug !== seed.featureSlug && (await operatorFor(featureSlug)) === "customer";
+    if (customerOperated) {
+      // The work is off-platform, so there is nothing to run and nothing to ask workflow-service
+      // about. The campaign exists so the customer's own work has something to be attributed to:
+      // a budget line, a scope for stats, a thing they can pause.
+      workflowSlug = null;
+    } else if (featureSlug !== seed.featureSlug) {
       if (!workflowByFeature.has(featureSlug)) {
         workflowByFeature.set(
           featureSlug,
@@ -641,7 +684,7 @@ async function ensureFundedFunnelCampaigns({
       }
       workflowSlug = read.workflowSlug;
     }
-    if (!workflowSlug) {
+    if (!workflowSlug && !customerOperated) {
       console.log(
         `[campaign-service] Not provisioning ${featureSlug} for funnel ${f.funnelKey} (brand ${brandId}) — workflow-service states no active workflow for that channel`,
       );

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -90,6 +90,12 @@ export async function reRunDueCampaigns(): Promise<number> {
     .where(
       and(
         eq(campaigns.status, "ongoing"),
+        // A campaign with no workflow has no DAG to run — its channel is operated by the
+        // CUSTOMER's own team, off-platform. It is never claimed, so it never takes a turn, never
+        // triggers an execution and never spends. It exists to be a scope for the work they do
+        // themselves. NOT a filter on a list of slugs: the row states the absence, and the
+        // catalogue decided it at provisioning time.
+        isNotNull(campaigns.workflowSlug),
         isNotNull(campaigns.nextRunAt),
         lte(campaigns.nextRunAt, now),
       ),
@@ -188,10 +194,11 @@ export async function reRunDueCampaigns(): Promise<number> {
             runId,
             campaignId: campaign.id,
             brandId: brandIdCsv,
-            workflowSlug: campaign.workflowSlug,
+            workflowSlug: campaign.workflowSlug!,
             featureSlug,
           },
-          fallbackSlug: campaign.workflowSlug,
+          // The claim above filters out the workflow-less rows, so this is always a real slug.
+          fallbackSlug: campaign.workflowSlug!,
           // Price the pick on the funnel the campaign STATES — the only word that separates the
           // two meeting funnels. A campaign that states one is never goal-arbitrated.
           funnelKey: campaign.funnelKey,
@@ -236,6 +243,10 @@ export async function claimStuckCampaigns(): Promise<number> {
   const ongoingCampaigns = await db.query.campaigns.findMany({
     where: and(
       eq(campaigns.status, "ongoing"),
+      // (status=ongoing, nextRunAt=NULL) is the PERMANENT resting state of a campaign whose
+      // channel the customer operates — there is nothing to run, so nothing is stuck. Claiming it
+      // here would set nextRunAt=now every tick forever for a campaign that must never fire.
+      isNotNull(campaigns.workflowSlug),
       isNull(campaigns.nextRunAt),
     ),
     columns: { id: true, orgId: true },
@@ -313,7 +324,9 @@ async function loadOngoingSnapshot(): Promise<Array<{ nextRunAt: Date | null }>>
     // A held campaign carries a nextRunAt on the funding cadence rather than being absent from
     // this snapshot, so a brand that funds nothing sleeps for ten minutes at a time instead of
     // pinning the 60s active cadence — and is still looked at without anyone asking.
-    where: eq(campaigns.status, "ongoing"),
+    // A campaign with no workflow rests at nextRunAt=NULL forever. Counting it would read as
+    // "something is in flight" and pin the 60s active cadence for a service with nothing to do.
+    where: and(eq(campaigns.status, "ongoing"), isNotNull(campaigns.workflowSlug)),
     columns: { nextRunAt: true },
   });
 }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -265,7 +265,11 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
         }, req.headers).catch(() => {});
       }
 
-      executeCampaignWorkflow(updated.workflowSlug, {
+      // Every campaign created or updated through this route states a workflow (the request
+      // schema requires one), so this is the ordinary path. The guard is what keeps a
+      // workflow-less row — a channel the customer operates, provisioned with no DAG — from ever
+      // being handed to workflow-service.
+      if (updated.workflowSlug) executeCampaignWorkflow(updated.workflowSlug, {
         campaignId: updated.id,
         orgId: req.orgId!,
         brandId: (updated.brandIds ?? []).join(","),
@@ -341,7 +345,7 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
       brandProfileId: campaign.brandProfileId,
       audienceId: campaign.audienceId,
     };
-    executeCampaignWorkflow(campaign.workflowSlug, workflowInputs).catch((err) => {
+    if (campaign.workflowSlug) executeCampaignWorkflow(campaign.workflowSlug, workflowInputs).catch((err) => {
       console.error(`[campaign-service] Failed to trigger initial workflow for campaign ${campaign.id}:`, err);
     });
 
@@ -465,7 +469,10 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
         brandProfileId: updated.brandProfileId,
         audienceId: updated.audienceId,
       };
-      executeCampaignWorkflow(updated.workflowSlug, activateInputs).catch((err) => {
+      // A campaign whose channel the customer operates carries no workflow: activating it makes
+      // it ongoing (a live scope for their own work) and triggers nothing, because there is
+      // nothing to trigger.
+      if (updated.workflowSlug) executeCampaignWorkflow(updated.workflowSlug, activateInputs).catch((err) => {
         console.error(`[campaign-service] Failed to trigger workflow for campaign ${id}:`, err);
       });
       // Campaign just activated (status → ongoing) → wake the scheduler from idle.

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -92,7 +92,7 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
       runId: req.runId,
       brandId: resolvedBrandIds.join(","),
       brandIds: resolvedBrandIds,
-      workflowSlug: req.workflowSlug || campaign.workflowSlug,
+      workflowSlug: req.workflowSlug || campaign.workflowSlug || undefined,
       featureSlug: req.featureSlug || campaign.featureSlug || undefined,
       status: campaign.status,
       maxBudgetDailyUsd: campaign.maxBudgetDailyUsd,
@@ -205,6 +205,14 @@ router.post("/start-run", requireApiKey, requirePipelineHeaders, trackingHeaders
     const brandIdCsv = campaign.brandIds!.join(",");
     const primaryBrandId = campaign.brandIds[0];
     const workflowSlug = req.workflowSlug || campaign.workflowSlug;
+    if (!workflowSlug) {
+      // A campaign whose channel the CUSTOMER operates runs no DAG, so nothing should ever have
+      // reached this route for it — the scheduler never claims it and never triggers it. Fail
+      // loud rather than minting a slug or starting a run nothing can execute.
+      return res.status(400).json({
+        error: `Campaign ${campaignId} states no workflow — its acquisition channel is operated by the customer, so it has no DAG to run`,
+      });
+    }
 
     // Re-decide the priority audience for THIS run with fresh cost data, BEFORE creating
     // the run row — so the chosen audience is stamped on campaign-service's own run AND

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -140,7 +140,9 @@ router.get("/stats", requireApiKey, validateQuery(StatsFilterQuery), async (req,
       let key: string;
 
       if (groupBy === "workflowSlug") {
-        key = c.workflowSlug;
+        // A campaign whose channel the customer operates runs no workflow, and groups with the
+        // other rows that state none rather than inventing a slug for it.
+        key = c.workflowSlug || "__null__";
       } else {
         // featureSlug
         key = c.featureSlug || "__null__";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -28,7 +28,11 @@ export const CampaignSchema = z.object({
   createdByUserId: z.string().nullable(),
   parentRunId: z.string().nullable(),
   name: z.string(),
-  workflowSlug: z.string(),
+  // NULL for a campaign whose acquisition channel the CUSTOMER operates: the work is performed by
+  // their own team off-platform, so there is no DAG and none is invented. Such a campaign is never
+  // scheduled and never runs — it is a budget line, a scope for stats and a thing they can pause.
+  // Every platform-operated campaign states one, and CreateCampaignBody still requires one.
+  workflowSlug: z.string().nullable(),
   brandIds: z.array(z.string().uuid()).nullable(),
   featureSlug: z.string().nullable(),
   featureInputs: z.record(z.string(), z.unknown()).nullable(),

--- a/tests/unit/channel-operator-client.test.ts
+++ b/tests/unit/channel-operator-client.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { fetchChannelOperators } from "../../src/lib/channel-operator-client.js";
+
+/**
+ * WHO operates a channel is features-service's statement, read from its PUBLIC catalogue. These
+ * tests pin the read to the shape the DEPLOYED service serves (`GET /public/channels` ->
+ * `{ channels: [{ slug, operatedBy }] }`, verified on the api-registry contract) — a client that
+ * only ever agrees with its own mock is what took the sales-funnels read out of production for
+ * its whole life.
+ */
+describe("fetchChannelOperators", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.FEATURES_SERVICE_URL = "https://features.test.local";
+  });
+
+  it("reads operatedBy per channel from the public catalogue", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        channels: [
+          { slug: "sales-cold-email-outreach", operatedBy: "platform" },
+          { slug: "in-house-meeting-booking", operatedBy: "customer" },
+        ],
+        steps: [],
+      }),
+    });
+
+    const read = await fetchChannelOperators();
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.operatorBySlug.get("sales-cold-email-outreach")).toBe("platform");
+    expect(read.operatorBySlug.get("in-house-meeting-booking")).toBe("customer");
+  });
+
+  it("carries NO identity — no customer identity ever appears on that path", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ channels: [], steps: [] }) });
+    await fetchChannelOperators();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe("https://features.test.local/public/channels");
+    expect(init).toBeUndefined();
+  });
+
+  it("does not answer for a channel it has never been told about", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ channels: [{ slug: "google-ads", operatedBy: "platform" }], steps: [] }),
+    });
+    const read = await fetchChannelOperators();
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    // An unpublished slug is absent rather than defaulted here: the CALLER decides what an
+    // unknown channel means (platform, i.e. today's behaviour), and it says so where it decides.
+    expect(read.operatorBySlug.has("some-unpublished-channel")).toBe(false);
+  });
+
+  it("leaves out an operator value it has never heard of rather than guessing", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        channels: [{ slug: "partner-run-thing", operatedBy: "partner" }],
+        steps: [],
+      }),
+    });
+    const read = await fetchChannelOperators();
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.operatorBySlug.has("partner-run-thing")).toBe(false);
+  });
+
+  it("says a failure is a failure — never an empty catalogue", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 503, text: async () => "unavailable" });
+    const read = await fetchChannelOperators();
+    expect(read.ok).toBe(false);
+    if (read.ok) return;
+    expect(read.detail).toContain("503");
+  });
+
+  it("refuses a payload that states no channels array", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ steps: [] }) });
+    const read = await fetchChannelOperators();
+    expect(read.ok).toBe(false);
+  });
+
+  it("says so when features-service is not configured", async () => {
+    delete process.env.FEATURES_SERVICE_URL;
+    const read = await fetchChannelOperators();
+    expect(read.ok).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -89,6 +89,9 @@ import {
 const SALES = "sales-cold-email-outreach";
 const FEEDBACK = "feedback-request-cold-email-outreach";
 const GOOGLE_ADS = "google-ads";
+// A channel the CUSTOMER's own team operates: they work the replies and book the meeting
+// themselves. features-service publishes who operates each channel; nothing here holds a list.
+const IN_HOUSE_BOOKING = "in-house-meeting-booking";
 const ANCESTOR_RUN_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -156,6 +159,26 @@ function mockDeclaredFunnels(funnels: Array<{ funnelKey: string; active?: boolea
       })),
     }),
   });
+}
+
+/**
+ * features-service's PUBLIC acquisition-channel catalogue — the one statement of WHO operates a
+ * channel. Every slug the tests use is platform-operated except the in-house one, which is what
+ * the provisioning tells the two cases apart by; nothing in the service holds that list.
+ */
+function catalogueResponse() {
+  return {
+    ok: true,
+    json: async () => ({
+      channels: [
+        { slug: SALES, operatedBy: "platform" },
+        { slug: FEEDBACK, operatedBy: "platform" },
+        { slug: GOOGLE_ADS, operatedBy: "platform" },
+        { slug: IN_HOUSE_BOOKING, operatedBy: "customer" },
+      ],
+      steps: [],
+    }),
+  };
 }
 
 /** Run something and return everything it said on console.warn, joined. */
@@ -260,6 +283,7 @@ describe("planFunnelTurns", () => {
           }),
         };
       }
+      if (url.includes("/public/channels")) return catalogueResponse();
       throw new Error(`unexpected fetch in test: ${url}`);
     });
     mockListRuns.mockResolvedValue({ runs: [] });
@@ -509,6 +533,7 @@ describe("planFunnelTurns", () => {
     mockFindFirst.mockResolvedValue(undefined);
     mockFetch.mockImplementation(async (input: URL | string) => {
       const url = String(input);
+      if (url.includes("/public/channels")) return catalogueResponse();
       if (url.includes("/features/")) {
         return { ok: true, json: async () => ({ feature: { slug: new URL(url).pathname.split("/features/")[1], salesFunnels: [...SALES_FUNNEL_KEYS] } }) };
       }
@@ -517,7 +542,8 @@ describe("planFunnelTurns", () => {
 
     await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
 
-    // A campaign with no DAG to run would sit ongoing and produce nothing forever.
+    // A campaign with no DAG to run would sit ongoing and produce nothing forever — for a channel
+    // the PLATFORM operates, which is what the catalogue says of this one.
     expect(mockInsertValues).not.toHaveBeenCalled();
   });
 
@@ -988,6 +1014,7 @@ describe("planFunnelTurns", () => {
           }),
         };
       }
+      if (url.includes("/public/channels")) return catalogueResponse();
       throw new Error(`unexpected fetch in test: ${url}`);
     });
     mockFunnelBudgets(
@@ -1122,5 +1149,108 @@ describe("planFunnelTurns", () => {
 
     expect(deferred.has("c-form")).toBe(false); // the emptiest relative to its own ceiling
     expect(deferred.get("c-purchases")?.getTime()).toBe(now.getTime() + FUNNEL_TURN_DEFER_MS);
+  });
+  // ── Customer-operated channels: a funded pair with NO workflow, on purpose ────────────────────
+  // Some legs of a chain are performed by a human at the CUSTOMER's side — they work the replies,
+  // run the meeting, close the deal. There is no DAG for that and there must not be one, so the
+  // campaign is provisioned with no workflow at all. features-service's public catalogue is what
+  // tells that case apart from a platform channel nothing can execute yet; no list lives here.
+
+  it("gives a funded pair on a CUSTOMER-OPERATED channel its campaign, with no workflow", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: IN_HOUSE_BOOKING, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined); // the pair has no campaign yet
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(1);
+    const inserted = mockInsertValues.mock.calls[0][0];
+    expect(inserted.featureSlug).toBe(IN_HOUSE_BOOKING);
+    expect(inserted.funnelKey).toBe("sales_meetings_from_conversation");
+    // NULL, never a seed slug and never an invented no-op workflow: the absence is the statement.
+    expect(inserted.workflowSlug).toBeNull();
+    expect(inserted.status).toBe("ongoing");
+    // Its own identity, so it never collides with the cold-email campaign of the same funnel.
+    expect(inserted.acquisitionChannel).toBe("in_house_meeting_booking");
+  });
+
+  it("never asks workflow-service about a customer-operated channel — there is nothing to run", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: IN_HOUSE_BOOKING, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    const asked = mockFetch.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(asked.some((u) => u.includes("/workflows"))).toBe(false);
+    expect(asked.some((u) => u.includes("/public/channels"))).toBe(true);
+  });
+
+  it("a PLATFORM channel with no active workflow still produces nothing, saying exactly that", async () => {
+    mockFetch.mockImplementation(async (input: URL | string) => {
+      const url = String(input);
+      if (url.includes("/public/channels")) return catalogueResponse();
+      if (url.includes("/features/")) {
+        return { ok: true, json: async () => ({ feature: { slug: new URL(url).pathname.split("/features/")[1], salesFunnels: [...SALES_FUNNEL_KEYS] } }) };
+      }
+      if (url.includes("/workflows")) return { ok: true, json: async () => ({ workflows: [] }) };
+      throw new Error(`unexpected fetch in test: ${url}`);
+    });
+    mockFunnelBudgets(
+      [{ funnelKey: "visit_signup", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "visit_signup", featureSlug: GOOGLE_ADS, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "website_purchases" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    const said: string[] = [];
+    const log = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      said.push(args.map(String).join(" "));
+    });
+    try {
+      await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(said.join("\n")).toContain("workflow-service states no active workflow for that channel");
+  });
+
+  it("an unreadable catalogue provisions nothing new for that channel, and says so", async () => {
+    mockFetch.mockImplementation(async (input: URL | string) => {
+      const url = String(input);
+      if (url.includes("/public/channels")) return { ok: false, status: 503, text: async () => "down" };
+      if (url.includes("/features/")) {
+        return { ok: true, json: async () => ({ feature: { slug: new URL(url).pathname.split("/features/")[1], salesFunnels: [...SALES_FUNNEL_KEYS] } }) };
+      }
+      if (url.includes("/workflows")) return { ok: true, json: async () => ({ workflows: [] }) };
+      throw new Error(`unexpected fetch in test: ${url}`);
+    });
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: IN_HOUSE_BOOKING, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    const warnings = await captureWarnings(() =>
+      planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]),
+    );
+
+    // Treated as platform-operated, i.e. today's behaviour: workflow-service is asked, has no
+    // dynasty for it, and nothing is stood up on a guess. The failure is never silent.
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(warnings).toContain("channel catalogue");
   });
 });

--- a/tests/unit/no-legacy.test.ts
+++ b/tests/unit/no-legacy.test.ts
@@ -52,6 +52,47 @@ describe('No Legacy Patterns - CRITICAL', () => {
     ).toHaveLength(0);
   });
 
+  it('should NOT hold a list of customer-operated channels', () => {
+    // WHO operates a channel is features-service's statement, published on its public catalogue and
+    // read per sweep. A slug named here would be a second copy of one product fact: the ninth
+    // customer-operated channel published upstream must work with no change in this repo, exactly
+    // as the funnels a channel may be sold through are asked rather than held.
+    const files = getAllTsFiles(srcDir);
+    const violations: { file: string; line: number; code: string }[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+      content.split('\n').forEach((line, index) => {
+        // The published customer-operated channels of the day this shipped. Any of them appearing
+        // as a literal in source means the catalogue is being second-guessed.
+        if (/["'`](in-house-[a-z-]+|founder-led-[a-z-]+|managed-[a-z-]+)["'`]/.test(line)) {
+          violations.push({
+            file: path.relative(srcDir, file),
+            line: index + 1,
+            code: line.trim().substring(0, 80),
+          });
+        }
+      });
+    }
+
+    expect(
+      violations,
+      `A channel's operator is asked, never held:\n${violations.map(v => `  ${v.file}:${v.line}\n    ${v.code}`).join('\n')}`
+    ).toHaveLength(0);
+  });
+
+  it('should read operatedBy in exactly ONE place', () => {
+    // One reader, one contract. A second one drifts the day features-service publishes a third
+    // operator, and the fail-soft decision ("unknown means platform, i.e. today's behaviour")
+    // has to be made once or it is not a rule.
+    const files = getAllTsFiles(srcDir);
+    const readers = files
+      .filter((f) => /operatedBy/.test(fs.readFileSync(f, 'utf-8')))
+      .map((f) => path.relative(srcDir, f));
+
+    expect(readers).toEqual(['lib/channel-operator-client.ts']);
+  });
+
   it('should NOT read a goal off brand-service beyond the brand-level currentGoal', () => {
     // brand-service retired the goal set: the funnel is the only word it emits for what a brand
     // sells. Reading a goal off a DECLARED FUNNEL is what silently stopped every funnel campaign

--- a/tests/unit/offer-grain-funnels.test.ts
+++ b/tests/unit/offer-grain-funnels.test.ts
@@ -189,6 +189,9 @@ beforeEach(() => {
         }),
       };
     }
+    if (url.includes("/public/channels")) {
+      return { ok: true, json: async () => ({ channels: [], steps: [] }) };
+    }
     throw new Error(`unexpected fetch in test: ${url}`);
   });
   mockListRuns.mockResolvedValue({ runs: [] });

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -507,6 +507,33 @@ describe("Scheduler - reRunDueCampaigns", () => {
   });
 });
 
+describe("Scheduler - a campaign with NO workflow is never scheduled", () => {
+  // Its acquisition channel is operated by the CUSTOMER's own team: they work the replies, run
+  // the meeting, close the deal, off-platform. There is no DAG to run, so the row must never be
+  // claimed, never take a turn and never trigger an execution — it exists to be a budget line, a
+  // scope for stats and a thing they can pause. The claim states that on the row (workflow_slug
+  // IS NOT NULL), never on a list of slugs kept here.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbReturning.mockResolvedValue([]);
+    mockDbFindMany.mockResolvedValue([]);
+    mockListRuns.mockResolvedValue({ runs: [], limit: 50, offset: 0 });
+  });
+
+  it("the due-campaign claim requires a workflow slug", async () => {
+    const { isNotNull } = await import("drizzle-orm");
+    await reRunDueCampaigns();
+    expect(isNotNull).toHaveBeenCalledWith("workflow_slug");
+  });
+
+  it("the stuck-campaign sweep requires a workflow slug", async () => {
+    const { isNotNull } = await import("drizzle-orm");
+    await claimStuckCampaigns();
+    // (ongoing, nextRunAt=NULL) is this campaign's PERMANENT resting state — nothing is stuck.
+    expect(isNotNull).toHaveBeenCalledWith("workflow_slug");
+  });
+});
+
 describe("Scheduler - claimStuckCampaigns", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
Automated by release.sh