### PR TITLE
feat(legs): a campaign is provisioned, found and paced on the leg it is bought for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,32 @@ A gate block caused by a **normal, expected** business state — out of credits,
 
 **Downgrading warn→info is NOT always enough — for a HIGH-FREQUENCY routine event, the right level is NO LOG.** Decide level on TWO axes: (1) expected-vs-fault → picks warn vs info; (2) frequency → a routine event that fires on a per-tick / per-minute cadence for **every** campaign × **every** client (scheduler dedup skips, "still in-flight, rescheduled", poll heartbeats) must not be logged at all — even `info` spams the logs minute-by-minute across the fleet and buries real signal. Ask "how often, across how many entities, does this line fire?" before logging it; if the answer is "every tick for everyone," drop it. The decision is already observable in durable state (persisted `nextRunAt` in DB, trace events) — a per-minute log is the wrong observability mechanism. (Set 2026-06-14, scheduler in-flight skip v0.26.1: first instinct was to downgrade the `console.warn` to `console.log`; Kevin: "tu ne vas pas faire un bip toutes les minutes pour toutes les campagnes, pour tous les clients… ça n'a aucun sens" — the log was deleted, not downgraded.)
 
+## The credit pre-filter is fail-OPEN, and it SAYS which of the two things happened
+
+`readCreditAffordability` (`src/lib/gate-check.ts`, block 3b) allows the run on every failure —
+unconfigured billing, non-2xx, a network throw, a 200 whose body states no `affordable`. That is
+deliberate and stays: a billing blip must not freeze every campaign of every client, and
+chat-service's own authorize is the hard gate downstream. What was wrong is that the fail-open path
+was indistinguishable from an authorization: both reached the run trace as the single word `PASSED`,
+so during an incident nobody could tell "billing said this org can pay" from "billing could not be
+asked and we let it through" — which is the only question worth asking about this gate.
+
+- **The ANSWER travels with the decision.** `GateCheckResult.creditCheck` is
+  `affordable | unaffordable | unreadable` (+ `creditCheckDetail` naming why billing could not be
+  read), and it rides the `gate-check-result` trace event that is **already emitted once per gate
+  check** — no new event, no new log line, no volume at all on the healthy path. The log-discipline
+  rule above is why: a `console` line here would fire per campaign per tick across the fleet.
+- **`unreadable` traces at `warn`, and it is the ONE outcome of this block that does.** A fail-OPEN
+  default-allow is a genuine anomaly (the class this repo reserves warn for); running out of credit
+  is an expected business state and stays `info`.
+- **Nothing about the gate's behaviour changed.** Same fail-open, same `Insufficient credits` block
+  with a 30-minute backoff, same silence on the expected path.
+- **Verified against the 2026-08-29 incident** (org `b645207b`): the last PASSED gate-check was
+  02:52:18 and the first `Insufficient credits` 02:53:28, 70 seconds later, and it has blocked every
+  ~30 minutes since. The pre-filter did its job; the burst of declined charges hours later was
+  Stripe invoice retries, with zero campaign runs behind it. The gap was that no artifact could
+  prove the PASSED verdicts had been authorizations. (Set 2026-08-29, issue #421.)
+
 ## Two distinct "goal" concepts — `activeGoalId` (attribution) vs `campaigns.goal` (pacing). Do NOT conflate.
 
 - **`activeGoalId`** (text, nullable) is an OPAQUE attribution id, threaded downstream as the `x-active-goal-id` header and returned on reads. It **never drives pacing** — no gate-check, workflow pick, or audience selection reads it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -641,10 +641,8 @@ from a positive reply AND from a website visit), so the step a leg lands on does
   so a create that states no leg behaves EXACTLY as it did before the column existed and callers
   state it as they migrate. `PATCH` sets or clears it, which is how a campaign created before it
   could state a leg says which one it buys, without a second campaign.
-- **It decides no MONEY question.** No pacing, funding, gate, provisioning, scheduling,
-  serialization or ranking decision reads it; `idx_campaigns_org_leg` serves the per-leg
-  attribution read it exists for. Nothing about provisioning, the turn planner, the ceilings or the
-  serialization cohorts changed.
+- **It decided no MONEY question at first, and now it decides the FINEST one** — see the section
+  below. `idx_campaigns_org_leg` still serves the per-leg attribution read it was added for.
 - **It IS part of the uniqueness, because a campaign bought for one leg is not the campaign bought
   for another.** `uniq_campaigns_org_brand_funnel_channel` gained `coalesce(leg_key, '')`, and the
   create route's incumbent lookup and its `23505` winner lookup gained the same clause — without
@@ -659,6 +657,64 @@ from a positive reply AND from a website visit), so the step a leg lands on does
   ship; this one adds the leg beside it and changes nothing about what is required at create.
 
 (Set 2026-08-30.)
+
+## The LEG is what a campaign is PROVISIONED, FOUND and PACED on — the sales funnel becomes a way of READING legs
+
+Stating the leg was half of it: the funnel was still what this service provisioned on, keyed its
+existing-campaign lookup on, and asked other services about. A leg belongs to SEVERAL funnels at
+once, so a funnel can never say which of them the customer bought — and a (funnel, channel, offer)
+worked for TWO legs was one provisioning question, one identity and one summed ceiling, i.e. one
+campaign doing two jobs on money funded for two.
+
+- **billing's LEG grain is the finest it stores and the unit ONE campaign is provisioned per**
+  (`legs[]` on `GET /internal/brands/:id/funnel-budgets`: funnel, channel, offer, `legKey`). Every
+  coarser grain billing serves is a SUM of these rows, so nothing is added up here — `fundedPairs`
+  reads `legs` first, falls back to `channels`, then to `funnels`. **A row whose `legKey` is null
+  is a ceiling written before legs existed and provisions a leg-less campaign byte-identically to
+  what the pair grain provisioned for it**, which is why every brand alive today is untouched.
+- **`legCeilingCents` is one notch below `offerCeilingCents`**, in gate-check and in
+  `campaign-funding`, on the one shared precedence: own `dailyBudgetCents` → LEG → offer → pair →
+  funnel → brand pot. Same three answers and the same reasons as every grain above it, so a
+  campaign that states no leg — and a brand whose ceilings name none — answers `none` and paces
+  exactly as it always did. The offer half of the match is billing's own rule, mirrored rather
+  than re-invented. A leg the brand's money is not scoped to is UNFUNDED, never a fallback to the
+  offer or pair figure: that is the whole point of the grain.
+- **WHAT A CHANNEL CAN DO IS ASKED IN THE VOCABULARY OF WHAT WAS BOUGHT.** A pair that states a
+  LEG asks "does this channel perform this leg?" and names NO funnel — features-service publishes
+  every channel's legs as `channels[].stepTransitions[].legKey` on the same public catalogue this
+  pass already reads for who operates them, so one read answers both and the identifier is joined
+  verbatim. A pair that states no leg keeps asking the per-feature FUNNEL question, unchanged: that
+  IS the question for a ceiling written before a campaign could state a leg. An unreadable
+  catalogue provisions nothing for that leg and says so — a funded pair we failed to EVALUATE is
+  not a pair we evaluated and rejected.
+- **The existing-campaign lookup keys on the leg**, so a brand working ONE channel for TWO legs
+  gets two campaigns instead of finding the first one for the second pair and never provisioning
+  it. The insert states the leg, and the deterministic NAME appends it — two legs of one (funnel,
+  channel) would otherwise collide on `uniq_campaigns_org_name` and the second insert would be
+  swallowed as a race. **A leg-less campaign keeps the name it has always had, byte for byte.**
+- **A campaign already doing the work is ADOPTED, never twinned.** When a pair states a leg and no
+  campaign of that leg exists, the LEG-LESS campaign of the same (org, brand, funnel, channel) is
+  that pair's campaign — it has been doing exactly this work since before a campaign could say
+  which leg it was bought for — so the leg is stamped on it. Leaving it alone inserts a twin
+  beside it: two live campaigns doing one job, splitting one identity's history and spending on two
+  ceilings, which is the funnel-less-ancestor recurrence one word along. Nothing else about the row
+  moves (id, status, schedule, spend and history are untouched) and the money is the same money
+  restated at the grain it was funded at. Guarded on the row still stating no leg, so a re-run
+  writes nothing and a race with a live create cannot overwrite it; a `23505` leaves the row alone
+  and says so.
+- **`spendable-budget` counts at the LEG grain too**, or a (funnel, channel, offer) funding two
+  legs would give one campaign the whole summed figure and report the other as running on nothing —
+  a secondary surface contradicting the ceiling the gate actually binds. `legKey` rides on the row
+  and the campaign line; the grain enum gained `leg`.
+- **Nothing about pacing, scheduling or serialization changed.** The turn planner still ranks on
+  spent ÷ own ceiling (that ceiling is simply the leg's when one binds), the cohorts are still the
+  acquisition channel's, the cadences are the same, and no campaign changed id, status, money or
+  history because of this.
+- **The funnel COLUMN stays.** It is still part of the identity index, still what billing's rows
+  and brand-service's declarations are keyed on, and still what a leg-less campaign is provisioned
+  by. Dropping it is a later, separate step once nothing reads it.
+
+(Set 2026-08-31.)
 
 ## The OFFER a campaign sells is brand-service's UUID, carried and never derived
 

--- a/openapi.json
+++ b/openapi.json
@@ -583,6 +583,7 @@
           "grain": {
             "type": "string",
             "enum": [
+              "leg",
               "offer",
               "channel",
               "funnel",
@@ -677,6 +678,10 @@
             "type": "string",
             "nullable": true
           },
+          "legKey": {
+            "type": "string",
+            "nullable": true
+          },
           "configuredDailyBudgetCents": {
             "type": "integer"
           },
@@ -691,6 +696,7 @@
           "funnelKey",
           "featureSlug",
           "offerId",
+          "legKey",
           "configuredDailyBudgetCents",
           "runningDailyBudgetCents"
         ]
@@ -707,6 +713,10 @@
             "nullable": true
           },
           "offerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "legKey": {
             "type": "string",
             "nullable": true
           },
@@ -733,6 +743,7 @@
           "funnelKey",
           "featureSlug",
           "offerId",
+          "legKey",
           "resolvedOfferId",
           "dailyBudgetCents",
           "running",

--- a/src/lib/campaign-funding.ts
+++ b/src/lib/campaign-funding.ts
@@ -1,6 +1,7 @@
 import type { IdentityHeaders } from "@distribute/runs-client";
 import {
   channelCeilingCents,
+  legCeilingCents,
   fetchFunnelBudgets,
   offerCeilingCents,
   type FunnelBudgetsRead,
@@ -49,6 +50,12 @@ export function fundingFromBudgets(
      * pre-offer population and paces on the pair figure exactly as it always did.
      */
     offerId?: string | null;
+    /**
+     * The single funnel LEG this campaign was bought for — features-service's identifier, carried
+     * and never derived. Null is the pre-leg population and paces on the offer figure exactly as
+     * it always did.
+     */
+    legKey?: string | null;
   },
   budgets: Extract<FunnelBudgetsRead, { ok: true }>,
 ): FundingVerdict {
@@ -77,6 +84,33 @@ export function fundingFromBudgets(
       // served as a single summed pair figure, so pacing both campaigns on it hands each the money
       // the other was funded for. A campaign stating no offer, or a brand whose ceilings name
       // none, answers `none` here and falls through to the pair figure unchanged.
+      // And one grain below the offer: what the customer BUYS is a LEG, and one (funnel, channel,
+      // offer) can be worked for two legs at once — billing serves the offer figure as their SUM,
+      // so pacing both campaigns on it hands each the money the other was funded for. A campaign
+      // stating no leg, or a brand whose ceilings name none, answers `none` here and falls through
+      // to the offer figure unchanged.
+      const leg = legCeilingCents(
+        budgets,
+        funnelKey,
+        campaign.featureSlug,
+        campaign.offerId,
+        campaign.legKey,
+      );
+      if (leg.grain === "leg") {
+        if (leg.cents === null) {
+          return {
+            funded: false,
+            reason: `leg ${campaign.legKey} is not funded on channel ${campaign.featureSlug ?? "none"}`,
+          };
+        }
+        return leg.cents > 0
+          ? { funded: true, ceilingCents: leg.cents }
+          : {
+              funded: false,
+              reason: `leg ${campaign.legKey} is funded at zero on channel ${campaign.featureSlug ?? "none"}`,
+            };
+      }
+
       const offer = offerCeilingCents(budgets, funnelKey, campaign.featureSlug, campaign.offerId);
       if (offer.grain === "offer") {
         if (offer.cents === null) {

--- a/src/lib/channel-operator-client.ts
+++ b/src/lib/channel-operator-client.ts
@@ -14,8 +14,15 @@
  * a ninth customer-operated channel published upstream works with no change in this repo, the same
  * posture this service holds for the goal, the funnel and the channel vocabularies.
  *
+ * The same catalogue is also the ONE place that says WHICH LEGS a channel performs. A leg is what
+ * a customer buys — one leg belongs to several funnels at once, so the funnel never identified the
+ * purchase — and the identifiers are minted and published there. They are carried verbatim: no leg
+ * vocabulary, list or matrix exists in this service, and the identifier is never SPLIT back into
+ * the two steps it connects (they ride beside it on the very same payload).
+ *
  * Contract (features-service): GET /public/channels (no auth, no identity)
- *   -> { channels: [{ slug, operatedBy: "platform" | "customer", ... }], steps: [...] }
+ *   -> { channels: [{ slug, operatedBy: "platform" | "customer",
+ *                     stepTransitions: [{ legKey, from, to }], ... }], legs: [...], steps: [...] }
  *
  * A channel the catalogue does not publish, and a catalogue that cannot be READ, both resolve to
  * "platform" at the call site — i.e. to today's behaviour exactly. That direction is deliberate:
@@ -26,10 +33,19 @@
 export type ChannelOperator = "platform" | "customer";
 
 export type ChannelCatalogueRead =
-  | { ok: true; operatorBySlug: Map<string, ChannelOperator> }
+  | {
+      ok: true;
+      operatorBySlug: Map<string, ChannelOperator>;
+      /**
+       * channel slug -> the legs that channel PERFORMS, as features-service's own identifiers.
+       * A slug the catalogue does not publish is absent, which is a different statement from a
+       * channel that publishes an empty set, and the call site treats it as such.
+       */
+      legsBySlug: Map<string, ReadonlySet<string>>;
+    }
   | { ok: false; detail: string };
 
-export async function fetchChannelOperators(): Promise<ChannelCatalogueRead> {
+export async function fetchChannelCatalogue(): Promise<ChannelCatalogueRead> {
   const baseUrl = process.env.FEATURES_SERVICE_URL;
   if (!baseUrl) {
     return { ok: false, detail: "FEATURES_SERVICE_URL not configured" };
@@ -48,22 +64,39 @@ export async function fetchChannelOperators(): Promise<ChannelCatalogueRead> {
     }
 
     const data = await res.json() as {
-      channels?: Array<{ slug?: unknown; operatedBy?: unknown }>;
+      channels?: Array<{
+        slug?: unknown;
+        operatedBy?: unknown;
+        stepTransitions?: Array<{ legKey?: unknown }>;
+      }>;
     };
     if (!Array.isArray(data.channels)) {
       return { ok: false, detail: "response states no channels array" };
     }
 
     const operatorBySlug = new Map<string, ChannelOperator>();
+    const legsBySlug = new Map<string, ReadonlySet<string>>();
     for (const channel of data.channels) {
       if (typeof channel?.slug !== "string" || channel.slug.length === 0) continue;
+      // Which legs this channel performs. A channel that publishes none states an EMPTY set,
+      // which is a truthful answer ("this channel performs no leg of any declared funnel") and
+      // not the same thing as a slug the catalogue never names.
+      const legs = new Set<string>();
+      if (Array.isArray(channel.stepTransitions)) {
+        for (const transition of channel.stepTransitions) {
+          if (typeof transition?.legKey === "string" && transition.legKey.length > 0) {
+            legs.add(transition.legKey);
+          }
+        }
+      }
+      legsBySlug.set(channel.slug, legs);
       // Only the two published values are read. A third one this service has never heard of is
       // NOT guessed at: it is left out of the map, so the call site treats that channel exactly
       // as it treats one the catalogue does not publish.
       if (channel.operatedBy !== "platform" && channel.operatedBy !== "customer") continue;
       operatorBySlug.set(channel.slug, channel.operatedBy);
     }
-    return { ok: true, operatorBySlug };
+    return { ok: true, operatorBySlug, legsBySlug };
   } catch (err) {
     return { ok: false, detail: err instanceof Error ? err.message : String(err) };
   }

--- a/src/lib/funnel-budget-client.ts
+++ b/src/lib/funnel-budget-client.ts
@@ -73,6 +73,34 @@ export interface FunnelOfferBudget {
   dailyBudgetCents: number;
 }
 
+/**
+ * One (sales funnel, ACQUISITION CHANNEL, OFFER, LEG) ceiling — the finest grain billing stores,
+ * and the grain a campaign is bought at.
+ *
+ * A sales funnel is a chain of steps and what a customer BUYS is one of its LEGS: the leg that
+ * takes a lead sitting at one step and moves it to the next. One leg belongs to SEVERAL funnels at
+ * once, so the funnel never identified what was bought — the leg does. `offers` above is the SUM of
+ * these rows, so a (funnel, channel, offer) worked for two legs collapses into one figure there,
+ * and pacing both campaigns on it hands each the money the other was funded for: the same failure
+ * the offer grain closed one level up, re-opened one level down.
+ *
+ * `legKey` is features-service's canonical identifier, carried verbatim and NEVER parsed — the two
+ * steps it connects ride beside it on that service's catalogue. It is NULL for every ceiling
+ * written before legs existed, which is the population that keeps behaving exactly as it did.
+ */
+export interface FunnelLegBudget {
+  /** Canonical funnel key, same canonicalisation as `FunnelBudget.funnelKey`. */
+  funnelKey: SalesFunnelKey;
+  /** The acquisition channel this ceiling funds, as a features-service feature slug. */
+  featureSlug: string;
+  /** The offer this ceiling funds, or null for an UNSCOPED (pre-offer) ceiling. */
+  offerId: string | null;
+  /** The funnel leg this ceiling funds, or null for a ceiling written before legs existed. */
+  legKey: string | null;
+  /** This ROW's own daily ceiling, in CENTS. */
+  dailyBudgetCents: number;
+}
+
 export type FunnelBudgetsRead =
   | {
       ok: true;
@@ -92,6 +120,13 @@ export type FunnelBudgetsRead =
        * consumer on the pair figure and behaves byte for byte as it did.
        */
       offers: FunnelOfferBudget[];
+      /**
+       * ADDITIVE grain, one level below `offers` and the finest billing stores. Read exactly as
+       * the two grains above it: an ABSENT `legs` field is a billing deploy that predates it, so
+       * every consumer stays on the offer figure and behaves byte for byte as it did. A row whose
+       * `legKey` is null is a ceiling written before a campaign could state a leg.
+       */
+      legs: FunnelLegBudget[];
     }
   | { ok: false };
 
@@ -139,6 +174,13 @@ export async function fetchFunnelBudgets(
         funnelKey?: string;
         featureSlug?: string;
         offerId?: string | null;
+        dailyBudgetCents?: string;
+      }>;
+      legs?: Array<{
+        funnelKey?: string;
+        featureSlug?: string;
+        offerId?: string | null;
+        legKey?: string | null;
         dailyBudgetCents?: string;
       }>;
     };
@@ -210,7 +252,36 @@ export async function fetchFunnelBudgets(
       }
     }
 
-    return { ok: true, brandDailyBudgetCents, funnels, channels, offers };
+    // The leg grain, read exactly as the offer grain above and for the same reasons: absent is
+    // "no finer grain" (an older billing deploy), unparseable is refused, a funnel no catalogue
+    // names is dropped. `legKey` is nullable ON THE WIRE — a ceiling written before legs existed
+    // states none, and that null is a VALUE (see `legCeilingCents`), not a missing field.
+    const legs: FunnelLegBudget[] = [];
+    if (data.legs !== undefined) {
+      if (!Array.isArray(data.legs)) return { ok: false };
+      for (const raw of data.legs) {
+        if (!raw?.funnelKey || !raw?.featureSlug) return { ok: false };
+        if (raw.offerId !== null && raw.offerId !== undefined && typeof raw.offerId !== "string") {
+          return { ok: false };
+        }
+        if (raw.legKey !== null && raw.legKey !== undefined && typeof raw.legKey !== "string") {
+          return { ok: false };
+        }
+        const cents = parseFloat(raw.dailyBudgetCents ?? "");
+        if (!Number.isFinite(cents)) return { ok: false };
+        const funnelKey = toFunnelKey(raw.funnelKey);
+        if (!funnelKey) continue; // a funnel no catalogue names — same treatment as above
+        legs.push({
+          funnelKey,
+          featureSlug: raw.featureSlug,
+          offerId: raw.offerId ?? null,
+          legKey: raw.legKey ?? null,
+          dailyBudgetCents: cents,
+        });
+      }
+    }
+
+    return { ok: true, brandDailyBudgetCents, funnels, channels, offers, legs };
   } catch {
     return { ok: false };
   }
@@ -343,4 +414,94 @@ export function fundedChannelPairs(
   read: Extract<FunnelBudgetsRead, { ok: true }>,
 ): FunnelChannelBudget[] {
   return (read.channels ?? []).filter((c) => c.dailyBudgetCents > 0);
+}
+
+/**
+ * The ceiling that binds ONE (funnel, acquisition channel, offer, LEG) row — the grain BELOW the
+ * offer, and the finest billing stores.
+ *
+ * A customer buys a LEG of a sales funnel, and one (funnel, channel, offer) can be worked for two
+ * legs at once. billing serves the offer figure as the SUM of both, so pacing either campaign on
+ * it hands each the money the other was funded for — the same failure `offerCeilingCents` closed
+ * one level up, re-opened one level down.
+ *
+ * Three answers, and the middle one is what keeps every campaign alive today behaving identically:
+ *
+ *   - `grain: "none"` — there is no leg question to ask here, so the caller falls through to the
+ *     offer figure, i.e. today's behaviour byte for byte. That covers a billing deploy that does
+ *     not serve `legs` yet, a campaign that states NO leg (the pre-leg population — a leg is never
+ *     fabricated for it), a brand whose stored ceilings name no leg AT ALL, and a funnel billing
+ *     states no row for.
+ *   - `cents` — this row is funded at that amount.
+ *   - `cents: null` — this brand's money IS scoped to legs and none of it is this leg's, so the
+ *     campaign is unfunded. Never a fallback to the offer, pair or funnel total: that is the whole
+ *     point of the grain.
+ *
+ * The offer half of the match is billing's own rule, mirrored from `offerCeilingCents` rather than
+ * re-invented: a row that NAMES the offer always counts, and an UNSCOPED one counts only when this
+ * offer is the brand's sole named one. The channel half is the same rule one grain up: a funnel
+ * worked through exactly ONE channel binds whatever feature the campaign states.
+ */
+export function legCeilingCents(
+  read: Extract<FunnelBudgetsRead, { ok: true }>,
+  funnelKey: SalesFunnelKey,
+  featureSlug: string | null | undefined,
+  offerId: string | null | undefined,
+  legKey: string | null | undefined,
+): { grain: "none" } | { grain: "leg"; cents: number | null } {
+  const stored = read.legs ?? [];
+  if (stored.length === 0) return { grain: "none" };
+  // The pre-leg population. Never fabricate a leg for it: it resolves exactly as it always has,
+  // on the offer figure.
+  if (!legKey) return { grain: "none" };
+
+  // A brand whose ceilings name no leg at all has not entered the leg world, so neither does this
+  // read — every such brand keeps pacing on its offer figure.
+  const namedLegs = stored.filter((l) => l.legKey !== null);
+  if (namedLegs.length === 0) return { grain: "none" };
+
+  const rowsForFunnel = stored.filter((l) => l.funnelKey === funnelKey);
+  if (rowsForFunnel.length === 0) return { grain: "none" };
+
+  // billing's offer rule, verbatim (see `offerCeilingCents`).
+  const namedOffers = new Set(
+    stored.map((l) => l.offerId).filter((id): id is string => id !== null),
+  );
+  // A brand whose money IS scoped to offers, asked about a campaign that states none: there is no
+  // honest owner for an unscoped remainder, so this read has nothing to say and the campaign falls
+  // through exactly as it does one grain up.
+  if (namedOffers.size > 0 && !offerId) return { grain: "none" };
+  const soleNamed = namedOffers.size === 1 && !!offerId && namedOffers.has(offerId);
+  const owned = rowsForFunnel.filter((l) =>
+    namedOffers.size === 0
+      ? true
+      : l.offerId === offerId || (soleNamed && l.offerId === null),
+  );
+  if (owned.length === 0) return { grain: "leg", cents: null };
+
+  const forLeg = owned.filter((l) => l.legKey === legKey);
+  if (forLeg.length === 0) return { grain: "leg", cents: null };
+
+  const match = featureSlug ? forLeg.find((l) => l.featureSlug === featureSlug) : undefined;
+  if (match) return { grain: "leg", cents: match.dailyBudgetCents };
+
+  // No row for the channel this campaign states. A funnel worked through exactly ONE channel has
+  // nothing to confuse this ceiling with, so it binds whatever feature the campaign states —
+  // billing's rule for a write naming no channel. A funnel SPLIT across channels is different: a
+  // channel the split does not fund is unfunded, never the neighbour's money.
+  const channelsOfFunnel = new Set(rowsForFunnel.map((l) => l.featureSlug));
+  if (channelsOfFunnel.size === 1) return { grain: "leg", cents: forLeg[0]!.dailyBudgetCents };
+  return { grain: "leg", cents: null };
+}
+
+/**
+ * The (funnel, acquisition channel, offer, LEG) rows this org actually FUNDS for the brand — the
+ * finest grain billing stores, and the unit ONE campaign is provisioned per.
+ *
+ * A ceiling of zero is a deliberate "do not work this", exactly as at every grain above.
+ */
+export function fundedLegRows(
+  read: Extract<FunnelBudgetsRead, { ok: true }>,
+): FunnelLegBudget[] {
+  return (read.legs ?? []).filter((l) => l.dailyBudgetCents > 0);
 }

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -6,12 +6,13 @@ import {
   fetchFunnelBudgets,
   fundedChannelPairs,
   fundedFunnels,
+  fundedLegRows,
   type FunnelBudgetsRead,
 } from "./funnel-budget-client.js";
 import { fetchFeatureSalesFunnels, type FeatureSalesFunnelsRead } from "./feature-sales-funnels-client.js";
 import { fetchActiveWorkflowSlugForFeature, type ActiveWorkflowRead } from "./feature-workflow-client.js";
 import {
-  fetchChannelOperators,
+  fetchChannelCatalogue,
   type ChannelCatalogueRead,
   type ChannelOperator,
 } from "./channel-operator-client.js";
@@ -85,6 +86,12 @@ export interface ClaimedFunnelCampaign {
    * offers. NULL is the pre-offer population and keeps the brand-keyed read it has always had.
    */
   offerId?: string | null;
+  /**
+   * The single funnel LEG this campaign was bought for — features-service's identifier, carried
+   * and never derived. NULL is the pre-leg population and paces on the offer figure exactly as it
+   * always did.
+   */
+  legKey?: string | null;
 }
 
 /** One funnel campaign in the running to take the brand's next turn. */
@@ -360,29 +367,59 @@ interface FundedPair {
   funnelKey: SalesFunnelKey;
   /** The acquisition channel, as a features-service feature slug. A channel IS a feature slug. */
   featureSlug: string;
+  /**
+   * The single funnel LEG this money is behind — features-service's identifier, carried verbatim
+   * and never derived, parsed or minted. NULL is a ceiling written before a campaign could state
+   * a leg: that pair provisions a leg-less campaign, exactly as it always did.
+   */
+  legKey: string | null;
 }
 
 /**
  * What the customer funds, at the grain a campaign is provisioned per.
  *
- * billing states the pair grain ADDITIVELY, so both shapes are live at once and the fallback is
- * what keeps every brand funding one channel per funnel untouched:
+ * billing states every grain ADDITIVELY, so all three shapes are live at once and each fallback is
+ * what keeps the population below it untouched:
  *
- *   - pairs stated → one campaign per funded pair, each on its own channel.
- *   - no pairs (an older billing deploy, or a brand that funds nothing per funnel) → one campaign
- *     per funded FUNNEL on the seed's channel, i.e. exactly what this did before.
+ *   - LEG rows stated → one campaign per funded (funnel, channel, leg). A row whose leg is null is
+ *     a ceiling written before legs existed and provisions a leg-less campaign, byte-identically
+ *     to what the pair grain provisioned for it.
+ *   - no legs (an older billing deploy) → one campaign per funded pair, each on its own channel.
+ *   - no pairs either → one campaign per funded FUNNEL on the seed's channel, i.e. exactly what
+ *     this did before.
  */
 function fundedPairs(
   budgets: Extract<FunnelBudgetsRead, { ok: true }>,
   seedFeatureSlug: string,
 ): FundedPair[] {
+  // The LEG grain is the finest billing stores and the one a campaign is bought at, so it is asked
+  // first. Every coarser grain is a SUM of these rows, which is why nothing is added up here: a
+  // (funnel, channel) worked for two legs is TWO campaigns, and reading it at the pair grain would
+  // give them one identity and let each spend what the other was funded for.
+  const legRows = fundedLegRows(budgets);
+  if (legRows.length > 0) {
+    // Deduplicated on the identity a campaign holds. Two stored rows differing only by OFFER are
+    // one provisioning question here — which offer a new campaign is filed under is the DECLARING
+    // offer's answer, resolved further down, never billing's row.
+    const seen = new Set<string>();
+    const pairs: FundedPair[] = [];
+    for (const row of legRows) {
+      const key = `${row.funnelKey}\u0000${row.featureSlug}\u0000${row.legKey ?? ""}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      pairs.push({ funnelKey: row.funnelKey, featureSlug: row.featureSlug, legKey: row.legKey });
+    }
+    return pairs;
+  }
+
   const pairs = fundedChannelPairs(budgets);
   if (pairs.length > 0) {
-    return pairs.map((p) => ({ funnelKey: p.funnelKey, featureSlug: p.featureSlug }));
+    return pairs.map((p) => ({ funnelKey: p.funnelKey, featureSlug: p.featureSlug, legKey: null }));
   }
   return fundedFunnels(budgets).map((f) => ({
     funnelKey: f.funnelKey,
     featureSlug: seedFeatureSlug,
+    legKey: null,
   }));
 }
 
@@ -544,17 +581,21 @@ async function ensureFundedFunnelCampaigns({
   // workflow-less campaign on a guess. The customer-operated pair waits for the next sweep, and
   // the failure says so rather than passing in silence.
   let catalogue: ChannelCatalogueRead | null = null;
-  const operatorFor = async (slug: string): Promise<ChannelOperator> => {
+  const readCatalogue = async (): Promise<ChannelCatalogueRead> => {
     if (catalogue === null) {
-      catalogue = await fetchChannelOperators();
+      catalogue = await fetchChannelCatalogue();
       if (!catalogue.ok) {
         console.warn(
           `[campaign-service] Could not read features-service's channel catalogue (brand ${brandId}, org ${seed.orgId}) — ${catalogue.detail}. Every channel is treated as platform-operated this sweep, which is the behaviour that predates customer-operated channels.`,
         );
       }
     }
-    if (!catalogue.ok) return "platform";
-    return catalogue.operatorBySlug.get(slug) ?? "platform";
+    return catalogue;
+  };
+  const operatorFor = async (slug: string): Promise<ChannelOperator> => {
+    const read = await readCatalogue();
+    if (!read.ok) return "platform";
+    return read.operatorBySlug.get(slug) ?? "platform";
   };
 
   // The (org, brand, acquisition channel) triples a funnel campaign is provisioned for on this
@@ -578,28 +619,64 @@ async function ensureFundedFunnelCampaigns({
     if (offerId === undefined) continue; // funded, but nobody declares selling through it
     const featureSlug = f.featureSlug;
 
-    if (!sellableByFeature.has(featureSlug)) {
-      sellableByFeature.set(featureSlug, await fetchFeatureSalesFunnels(featureSlug, identity));
-    }
-    const sellable = sellableByFeature.get(featureSlug)!;
-    // Unreadable → provision nothing for this channel, exactly as an unreadable brand declaration
-    // provisions nothing for the brand. A pair is not guessed at — but it is not passed over in
-    // silence either: the customer's money is on this pair and we failed to evaluate it, which is
-    // a different thing from evaluating it and saying no.
-    if (!sellable.ok) {
-      console.warn(
-        `[campaign-service] Not provisioning ${featureSlug} for funnel ${f.funnelKey} (brand ${brandId}, org ${seed.orgId}) — could not READ features-service's statement of which funnels this channel sells: ${sellable.detail}`,
-      );
-      continue;
-    }
-    if (!sellable.funnels.has(f.funnelKey)) {
-      // A pair nobody can run: the customer funds it, but this channel has no way to sell that
-      // funnel. Logged once per sweep rather than silently dropped — the money is real and the
-      // customer is owed an answer about it eventually.
-      console.log(
-        `[campaign-service] Not provisioning ${featureSlug} for funnel ${f.funnelKey} (brand ${brandId}) — features-service does not state that pair`,
-      );
-      continue;
+    // WHAT THE CHANNEL CAN DO, asked in the vocabulary of what the customer BOUGHT.
+    //
+    // A pair that states a LEG asks the leg question — "does this channel perform this leg?" — and
+    // names no funnel at all, which is the point: one leg belongs to several funnels, so a funnel
+    // cannot say which of them was bought. features-service publishes every channel's legs on the
+    // same public catalogue this pass already reads for who operates them, so the identifier is
+    // carried verbatim and joined; it is never parsed and no matrix is held here.
+    //
+    // A pair that states NO leg keeps asking the funnel question, unchanged: that IS the question
+    // for a ceiling written before a campaign could state a leg.
+    if (f.legKey) {
+      const read = await readCatalogue();
+      if (!read.ok) {
+        console.warn(
+          `[campaign-service] Not provisioning ${featureSlug} for leg ${f.legKey} (brand ${brandId}, org ${seed.orgId}) — could not READ features-service's channel catalogue: ${read.detail}`,
+        );
+        continue;
+      }
+      const performed = read.legsBySlug.get(featureSlug);
+      if (!performed) {
+        console.log(
+          `[campaign-service] Not provisioning ${featureSlug} for leg ${f.legKey} (brand ${brandId}) — features-service's catalogue publishes no such channel`,
+        );
+        continue;
+      }
+      if (!performed.has(f.legKey)) {
+        // A pair nobody can run: the customer funds it, but this channel does not perform that
+        // leg. Logged once per sweep rather than silently dropped — the money is real.
+        console.log(
+          `[campaign-service] Not provisioning ${featureSlug} for leg ${f.legKey} (brand ${brandId}) — features-service does not state that this channel performs it`,
+        );
+        continue;
+      }
+    } else {
+
+      if (!sellableByFeature.has(featureSlug)) {
+        sellableByFeature.set(featureSlug, await fetchFeatureSalesFunnels(featureSlug, identity));
+      }
+      const sellable = sellableByFeature.get(featureSlug)!;
+      // Unreadable → provision nothing for this channel, exactly as an unreadable brand declaration
+      // provisions nothing for the brand. A pair is not guessed at — but it is not passed over in
+      // silence either: the customer's money is on this pair and we failed to evaluate it, which is
+      // a different thing from evaluating it and saying no.
+      if (!sellable.ok) {
+        console.warn(
+          `[campaign-service] Not provisioning ${featureSlug} for funnel ${f.funnelKey} (brand ${brandId}, org ${seed.orgId}) — could not READ features-service's statement of which funnels this channel sells: ${sellable.detail}`,
+        );
+        continue;
+      }
+      if (!sellable.funnels.has(f.funnelKey)) {
+        // A pair nobody can run: the customer funds it, but this channel has no way to sell that
+        // funnel. Logged once per sweep rather than silently dropped — the money is real and the
+        // customer is owed an answer about it eventually.
+        console.log(
+          `[campaign-service] Not provisioning ${featureSlug} for funnel ${f.funnelKey} (brand ${brandId}) — features-service does not state that pair`,
+        );
+        continue;
+      }
     }
 
     // This pair gets a campaign on this channel — whether one already exists or one is inserted
@@ -621,10 +698,68 @@ async function ensureFundedFunnelCampaigns({
         eq(campaigns.orgId, seed.orgId),
         eq(campaigns.featureSlug, featureSlug),
         eq(campaigns.funnelKey, f.funnelKey),
+        // The campaign bought for one LEG is not the campaign bought for another, so a pair is
+        // only ever matched against the campaign of ITS leg. Without this, a brand working one
+        // channel for two legs finds the first campaign for the second pair and never provisions
+        // it — the exact pair the leg exists to tell apart, collapsed back into one.
+        f.legKey ? eq(campaigns.legKey, f.legKey) : isNull(campaigns.legKey),
         arrayContains(campaigns.brandIds, [brandId]),
       ),
       orderBy: [desc(sql`(${campaigns.status} = 'ongoing')`), desc(campaigns.createdAt)],
     });
+
+    // A campaign that already exists for this (funnel, channel) but states NO leg, on a pair the
+    // customer now funds AT the leg grain, is that pair's campaign — it is doing exactly this
+    // work and has been since before a campaign could say which leg it was bought for. It is
+    // ADOPTED (the leg is stamped on it) rather than left alone, because leaving it alone inserts
+    // a TWIN beside it: two live campaigns doing one job, splitting one identity's history and
+    // spending on two ceilings. That is the same recurrence the funnel-less ancestors had, one
+    // word along. Nothing else about the row moves — id, status, schedule, money and history are
+    // untouched, and the money is the same money restated at the grain it was funded at (the
+    // coarser figures are SUMS of these rows).
+    const adoptable = existing
+      ? null
+      : f.legKey
+        ? await db.query.campaigns.findFirst({
+            where: and(
+              eq(campaigns.orgId, seed.orgId),
+              eq(campaigns.featureSlug, featureSlug),
+              eq(campaigns.funnelKey, f.funnelKey),
+              isNull(campaigns.legKey),
+              arrayContains(campaigns.brandIds, [brandId]),
+            ),
+            orderBy: [desc(sql`(${campaigns.status} = 'ongoing')`), desc(campaigns.createdAt)],
+          })
+        : null;
+
+    if (adoptable) {
+      try {
+        await db
+          .update(campaigns)
+          .set({ legKey: f.legKey, updatedAt: now })
+          .where(and(
+            eq(campaigns.id, adoptable.id),
+            eq(campaigns.orgId, seed.orgId),
+            // Restated in the UPDATE so a re-run writes nothing and a race with a live create
+            // that just stated a leg cannot overwrite it.
+            isNull(campaigns.legKey),
+          ));
+        console.log(
+          `[campaign-service] Campaign ${adoptable.id} states the leg it is bought for (${f.legKey}) — the funded pair it was already working (brand ${brandId}, channel ${featureSlug})`,
+        );
+      } catch (err) {
+        // Another live campaign already holds the identity this adoption would move it onto. The
+        // row stays exactly as it is; provisioning is not the place to arbitrate that.
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes("uniq_campaigns_org_brand_funnel_channel")) throw err;
+        console.warn(
+          `[campaign-service] Not stating leg ${f.legKey} on campaign ${adoptable.id} — another live campaign already holds that identity`,
+        );
+      }
+      const adoptChannel = acquisitionChannelForFeature(featureSlug);
+      if (adoptChannel) adoptFor.add(adoptChannel);
+      continue;
+    }
 
     if (existing) {
       // A funnel the customer re-funded after switching it off resumes rather than duplicating —
@@ -695,7 +830,7 @@ async function ensureFundedFunnelCampaigns({
     // here (brand_ids is a text[], so no unique index can span it), which makes a duplicate
     // provision a constraint violation rather than a second campaign for the same pair. The name
     // already carries the channel, so two channels of one funnel never collide on it.
-    const name = funnelCampaignName(featureSlug, brandId, f.funnelKey);
+    const name = funnelCampaignName(featureSlug, brandId, f.funnelKey, f.legKey);
 
     try {
       await db.insert(campaigns).values({
@@ -710,6 +845,10 @@ async function ensureFundedFunnelCampaigns({
         // NOT written any more: it could not tell the two meeting funnels apart, and a consumer
         // reading it reads a poorer statement of the same thing.
         funnelKey: f.funnelKey,
+        // The single leg this campaign is bought for. features-service's identifier, carried
+        // verbatim from the ceiling the customer set: never derived from the funnel (several legs
+        // sell one funnel and one leg belongs to several funnels), the channel or the workflow.
+        legKey: f.legKey,
         // The offer whose declaration is what put this funnel in scope. Carried, never derived:
         // NULL when the funnel came from the brand-keyed read, which is the pre-offer world.
         offerId: offerId ?? null,
@@ -737,8 +876,18 @@ async function ensureFundedFunnelCampaigns({
   }
 }
 
-export function funnelCampaignName(featureSlug: string, brandId: string, funnelKey: string): string {
-  return `${featureSlug} - ${brandId} - ${funnelKey}`;
+export function funnelCampaignName(
+  featureSlug: string,
+  brandId: string,
+  funnelKey: string,
+  legKey?: string | null,
+): string {
+  // The name is the only uniqueness Postgres can enforce on an INSERT here (brand_ids is a
+  // text[]), so it has to separate everything a campaign is. The LEG is appended only when the
+  // campaign states one: a leg-less campaign keeps the name it has always had, byte for byte, so
+  // nothing alive today is renamed or re-provisioned.
+  const base = `${featureSlug} - ${brandId} - ${funnelKey}`;
+  return legKey ? `${base} - ${legKey}` : base;
 }
 
 /**
@@ -877,6 +1026,7 @@ export async function provisionFundedPairsForQuietBrands(now: Date = new Date())
         funnelKey: null,
         dailyBudgetCents: null,
         offerId: row.offer_id,
+        legKey: null,
       };
 
       const identity: IdentityHeaders = {

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -3,7 +3,7 @@ import { db } from "../db/index.js";
 import { campaigns } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 import { isSalesFunnelFeature } from "./sales-outreach-campaign.js";
-import { channelCeilingCents, fetchFunnelBudgets, offerCeilingCents } from "./funnel-budget-client.js";
+import { channelCeilingCents, fetchFunnelBudgets, legCeilingCents, offerCeilingCents } from "./funnel-budget-client.js";
 import { toFunnelKey } from "./sales-funnel-vocabulary.js";
 import { STOP_REASONS } from "./stop-reason.js";
 
@@ -53,6 +53,11 @@ export interface GateCheckInput {
   // offer's, not the (funnel, channel) SUM that also contains a sibling offer's ceiling. NULL is
   // the pre-offer population and paces exactly as it always did.
   offerId: string | null;
+  // The single funnel LEG this campaign was bought for — features-service's identifier, carried
+  // and never derived. When billing scopes any of this brand's money to a leg, the ceiling that
+  // binds this campaign is its own leg's, not the (funnel, channel, offer) SUM that also contains
+  // a sibling leg's ceiling. NULL is the pre-leg population and paces exactly as it always did.
+  legKey: string | null;
   maxLeads: number | null;
 }
 
@@ -298,7 +303,31 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
         // campaigns on it lets each spend what the other was funded for. A campaign that states no
         // offer, or a brand whose stored ceilings name none, falls through to the pair figure
         // below, unchanged.
+        // (a2''') And one grain below the offer: what a customer BUYS is a LEG of a funnel, and
+        // one (funnel, channel, offer) can be worked for two legs at once — billing serves the
+        // offer figure as their SUM, so pacing both campaigns on it lets each spend what the other
+        // was funded for. A campaign that states no leg, or a brand whose stored ceilings name
+        // none, falls through to the offer figure below, unchanged.
         if (funnelKey) {
+          const leg = legCeilingCents(
+            budgets,
+            funnelKey,
+            campaign.featureSlug,
+            campaign.offerId,
+            campaign.legKey,
+          );
+          if (leg.grain === "leg") {
+            // This brand's money is scoped to legs and none of it is this leg's — a deliberate
+            // customer decision, so never a fallback to the offer, pair, funnel or brand total.
+            if (leg.cents === null || leg.cents <= 0) {
+              return { allowed: false, reason: "Leg not funded" };
+            }
+            if (spentCents >= leg.cents) {
+              return { allowed: false, reason: "Leg daily budget reached" };
+            }
+            continue;
+          }
+
           const offer = offerCeilingCents(budgets, funnelKey, campaign.featureSlug, campaign.offerId);
           if (offer.grain === "offer") {
             // This brand's money is scoped to offers and none of it is this one's — a deliberate

--- a/src/lib/gate-check.ts
+++ b/src/lib/gate-check.ts
@@ -56,11 +56,24 @@ export interface GateCheckInput {
   maxLeads: number | null;
 }
 
+/**
+ * What the credit pre-filter actually ANSWERED, as opposed to what the gate decided.
+ *
+ * `unreadable` is the fail-open path: billing could not be asked (unconfigured, non-2xx,
+ * network throw) and the run was allowed anyway. It is reported so an incident can tell a
+ * genuine authorization apart from a default-allow — the two used to be the same word.
+ * Absent when the gate returned before block 3b ever ran.
+ */
+export type CreditCheckOutcome = "affordable" | "unaffordable" | "unreadable";
+
 export interface GateCheckResult {
   allowed: boolean;
   reason?: string;
   autoStopped?: boolean;
   nextRunAt?: Date;
+  creditCheck?: CreditCheckOutcome;
+  // Why billing could not be read. Only set alongside `unreadable`.
+  creditCheckDetail?: string;
 }
 
 type BrandDailyBudgetRead =
@@ -343,10 +356,22 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
   // via nextRunAt, so a recharge auto-resumes it on the next check (no manual restart,
   // no webhook). A billing blip must not freeze ALL campaigns, and chat-service's own
   // authorize remains the hard gate downstream — so any billing-call failure allows.
-  const affordable = await checkAffordability(campaign.campaignId, identity);
-  if (!affordable) {
-    return { allowed: false, reason: "Insufficient credits", nextRunAt: nextHalfHour() };
+  //
+  // The fail-open ANSWER is carried out, because "billing said this org can pay" and
+  // "billing could not be asked, so we let it through" are different facts that used to
+  // reach the run trace as the same word (PASSED). During an incident that is the one
+  // question worth answering about this gate, and the trace was unable to answer it.
+  const credit = await readCreditAffordability(campaign.campaignId, identity);
+  if (credit.readable && !credit.affordable) {
+    return {
+      allowed: false,
+      reason: "Insufficient credits",
+      nextRunAt: nextHalfHour(),
+      creditCheck: "unaffordable",
+    };
   }
+  const creditCheck: CreditCheckOutcome = credit.readable ? "affordable" : "unreadable";
+  const creditCheckDetail = credit.readable ? undefined : credit.detail;
 
   // 4. Volume check
   if (campaign.maxLeads != null) {
@@ -376,17 +401,17 @@ export async function runGateChecks(campaign: GateCheckInput): Promise<GateCheck
       if (err instanceof Error && "status" in err && (err as { status: number }).status === 404) {
         totalServed = completedRuns.length;
       } else {
-        return { allowed: false, reason: "Lead stats unavailable (fail-closed)" };
+        return { allowed: false, reason: "Lead stats unavailable (fail-closed)", creditCheck, creditCheckDetail };
       }
     }
 
     if (totalServed >= campaign.maxLeads) {
       await autoStopCampaign(campaign.campaignId);
-      return { allowed: false, reason: "Max leads reached", autoStopped: true };
+      return { allowed: false, reason: "Max leads reached", autoStopped: true, creditCheck, creditCheckDetail };
     }
   }
 
-  return { allowed: true };
+  return { allowed: true, creditCheck, creditCheckDetail };
 }
 
 async function autoStopCampaign(campaignId: string): Promise<void> {
@@ -432,23 +457,34 @@ async function fetchLeadStats(
   return { totalServed: (data.totalServed as number) || (data.served as number) || 0 };
 }
 
+type CreditAffordabilityRead =
+  | { readable: true; affordable: boolean }
+  | { readable: false; detail: string };
+
 /**
- * Pre-flight credit affordability check against billing-service.
- * Returns true (allow the run) unless billing explicitly reports affordable=false.
+ * Pre-flight credit affordability read against billing-service.
  *
- * Fail-OPEN by design: missing config, network error, or non-2xx all return true.
- * Credit affordability is a PRE-FILTER, not the final gate — chat-service's own
- * authorize is the hard gate. A billing outage must never freeze every campaign.
+ * Fail-OPEN by design: missing config, network error, non-2xx and an unparseable body all
+ * come back `readable: false`, and the caller allows the run on every one of them. Credit
+ * affordability is a PRE-FILTER, not the final gate — chat-service's own authorize is the
+ * hard gate. A billing outage must never freeze every campaign.
+ *
+ * The one thing that changed is that the caller can now tell "billing said yes" from
+ * "billing could not be asked". Both still run; only one of them is an authorization.
  */
-async function checkAffordability(campaignId: string, identity: IdentityHeaders): Promise<boolean> {
+async function readCreditAffordability(
+  campaignId: string,
+  identity: IdentityHeaders,
+): Promise<CreditAffordabilityRead> {
   const url = process.env.BILLING_SERVICE_URL;
   const apiKey = process.env.BILLING_SERVICE_API_KEY;
-  // Silent fail-open. Every fail-open path below (missing config / non-2xx / throw) is
-  // hit per gate check, i.e. per ~minute per campaign across every client — logging it
-  // (even at info) spams the fleet for a deliberate pre-filter degradation. Billing's own
-  // monitoring owns billing's health; chat-service authorize stays the hard gate downstream.
+  // Fail-open, and the reason travels with the answer. Nothing is logged here: every path
+  // below is hit per gate check, i.e. per campaign per tick across every client, so a console
+  // line would spam the fleet. The outcome rides the gate-check-result trace event that is
+  // already emitted once per gate check — no new event, no new volume, and an incident can
+  // finally read whether the gate authorized or merely could not ask.
   if (!url || !apiKey) {
-    return true;
+    return { readable: false, detail: "billing not configured" };
   }
 
   const headers: Record<string, string> = {
@@ -464,13 +500,19 @@ async function checkAffordability(campaignId: string, identity: IdentityHeaders)
   try {
     const res = await fetch(`${url}/internal/campaigns/${campaignId}/affordability`, { headers });
     if (!res.ok) {
-      return true;
+      return { readable: false, detail: `billing responded ${res.status}` };
     }
     const data = await res.json() as { affordable?: boolean };
-    // Only an explicit affordable=false blocks. Anything else (true, missing) allows.
-    return data.affordable !== false;
-  } catch {
-    return true;
+    // An answer with no `affordable` field is not an answer — billing served something this
+    // service does not understand, so it is a read failure, not an authorization. The run is
+    // still allowed (same fail-open behaviour as before), it is just no longer reported as a
+    // billing authorization that never happened.
+    if (typeof data.affordable !== "boolean") {
+      return { readable: false, detail: "billing answered without an affordable field" };
+    }
+    return { readable: true, affordable: data.affordable };
+  } catch (err) {
+    return { readable: false, detail: err instanceof Error ? err.message : "billing call threw" };
   }
 }
 

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -116,6 +116,9 @@ export async function reRunDueCampaigns(): Promise<number> {
       // The offer this campaign sells. The turn planner asks brand-service for the funnels of THAT
       // offer — the only grain with one answer on a brand selling several.
       offerId: campaigns.offerId,
+      // The single funnel LEG this campaign was bought for. The ceiling that binds it is its own
+      // leg's whenever the customer funds at that grain — the coarser figures are SUMS.
+      legKey: campaigns.legKey,
     });
 
   if (dueCampaigns.length === 0) return 0;

--- a/src/lib/spendable-budget.ts
+++ b/src/lib/spendable-budget.ts
@@ -36,18 +36,24 @@ export interface SpendableCampaign {
   funnelKey: string | null;
   featureSlug: string | null;
   offerId: string | null;
+  /** The single funnel LEG this campaign was bought for — the grain it is funded at. */
+  legKey: string | null;
   createdAt: Date;
 }
 
 /**
  * WHICH billing grain the figures were computed at.
  *
- * billing serves the same money at four widths — per (funnel, channel, offer), per (funnel,
- * channel), per funnel, and one brand pot — and the coarser three are SUMS of the finer, so
- * exactly ONE of them may be counted or the same dollar is counted twice. The finest one billing
- * actually states is chosen, once, here.
+ * billing serves the same money at five widths — per (funnel, channel, offer, LEG), per (funnel,
+ * channel, offer), per (funnel, channel), per funnel, and one brand pot — and the coarser four are
+ * SUMS of the finer, so exactly ONE of them may be counted or the same dollar is counted twice.
+ * The finest one billing actually states is chosen, once, here.
+ *
+ * The LEG is the finest and it is the grain a campaign is BOUGHT at: one (funnel, channel, offer)
+ * worked for two legs is TWO campaigns, so counting at the offer grain would find one campaign for
+ * a row that funds two and report the other as running on nothing.
  */
-export type SpendableGrain = "offer" | "channel" | "funnel" | "brand" | "none";
+export type SpendableGrain = "leg" | "offer" | "channel" | "funnel" | "brand" | "none";
 
 /** One configured ceiling, and the campaign (if any) standing behind it. */
 export interface SpendableRow {
@@ -57,6 +63,8 @@ export interface SpendableRow {
   featureSlug: string | null;
   /** The offer billing SCOPED this ceiling to, or null for a ceiling written before offers. */
   offerId: string | null;
+  /** The funnel LEG billing scoped this ceiling to, or null for a ceiling written before legs. */
+  legKey: string | null;
   /**
    * The offer this money actually works for: billing's when it states one, else the offer of the
    * campaign standing behind it. Production still carries ceilings written before the offer level
@@ -79,6 +87,8 @@ export interface SpendableCampaignLine {
   funnelKey: string | null;
   featureSlug: string | null;
   offerId: string | null;
+  /** The single funnel LEG this campaign was bought for, or null when it states none. */
+  legKey: string | null;
   configuredDailyBudgetCents: number;
   runningDailyBudgetCents: number;
 }
@@ -107,6 +117,7 @@ interface RawRow {
   funnelKey: SalesFunnelKey | null;
   featureSlug: string | null;
   offerId: string | null;
+  legKey: string | null;
   dailyBudgetCents: number;
 }
 
@@ -117,6 +128,21 @@ interface RawRow {
 function rowsAtFinestGrain(
   budgets: Extract<FunnelBudgetsRead, { ok: true }>,
 ): { grain: SpendableGrain; rows: RawRow[] } {
+  // The LEG grain first: it is the finest billing stores and the one a campaign is bought at.
+  const legs = budgets.legs ?? [];
+  if (legs.length > 0) {
+    return {
+      grain: "leg",
+      rows: legs.map((l) => ({
+        funnelKey: l.funnelKey,
+        featureSlug: l.featureSlug,
+        offerId: l.offerId,
+        legKey: l.legKey,
+        dailyBudgetCents: l.dailyBudgetCents,
+      })),
+    };
+  }
+
   const offers = budgets.offers ?? [];
   if (offers.length > 0) {
     return {
@@ -125,6 +151,7 @@ function rowsAtFinestGrain(
         funnelKey: o.funnelKey,
         featureSlug: o.featureSlug,
         offerId: o.offerId,
+        legKey: null,
         dailyBudgetCents: o.dailyBudgetCents,
       })),
     };
@@ -138,6 +165,7 @@ function rowsAtFinestGrain(
         funnelKey: c.funnelKey,
         featureSlug: c.featureSlug,
         offerId: null,
+        legKey: null,
         dailyBudgetCents: c.dailyBudgetCents,
       })),
     };
@@ -150,6 +178,7 @@ function rowsAtFinestGrain(
         funnelKey: f.funnelKey,
         featureSlug: null,
         offerId: null,
+        legKey: null,
         dailyBudgetCents: f.dailyBudgetCents,
       })),
     };
@@ -163,6 +192,7 @@ function rowsAtFinestGrain(
           funnelKey: null,
           featureSlug: null,
           offerId: null,
+          legKey: null,
           dailyBudgetCents: budgets.brandDailyBudgetCents,
         },
       ],
@@ -216,6 +246,13 @@ function campaignForRow(row: RawRow, all: SpendableCampaign[], rowsOfGrain: RawR
   if (row.offerId) {
     candidates = candidates.filter((c) => c.offerId === row.offerId);
   }
+  // The LEG is what the campaign was BOUGHT for, so a ceiling that names one belongs to the
+  // campaign of THAT leg and to no other. Without this, two campaigns of one (funnel, channel,
+  // offer) both match both of its leg rows and the older one is reported as running the money
+  // funded for the other.
+  if (row.legKey) {
+    candidates = candidates.filter((c) => c.legKey === row.legKey);
+  }
   if (candidates.length === 0) return null;
 
   const rank = (c: SpendableCampaign) => (c.status === "ongoing" ? 0 : 1);
@@ -263,6 +300,7 @@ export function computeSpendableBudget(
       funnelKey: raw.funnelKey,
       featureSlug: raw.featureSlug,
       offerId: raw.offerId,
+      legKey: raw.legKey,
       resolvedOfferId: raw.offerId ?? campaign?.offerId ?? null,
       dailyBudgetCents: raw.dailyBudgetCents,
       running,
@@ -287,6 +325,7 @@ export function computeSpendableBudget(
       funnelKey: c.funnelKey,
       featureSlug: c.featureSlug,
       offerId: c.offerId,
+      legKey: c.legKey,
       configuredDailyBudgetCents: configuredByCampaign.get(c.id) ?? 0,
       runningDailyBudgetCents: runningByCampaign.get(c.id) ?? 0,
     }));

--- a/src/routes/brands.ts
+++ b/src/routes/brands.ts
@@ -167,6 +167,7 @@ async function loadSalesCampaigns(orgId: string, brandId: string): Promise<Spend
       funnelKey: campaigns.funnelKey,
       featureSlug: campaigns.featureSlug,
       offerId: campaigns.offerId,
+      legKey: campaigns.legKey,
       createdAt: campaigns.createdAt,
     })
     .from(campaigns)

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -102,6 +102,7 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
       dailyBudgetCents: campaign.dailyBudgetCents,
       funnelKey: campaign.funnelKey,
       offerId: campaign.offerId,
+      legKey: campaign.legKey,
       maxLeads: campaign.maxLeads,
     });
 

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -121,12 +121,24 @@ router.post("/gate-check", requireApiKey, requirePipelineHeaders, trackingHeader
                           result.reason === "Funnel daily budget reached" ||
                           result.reason === "Funnel not funded" ||
                           result.reason === "Brand paused";
+      // A run allowed because billing could NOT be asked is a fail-OPEN anomaly, not an
+      // authorization — exactly the class this service warns on. It rides the event that is
+      // already emitted once per gate check, so it adds no log volume at all, and it is the
+      // only way an incident can tell "the gate authorized" apart from "the gate defaulted".
+      const creditUnreadable = result.creditCheck === "unreadable";
       traceEvent(req.runId, {
         service: "campaign-service",
         event: "gate-check-result",
-        detail: `Gate check ${result.allowed ? "PASSED" : "BLOCKED"} for campaign ${campaignId}${result.reason ? ` — reason: ${result.reason}` : ""}${result.autoStopped ? " (auto-stopped)" : ""}`,
-        level: result.allowed || benignBlock ? "info" : "warn",
-        data: { campaignId, allowed: result.allowed, reason: result.reason, autoStopped: result.autoStopped },
+        detail: `Gate check ${result.allowed ? "PASSED" : "BLOCKED"} for campaign ${campaignId}${result.reason ? ` — reason: ${result.reason}` : ""}${result.autoStopped ? " (auto-stopped)" : ""}${creditUnreadable ? ` — credit affordability NOT read (${result.creditCheckDetail}), allowed by fail-open` : ""}`,
+        level: creditUnreadable ? "warn" : (result.allowed || benignBlock ? "info" : "warn"),
+        data: {
+          campaignId,
+          allowed: result.allowed,
+          reason: result.reason,
+          autoStopped: result.autoStopped,
+          creditCheck: result.creditCheck,
+          creditCheckDetail: result.creditCheckDetail,
+        },
       }, req.headers).catch(() => {});
     }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -381,6 +381,7 @@ export const SpendableBudgetRow = z.object({
   funnelKey: z.string().nullable(),
   featureSlug: z.string().nullable(),
   offerId: z.string().nullable(),
+  legKey: z.string().nullable(),
   resolvedOfferId: z.string().nullable(),
   dailyBudgetCents: z.number().int(),
   running: z.boolean(),
@@ -402,6 +403,7 @@ export const SpendableBudgetCampaign = z.object({
   funnelKey: z.string().nullable(),
   featureSlug: z.string().nullable(),
   offerId: z.string().nullable(),
+  legKey: z.string().nullable(),
   configuredDailyBudgetCents: z.number().int(),
   runningDailyBudgetCents: z.number().int(),
 }).openapi("SpendableBudgetCampaign");
@@ -409,7 +411,7 @@ export const SpendableBudgetCampaign = z.object({
 export const SpendableBudgetResponse = z.object({
   orgId: z.string(),
   brandId: z.string(),
-  grain: z.enum(["offer", "channel", "funnel", "brand", "none"]),
+  grain: z.enum(["leg", "offer", "channel", "funnel", "brand", "none"]),
   configuredDailyBudgetCents: z.number().int(),
   runningDailyBudgetCents: z.number().int(),
   offers: z.array(SpendableBudgetOffer),

--- a/tests/integration/campaign-leg.test.ts
+++ b/tests/integration/campaign-leg.test.ts
@@ -124,6 +124,26 @@ describe("Campaign leg", () => {
     expect(booked.body.campaign.legKey).not.toBe(attended.body.campaign.legKey);
   });
 
+  it("never holds the same leg twice — a restated identity UPDATES the campaign it names", async () => {
+    const brandIds = [crypto.randomUUID()];
+    const channelFeature = "sales-cold-email-v1";
+
+    const first = await createCampaign(
+      { ...baseBody("Cold Email — booked meetings"), brandIds, legKey: BOOKED_FROM_CONVERSATION },
+      channelFeature,
+    ).expect(201);
+
+    // The SAME (org, brand, funnel, channel, leg). One live campaign per identity, so this is the
+    // same campaign restated — never a second row racing it for the brand's turn.
+    const again = await createCampaign(
+      { ...baseBody("Cold Email — booked meetings, restated"), brandIds, legKey: BOOKED_FROM_CONVERSATION },
+      channelFeature,
+    ).expect(200);
+
+    expect(again.body.campaign.id).toBe(first.body.campaign.id);
+    expect(again.body.campaign.legKey).toBe(BOOKED_FROM_CONVERSATION);
+  });
+
   it("a campaign created WITHOUT a leg states none — and nothing else about it changes", async () => {
     const body = baseBody("Legless Campaign");
 

--- a/tests/unit/channel-operator-client.test.ts
+++ b/tests/unit/channel-operator-client.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { fetchChannelOperators } from "../../src/lib/channel-operator-client.js";
+import { fetchChannelCatalogue } from "../../src/lib/channel-operator-client.js";
 
 /**
  * WHO operates a channel is features-service's statement, read from its PUBLIC catalogue. These
@@ -12,7 +12,7 @@ import { fetchChannelOperators } from "../../src/lib/channel-operator-client.js"
  * only ever agrees with its own mock is what took the sales-funnels read out of production for
  * its whole life.
  */
-describe("fetchChannelOperators", () => {
+describe("fetchChannelCatalogue", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.FEATURES_SERVICE_URL = "https://features.test.local";
@@ -30,16 +30,59 @@ describe("fetchChannelOperators", () => {
       }),
     });
 
-    const read = await fetchChannelOperators();
+    const read = await fetchChannelCatalogue();
     expect(read.ok).toBe(true);
     if (!read.ok) return;
     expect(read.operatorBySlug.get("sales-cold-email-outreach")).toBe("platform");
     expect(read.operatorBySlug.get("in-house-meeting-booking")).toBe("customer");
   });
 
+  it("reads the LEGS each channel performs, carrying the identifier verbatim", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        channels: [
+          {
+            slug: "sales-cold-email-outreach",
+            operatedBy: "platform",
+            // The two steps ride BESIDE the identifier, which is why nothing ever splits it.
+            stepTransitions: [
+              { legKey: "start_to_conversation", from: null, to: { key: "conversation" } },
+            ],
+          },
+          {
+            slug: "in-house-meeting-booking",
+            operatedBy: "customer",
+            stepTransitions: [
+              { legKey: "conversation_to_meeting_booked" },
+              { legKey: "meeting_booked_to_meeting_attended" },
+            ],
+          },
+          // A channel that performs no leg of any declared funnel states an EMPTY set — a
+          // truthful answer, and not the same thing as a slug the catalogue never names.
+          { slug: "press-kit-page-generation", operatedBy: "platform", stepTransitions: [] },
+        ],
+        legs: [],
+        steps: [],
+      }),
+    });
+
+    const read = await fetchChannelCatalogue();
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect([...read.legsBySlug.get("sales-cold-email-outreach")!]).toEqual(["start_to_conversation"]);
+    expect([...read.legsBySlug.get("in-house-meeting-booking")!].sort()).toEqual([
+      "conversation_to_meeting_booked",
+      "meeting_booked_to_meeting_attended",
+    ]);
+    expect([...read.legsBySlug.get("press-kit-page-generation")!]).toEqual([]);
+    // A slug the catalogue does not publish is ABSENT, never an empty set.
+    expect(read.legsBySlug.has("google-ads")).toBe(false);
+  });
+
   it("carries NO identity — no customer identity ever appears on that path", async () => {
     mockFetch.mockResolvedValue({ ok: true, json: async () => ({ channels: [], steps: [] }) });
-    await fetchChannelOperators();
+    await fetchChannelCatalogue();
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit | undefined];
     expect(url).toBe("https://features.test.local/public/channels");
     expect(init).toBeUndefined();
@@ -50,7 +93,7 @@ describe("fetchChannelOperators", () => {
       ok: true,
       json: async () => ({ channels: [{ slug: "google-ads", operatedBy: "platform" }], steps: [] }),
     });
-    const read = await fetchChannelOperators();
+    const read = await fetchChannelCatalogue();
     expect(read.ok).toBe(true);
     if (!read.ok) return;
     // An unpublished slug is absent rather than defaulted here: the CALLER decides what an
@@ -66,7 +109,7 @@ describe("fetchChannelOperators", () => {
         steps: [],
       }),
     });
-    const read = await fetchChannelOperators();
+    const read = await fetchChannelCatalogue();
     expect(read.ok).toBe(true);
     if (!read.ok) return;
     expect(read.operatorBySlug.has("partner-run-thing")).toBe(false);
@@ -74,7 +117,7 @@ describe("fetchChannelOperators", () => {
 
   it("says a failure is a failure — never an empty catalogue", async () => {
     mockFetch.mockResolvedValue({ ok: false, status: 503, text: async () => "unavailable" });
-    const read = await fetchChannelOperators();
+    const read = await fetchChannelCatalogue();
     expect(read.ok).toBe(false);
     if (read.ok) return;
     expect(read.detail).toContain("503");
@@ -82,13 +125,13 @@ describe("fetchChannelOperators", () => {
 
   it("refuses a payload that states no channels array", async () => {
     mockFetch.mockResolvedValue({ ok: true, json: async () => ({ steps: [] }) });
-    const read = await fetchChannelOperators();
+    const read = await fetchChannelCatalogue();
     expect(read.ok).toBe(false);
   });
 
   it("says so when features-service is not configured", async () => {
     delete process.env.FEATURES_SERVICE_URL;
-    const read = await fetchChannelOperators();
+    const read = await fetchChannelCatalogue();
     expect(read.ok).toBe(false);
     expect(mockFetch).not.toHaveBeenCalled();
   });

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -93,6 +93,12 @@ const GOOGLE_ADS = "google-ads";
 // themselves. features-service publishes who operates each channel; nothing here holds a list.
 const IN_HOUSE_BOOKING = "in-house-meeting-booking";
 const ANCESTOR_RUN_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+// features-service MINTS these; the tests carry them verbatim exactly as the service does. They
+// are deliberately three DIFFERENT legs of the SAME funnel: what a customer buys is one leg, and
+// two legs of one funnel through one channel are two campaigns.
+const ENTRY_LEG = "start_to_conversation";
+const BOOKING_LEG = "conversation_to_meeting_booked";
+const ATTENDED_LEG = "meeting_booked_to_meeting_attended";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // The brand's alive campaigns, as the sales-scoped liveness check reads them.
@@ -109,6 +115,7 @@ function claimed(overrides: Partial<ClaimedFunnelCampaign> = {}): ClaimedFunnelC
     featureSlug: SALES,
     funnelKey: null,
     dailyBudgetCents: null,
+    legKey: null,
     ...overrides,
   };
 }
@@ -125,6 +132,16 @@ function mockFunnelBudgets(
   // billing deploy that does not serve it, which every test below relies on to prove the
   // per-funnel behaviour is untouched.
   channels?: Array<{ funnelKey: string; featureSlug: string; dailyBudgetCents: string }>,
+  // The FINEST grain billing stores: one row per (funnel, channel, offer, LEG) — the unit a
+  // campaign is bought at. Omitted = a billing deploy that does not serve it, which is what every
+  // test above relies on to prove the pair/funnel behaviour is untouched.
+  legs?: Array<{
+    funnelKey: string;
+    featureSlug: string;
+    offerId?: string | null;
+    legKey: string | null;
+    dailyBudgetCents: string;
+  }>,
 ) {
   mockFetch.mockResolvedValueOnce({
     ok: true,
@@ -136,6 +153,9 @@ function mockFunnelBudgets(
           : brandDailyBudgetCents,
       funnels: funnels.map(f => ({ ...f, updatedAt: null })),
       ...(channels ? { channels: channels.map(c => ({ ...c, updatedAt: null })) } : {}),
+      ...(legs
+        ? { legs: legs.map(l => ({ offerId: null, ...l, updatedAt: null })) }
+        : {}),
     }),
   });
 }
@@ -171,11 +191,17 @@ function catalogueResponse() {
     ok: true,
     json: async () => ({
       channels: [
-        { slug: SALES, operatedBy: "platform" },
-        { slug: FEEDBACK, operatedBy: "platform" },
-        { slug: GOOGLE_ADS, operatedBy: "platform" },
-        { slug: IN_HOUSE_BOOKING, operatedBy: "customer" },
+        { slug: SALES, operatedBy: "platform", stepTransitions: [{ legKey: ENTRY_LEG }] },
+        { slug: FEEDBACK, operatedBy: "platform", stepTransitions: [{ legKey: ENTRY_LEG }] },
+        { slug: GOOGLE_ADS, operatedBy: "platform", stepTransitions: [{ legKey: ENTRY_LEG }] },
+        {
+          slug: IN_HOUSE_BOOKING,
+          operatedBy: "customer",
+          // The customer's own team performs the two INTERNAL legs; it starts nothing.
+          stepTransitions: [{ legKey: BOOKING_LEG }, { legKey: ATTENDED_LEG }],
+        },
       ],
+      legs: [],
       steps: [],
     }),
   };
@@ -395,6 +421,144 @@ describe("planFunnelTurns", () => {
     // belongs to another offer and which workflow-service would refuse for this feature.
     const feedback = inserted.find(v => v.featureSlug === FEEDBACK)!;
     expect(feedback.workflowSlug).toBe(`${FEEDBACK}-seed`);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────
+  // The LEG is what a customer BUYS, so it is what a campaign is provisioned, found and
+  // deduplicated on. A leg belongs to SEVERAL funnels at once, which is why the funnel never
+  // identified the purchase — and why these tests never name a funnel where a leg is the subject.
+  // ─────────────────────────────────────────────────────────────────────────────────────────
+
+  it("provisions ONE campaign per funded LEG, each stating the leg it was bought for", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+      "3000",
+      [{ funnelKey: "reply_meeting", featureSlug: IN_HOUSE_BOOKING, dailyBudgetCents: "3000" }],
+      [
+        { funnelKey: "reply_meeting", featureSlug: IN_HOUSE_BOOKING, legKey: BOOKING_LEG, dailyBudgetCents: "2000" },
+        { funnelKey: "reply_meeting", featureSlug: IN_HOUSE_BOOKING, legKey: ATTENDED_LEG, dailyBudgetCents: "1000" },
+      ],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    const inserted = mockInsertValues.mock.calls.map(c => c[0]);
+    // TWO campaigns on ONE channel of ONE funnel — which is impossible to express without the leg,
+    // and is exactly the pair the leg exists to tell apart.
+    expect(inserted).toHaveLength(2);
+    expect(inserted.map(v => v.legKey).sort()).toEqual([BOOKING_LEG, ATTENDED_LEG].sort());
+    for (const values of inserted) {
+      expect(values.featureSlug).toBe(IN_HOUSE_BOOKING);
+      expect(values.name).toBe(
+        funnelCampaignName(values.featureSlug, "brand-1", values.funnelKey, values.legKey),
+      );
+    }
+    // Two names, or the unique-name index would silently swallow the second insert as a race.
+    expect(new Set(inserted.map(v => v.name)).size).toBe(2);
+  });
+
+  it("asks the channel about the LEG, naming no funnel", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: IN_HOUSE_BOOKING, dailyBudgetCents: "1000" }],
+      [{ funnelKey: "reply_meeting", featureSlug: IN_HOUSE_BOOKING, legKey: BOOKING_LEG, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(1);
+    // The per-feature "which FUNNELS does this channel sell?" read is not made at all: the
+    // question is about a leg, and the public catalogue answers it.
+    const funnelQuestions = mockFetch.mock.calls.filter((c) => String(c[0]).includes("/features/"));
+    expect(funnelQuestions).toHaveLength(0);
+    expect(
+      mockFetch.mock.calls.some((c) => String(c[0]).includes("/public/channels")),
+    ).toBe(true);
+  });
+
+  it("never provisions a leg the channel does not perform", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "1000" }],
+      // The cold-email channel starts a conversation; it does not sit in a meeting.
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, legKey: ATTENDED_LEG, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("provisions nothing for a leg when the catalogue cannot be READ — and says so", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "1000" }],
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, legKey: ENTRY_LEG, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+    const base = mockFetch.getMockImplementation()!;
+    mockFetch.mockImplementation(async (input: URL | string) => {
+      if (String(input).includes("/public/channels")) {
+        return { ok: false, status: 503, text: async () => "down" };
+      }
+      return base(input);
+    });
+
+    const said = await captureWarnings(() =>
+      planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]),
+    );
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(said).toContain("could not READ features-service's channel catalogue");
+  });
+
+  it("ADOPTS the campaign already doing the work instead of growing a twin beside it", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "1000" }],
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, legKey: ENTRY_LEG, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    // Nothing states this leg; the live campaign of the same (funnel, channel) states none at all.
+    mockFindFirst
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue({ id: "incumbent", status: "ongoing", legKey: null });
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(mockUpdateSet).toHaveBeenCalledWith(expect.objectContaining({ legKey: ENTRY_LEG }));
+  });
+
+  it("leaves a campaign that states no leg exactly as it is when billing states none either", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "1000" }],
+      // The pre-leg population: billing serves the grain, and every row states no leg.
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, legKey: null, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    const inserted = mockInsertValues.mock.calls.map(c => c[0]);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].legKey).toBeNull();
+    // The name it has always had, byte for byte, so nothing alive is renamed or re-provisioned.
+    expect(inserted[0].name).toBe(funnelCampaignName(SALES, "brand-1", "sales_meetings_from_conversation"));
   });
 
   it("never provisions a pair the channel may not be sold through", async () => {

--- a/tests/unit/funnel-leg-ceiling.test.ts
+++ b/tests/unit/funnel-leg-ceiling.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  fetchFunnelBudgets,
+  legCeilingCents,
+  fundedLegRows,
+  type FunnelBudgetsRead,
+} from "../../src/lib/funnel-budget-client.js";
+import { fundingFromBudgets } from "../../src/lib/campaign-funding.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const IDENTITY = { orgId: "org-1", userId: "user-1" };
+
+const FUNNEL = "sales_meetings_from_conversation";
+const SALES = "sales-cold-email-outreach";
+const FEEDBACK = "feedback-request-cold-email-outreach";
+const OFFER_A = "d5ecba00-783a-4939-b5bd-f85b9e6b7d9e";
+const OFFER_B = "8f1e2c44-6a10-4d3b-9c77-1b2a3c4d5e6f";
+// features-service MINTS these; they are carried verbatim and never parsed.
+const BOOKING_LEG = "conversation_to_meeting_booked";
+const ATTENDED_LEG = "meeting_booked_to_meeting_attended";
+
+type LegRow = {
+  funnelKey: string;
+  featureSlug: string;
+  offerId: string | null;
+  legKey: string | null;
+  dailyBudgetCents: number;
+};
+
+/**
+ * A read shaped as billing serves it: every coarser grain is the SUM of the leg rows, which is
+ * exactly what makes the offer figure the wrong ceiling for an offer worked for two legs.
+ */
+function readWith(legs: LegRow[]): Extract<FunnelBudgetsRead, { ok: true }> {
+  const offers = new Map<string, { funnelKey: string; featureSlug: string; offerId: string | null; dailyBudgetCents: number }>();
+  for (const l of legs) {
+    const key = `${l.funnelKey}|${l.featureSlug}|${l.offerId ?? ""}`;
+    const seen = offers.get(key);
+    if (seen) seen.dailyBudgetCents += l.dailyBudgetCents;
+    else offers.set(key, { funnelKey: l.funnelKey, featureSlug: l.featureSlug, offerId: l.offerId, dailyBudgetCents: l.dailyBudgetCents });
+  }
+  const offerRows = [...offers.values()];
+  const total = legs.reduce((s, l) => s + l.dailyBudgetCents, 0);
+  return {
+    ok: true,
+    brandDailyBudgetCents: total,
+    funnels: [{ funnelKey: FUNNEL, dailyBudgetCents: total }],
+    channels: offerRows.map((o) => ({ funnelKey: o.funnelKey, featureSlug: o.featureSlug, dailyBudgetCents: o.dailyBudgetCents })),
+    offers: offerRows,
+    legs,
+  };
+}
+
+describe("legCeilingCents", () => {
+  it("binds a campaign to its OWN leg's money, never the offer SUM the sibling leg is in", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: ATTENDED_LEG, dailyBudgetCents: 1000 },
+    ]);
+    // The offer figure is 3000 — the SUM. Pacing either campaign on it hands each the other's money.
+    expect(read.offers[0]!.dailyBudgetCents).toBe(3000);
+    expect(legCeilingCents(read, FUNNEL, SALES, OFFER_A, BOOKING_LEG)).toEqual({ grain: "leg", cents: 2000 });
+    expect(legCeilingCents(read, FUNNEL, SALES, OFFER_A, ATTENDED_LEG)).toEqual({ grain: "leg", cents: 1000 });
+  });
+
+  it("says UNFUNDED for a leg the brand's money is not scoped to — never a fallback", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+    ]);
+    expect(legCeilingCents(read, FUNNEL, SALES, OFFER_A, ATTENDED_LEG)).toEqual({ grain: "leg", cents: null });
+  });
+
+  it("has nothing to say about a campaign that states NO leg", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+    ]);
+    expect(legCeilingCents(read, FUNNEL, SALES, OFFER_A, null)).toEqual({ grain: "none" });
+  });
+
+  it("has nothing to say about a brand whose ceilings name no leg at all", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: null, dailyBudgetCents: 2000 },
+    ]);
+    expect(legCeilingCents(read, FUNNEL, SALES, OFFER_A, BOOKING_LEG)).toEqual({ grain: "none" });
+  });
+
+  it("has nothing to say when billing serves no leg grain at all (an older deploy)", () => {
+    const read = { ...readWith([]), legs: [] };
+    expect(legCeilingCents(read, FUNNEL, SALES, OFFER_A, BOOKING_LEG)).toEqual({ grain: "none" });
+  });
+
+  it("binds whatever feature the campaign states when the funnel is worked through ONE channel", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+    ]);
+    expect(legCeilingCents(read, FUNNEL, FEEDBACK, OFFER_A, BOOKING_LEG)).toEqual({ grain: "leg", cents: 2000 });
+  });
+
+  it("refuses the neighbour's money when the funnel IS split across channels", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+      { funnelKey: FUNNEL, featureSlug: FEEDBACK, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 500 },
+    ]);
+    expect(legCeilingCents(read, FUNNEL, "google-ads", OFFER_A, BOOKING_LEG)).toEqual({ grain: "leg", cents: null });
+  });
+
+  it("keeps billing's offer rule: another offer's leg money is not this offer's", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_B, legKey: BOOKING_LEG, dailyBudgetCents: 500 },
+    ]);
+    expect(legCeilingCents(read, FUNNEL, SALES, OFFER_A, BOOKING_LEG)).toEqual({ grain: "leg", cents: 2000 });
+    expect(legCeilingCents(read, FUNNEL, SALES, OFFER_B, BOOKING_LEG)).toEqual({ grain: "leg", cents: 500 });
+  });
+
+  it("falls through unchanged when the brand's money is scoped to offers and the campaign states none", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+    ]);
+    expect(legCeilingCents(read, FUNNEL, SALES, null, BOOKING_LEG)).toEqual({ grain: "none" });
+  });
+});
+
+describe("fundingFromBudgets — the leg notch", () => {
+  it("paces a leg campaign on its own leg's ceiling", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: ATTENDED_LEG, dailyBudgetCents: 1000 },
+    ]);
+    expect(
+      fundingFromBudgets(
+        { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: ATTENDED_LEG },
+        read,
+      ),
+    ).toEqual({ funded: true, ceilingCents: 1000 });
+  });
+
+  it("holds a campaign whose leg the customer funds nothing for", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+    ]);
+    const verdict = fundingFromBudgets(
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: ATTENDED_LEG },
+      read,
+    );
+    expect(verdict.funded).toBe(false);
+  });
+
+  it("leaves a leg-less campaign on the offer figure, byte for byte", () => {
+    const read = readWith([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: ATTENDED_LEG, dailyBudgetCents: 1000 },
+    ]);
+    expect(
+      fundingFromBudgets({ funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A }, read),
+    ).toEqual({ funded: true, ceilingCents: 3000 });
+  });
+});
+
+describe("fetchFunnelBudgets — the leg grain on the wire", () => {
+  function respond(body: unknown) {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => body });
+  }
+
+  it("carries the leg rows, canonicalising the funnel and keeping a null leg as a VALUE", async () => {
+    process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+    process.env.BILLING_SERVICE_API_KEY = "k";
+    respond({
+      brandId: "brand-1",
+      dailyBudgetCents: "3000",
+      funnels: [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+      legs: [
+        { funnelKey: "reply_meeting", featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: "2000" },
+        { funnelKey: "reply_meeting", featureSlug: SALES, offerId: null, legKey: null, dailyBudgetCents: "1000" },
+      ],
+    });
+
+    const read = await fetchFunnelBudgets("brand-1", IDENTITY);
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.legs).toEqual([
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: OFFER_A, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+      { funnelKey: FUNNEL, featureSlug: SALES, offerId: null, legKey: null, dailyBudgetCents: 1000 },
+    ]);
+    // A ceiling of zero is a deliberate "do not work this", at every grain.
+    expect(fundedLegRows(read)).toHaveLength(2);
+  });
+
+  it("reads an ABSENT legs field as no finer grain, never as nothing funded", async () => {
+    process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+    process.env.BILLING_SERVICE_API_KEY = "k";
+    respond({
+      brandId: "brand-1",
+      dailyBudgetCents: "3000",
+      funnels: [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+    });
+
+    const read = await fetchFunnelBudgets("brand-1", IDENTITY);
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.legs).toEqual([]);
+    expect(read.funnels[0]!.dailyBudgetCents).toBe(3000);
+  });
+
+  it("refuses the whole read on an unparseable leg ceiling — never reads it as no ceiling", async () => {
+    process.env.BILLING_SERVICE_URL = "https://billing.test.local";
+    process.env.BILLING_SERVICE_API_KEY = "k";
+    respond({
+      brandId: "brand-1",
+      dailyBudgetCents: "3000",
+      funnels: [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+      legs: [{ funnelKey: "reply_meeting", featureSlug: SALES, offerId: null, legKey: BOOKING_LEG, dailyBudgetCents: "not-a-number" }],
+    });
+
+    expect((await fetchFunnelBudgets("brand-1", IDENTITY)).ok).toBe(false);
+  });
+});

--- a/tests/unit/gate-check.test.ts
+++ b/tests/unit/gate-check.test.ts
@@ -589,6 +589,56 @@ describe("Gate Check", () => {
       expect(result.allowed).toBe(true);
     });
 
+    it("should report an ALLOWED run as authorized by billing, not merely allowed", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ affordable: true, balanceCents: "5000" }),
+      });
+
+      const result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+      expect(result.creditCheck).toBe("affordable");
+      expect(result.creditCheckDetail).toBeUndefined();
+    });
+
+    it("should report a BLOCKED run as unaffordable", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ affordable: false, balanceCents: "0" }),
+      });
+
+      const result = await runGateChecks(makeCampaign());
+      expect(result.creditCheck).toBe("unaffordable");
+    });
+
+    it("should report the fail-open path as UNREADABLE, never as an authorization", async () => {
+      // The whole point: an incident must be able to tell "billing said yes" from "billing
+      // could not be asked". Both allow the run; only one of them is an authorization.
+      mockFetch.mockRejectedValueOnce(new Error("ECONNRESET"));
+      let result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+      expect(result.creditCheck).toBe("unreadable");
+      expect(result.creditCheckDetail).toBe("ECONNRESET");
+
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 502 });
+      result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+      expect(result.creditCheck).toBe("unreadable");
+      expect(result.creditCheckDetail).toBe("billing responded 502");
+
+      // A 200 that does not state `affordable` is not an answer either.
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ balanceCents: "5000" }) });
+      result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+      expect(result.creditCheck).toBe("unreadable");
+
+      delete process.env.BILLING_SERVICE_URL;
+      result = await runGateChecks(makeCampaign());
+      expect(result.allowed).toBe(true);
+      expect(result.creditCheck).toBe("unreadable");
+      expect(result.creditCheckDetail).toBe("billing not configured");
+    });
+
     it("should call the locked affordability contract with x-api-key + identity headers", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/tests/unit/spendable-budget.test.ts
+++ b/tests/unit/spendable-budget.test.ts
@@ -12,6 +12,7 @@ function budgets(partial: Partial<Extract<FunnelBudgetsRead, { ok: true }>>): Ex
     funnels: [],
     channels: [],
     offers: [],
+    legs: [],
     ...partial,
   };
 }
@@ -22,6 +23,7 @@ function campaign(over: Partial<SpendableCampaign> & { id: string }): SpendableC
     funnelKey: "sales_meetings_from_conversation",
     featureSlug: "sales-cold-email-outreach",
     offerId: null,
+    legKey: null,
     createdAt: new Date("2026-01-01T00:00:00Z"),
     ...over,
   };
@@ -153,6 +155,7 @@ describe("computeSpendableBudget", () => {
         funnelKey: "sales_meetings_from_conversation",
         featureSlug: "sales-cold-email-outreach",
         offerId: null,
+        legKey: null,
         configuredDailyBudgetCents: 0,
         runningDailyBudgetCents: 0,
       },
@@ -210,5 +213,38 @@ describe("computeSpendableBudget", () => {
       result.offers.reduce((s, o) => s + o.runningDailyBudgetCents, 0),
     );
     expect(result.runningDailyBudgetCents).toBe(4000);
+  });
+
+  it("counts at the LEG grain, giving each leg's money to the campaign bought for THAT leg", () => {
+    const BOOKING_LEG = "conversation_to_meeting_booked";
+    const ATTENDED_LEG = "meeting_booked_to_meeting_attended";
+    const result = computeSpendableBudget(
+      ORG,
+      BRAND,
+      budgets({
+        brandDailyBudgetCents: 3000,
+        funnels: [{ funnelKey: "sales_meetings_from_conversation", dailyBudgetCents: 3000 }],
+        // The offer figure is the SUM of the two legs. Counting there would find ONE campaign for
+        // a row that funds two, and report the other as running on nothing.
+        offers: [{ funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-cold-email-outreach", offerId: null, dailyBudgetCents: 3000 }],
+        legs: [
+          { funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-cold-email-outreach", offerId: null, legKey: BOOKING_LEG, dailyBudgetCents: 2000 },
+          { funnelKey: "sales_meetings_from_conversation", featureSlug: "sales-cold-email-outreach", offerId: null, legKey: ATTENDED_LEG, dailyBudgetCents: 1000 },
+        ],
+      }),
+      [
+        campaign({ id: "booking", legKey: BOOKING_LEG }),
+        campaign({ id: "attended", legKey: ATTENDED_LEG, status: "stopped" }),
+      ],
+    );
+
+    expect(result.grain).toBe("leg");
+    expect(result.configuredDailyBudgetCents).toBe(3000);
+    // Only the leg whose campaign is ongoing is running money — and it is ITS leg's figure, not
+    // the offer SUM that also holds the stopped sibling's.
+    expect(result.runningDailyBudgetCents).toBe(2000);
+    const lines = Object.fromEntries(result.campaigns.map((c) => [c.campaignId, c]));
+    expect(lines.booking).toMatchObject({ legKey: BOOKING_LEG, configuredDailyBudgetCents: 2000, runningDailyBudgetCents: 2000 });
+    expect(lines.attended).toMatchObject({ legKey: ATTENDED_LEG, configuredDailyBudgetCents: 1000, runningDailyBudgetCents: 0 });
   });
 });


### PR DESCRIPTION
## What

The LEG is now the axis a campaign is provisioned, identified and deduplicated on. The sales funnel becomes a way of READING legs.

A leg belongs to several funnels at once, so the funnel never identified what the customer bought. Everything needed for this was already live: features-service publishes each channel's legs, billing accepts a ceiling stated for a leg, the campaign row already carries the identifier, and the dashboard already states it at create. What was left is that this service still provisioned on the funnel, keyed its existing-campaign lookup on it, and asked siblings about it.

A `(funnel, channel, offer)` worked for TWO legs was one provisioning question, one identity and one summed ceiling — one campaign doing two jobs on money funded for two.

## Changes

- **`fundedPairs` reads billing's `legs[]` grain first** (funnel, channel, offer, `legKey`), falling back to `channels` then `funnels`. Every coarser grain billing serves is a SUM of these rows, so nothing is added up here. A row whose `legKey` is null is a ceiling written before legs existed and provisions a leg-less campaign byte-identically to what the pair grain provisioned for it.
- **`legCeilingCents`** sits one notch below `offerCeilingCents` on the one shared precedence (own `dailyBudgetCents` → LEG → offer → pair → funnel → brand pot), in `gate-check` and `campaign-funding`. Same three answers and the same reasons as every grain above it; the offer half of the match is billing's own rule, mirrored rather than re-invented. A campaign that states no leg — and a brand whose ceilings name none — answers `grain: "none"` and paces exactly as it always did.
- **What a channel can do is asked in the LEG vocabulary, naming no funnel.** features-service publishes `channels[].stepTransitions[].legKey` on the same public catalogue this pass already reads for `operatedBy`, so one read answers both and the identifier is joined verbatim (never parsed). A pair that states no leg keeps asking the per-feature FUNNEL question, unchanged — that IS the question for a pre-leg ceiling. An unreadable catalogue provisions nothing for that leg and says so.
- **The existing-campaign lookup and the deterministic campaign name key on the leg.** Two legs of one channel are two campaigns; the same leg is never provisioned twice (the name would otherwise collide on `uniq_campaigns_org_name` and swallow the second insert as a race). A leg-less campaign keeps the name it has always had, byte for byte.
- **A live leg-less campaign of the same identity is ADOPTED, not twinned.** It has been doing exactly this work since before a campaign could say which leg it was bought for. Nothing else about the row moves; guarded on the row still stating no leg, and a `23505` leaves it alone and says so.
- **`spendable-budget` counts at the leg grain** (`grain` gained `leg`, rows and campaign lines gained `legKey`), or a `(funnel, channel, offer)` funding two legs would give one campaign the whole summed figure and report the other as running on nothing — a secondary surface contradicting the ceiling the gate binds.

## Not in this ship

- **No migration.** 0055 already added `leg_key` and widened `uniq_campaigns_org_brand_funnel_channel` with `coalesce(leg_key, '')`.
- **The leg stays OPTIONAL at create.** Other surfaces still create campaigns without one; a campaign that states none behaves exactly as it does today and is adopted on a later tick.
- **The funnel COLUMN stays.** Still part of the identity index, still what billing's rows and brand-service's declarations key on. Dropping it is a later, separate step once nothing reads it.
- **Pacing, scheduling and serialization are untouched.** The turn planner still ranks on spent ÷ own ceiling (that ceiling is simply the leg's when one binds), the cohorts are still the acquisition channel's, the cadences are the same.

## Verification

`759 tests / 57 files` green (unit + integration against a prod-shaped database), `tsc --noEmit` clean, build + `openapi.json` regenerated.

New coverage: `tests/unit/funnel-leg-ceiling.test.ts` (the ceiling rules and the wire shape), the leg block in `tests/unit/funnel-campaigns.test.ts` (one campaign per funded leg, the leg-keyed channel question, an unperformed leg, an unreadable catalogue, adoption instead of a twin, a leg-less pair unchanged), the leg grain in `tests/unit/spendable-budget.test.ts`, the catalogue's leg parsing, and a dedup case in `tests/integration/campaign-leg.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)