### PR TITLE
feat(events): a lead reaching a step runs the campaign bought for the leg out of it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -716,6 +716,57 @@ campaign doing two jobs on money funded for two.
 
 (Set 2026-08-31.)
 
+## A lead reaching a STEP runs the campaign bought for the leg OUT of it, NOW — an event entry point beside the clock
+
+Everything this service schedules is on a clock: the tick claims what is due, `/end-run` reschedules
+what just finished. Nothing could say "this just happened, run the campaign responsible for it", so
+a prospect who states a sales interest waited for that campaign's next daily tick before anyone
+answered them — which is the whole problem the leg they bought exists to solve.
+
+`POST /internal/campaigns/trigger-for-step` (`src/lib/step-trigger.ts`) is that entry point. The
+caller names the scope its lead is on — brand, offer, funnel — plus the STEP just reached, and the
+campaign bought for the leg OUT of that step runs immediately.
+
+- **It is a LOOKUP over state already held, not a new model.** A campaign states its (org, brand,
+  offer, funnel, channel) and the single LEG it was bought for; features-service publishes which leg
+  leaves which step. Joining the two is the whole resolution — no column, table, vocabulary,
+  accumulator or second scheduler.
+- **THE LEG IS ASKED, NEVER DERIVED, AND NEVER PARSED.** The legs out of a step come from the public
+  catalogue this service already reads (`GET /public/channels` -> `legs[]`, each carrying `legKey`,
+  `fromStep` and the funnels it is a leg of), joined VERBATIM against `campaigns.leg_key`. The steps
+  ride beside the identifier precisely so nobody splits it, and a well-formed `a_to_b` no catalogue
+  names is still not a leg. `channel-operator-client.ts` stays the ONE reader of that catalogue.
+- **The FUNNEL is part of the question because a leg belongs to several.** `sales_interest ->
+  meeting_booked` is a leg of more than one chain, and only the customer's funding says which one
+  they bought — so it is named by the caller rather than derived from the leg.
+- **THE GATE IS UNTOUCHED.** The dispatch is the SCHEDULER'S OWN — same anchor run
+  (`ensureCampaignRunId`), same greedy workflow pick, same `/execute` — so the run starts at
+  `gate-check`, the first node of every DAG, and is refused there exactly as a scheduled run is.
+  Before dispatching it applies the same two CORRECTNESS guards the scheduler applies (never two
+  runs of one campaign, never two of one brand COHORT — the outbound channels share a lead
+  population and a set of sending accounts) and the one shared funding definition
+  (`campaignFunding`, fail-CLOSED). A reply must never make a defunded, held or stopped campaign
+  spend.
+- **THE SCOPE FAILS LOUD; THE ANSWER IS OFTEN A NAMED NOTHING.** A step no catalogue publishes, a
+  funnel naming none of the four, and a catalogue that cannot be READ are a 400/400/502 — answering
+  them with "nothing to do" would make an unreachable feature indistinguishable from a brand that
+  simply has no campaign for this leg. Everything else is a 200: no campaign performs the leg
+  (the common case, empty), or one does and was skipped for a NAMED reason (`no_workflow` — the
+  customer operates that channel, so there is no DAG; `unfunded`; `run_in_flight`;
+  `cohort_run_in_flight`; `incomplete_campaign`; `dispatch_refused`). A caller can tell those from
+  an outage, which is the whole point.
+- **The OFFER is matched exactly and never inferred.** A campaign stating none is not the campaign
+  of the offer the caller named — the same posture the column has had since it was added.
+- **The time-based path is byte-identical.** No claim, cadence, defer, turn or reschedule changed;
+  this only adds a second way in.
+- **The downstream needed NO new payload.** A run names its campaign (`x-campaign-id`), and
+  `GET /campaigns/:id` already serves that row's `offerId`, `funnelKey` and `legKey` — so a node
+  that must read the funnel's own configuration from brand-service resolves it from the campaign.
+  Nothing was added to the `/start-run` response, which already re-serves several campaign fields
+  and at least one retired vocabulary; another copy would make that worse.
+
+(Set 2026-09-02.)
+
 ## The OFFER a campaign sells is brand-service's UUID, carried and never derived
 
 A new level sits between the brand and the campaign: **Org > Brand > Offer > Campaign**. An offer is

--- a/openapi.json
+++ b/openapi.json
@@ -1112,6 +1112,107 @@
         "required": [
           "updatedTables"
         ]
+      },
+      "TriggerForStepResponse": {
+        "type": "object",
+        "properties": {
+          "funnelKey": {
+            "type": "string"
+          },
+          "step": {
+            "type": "string"
+          },
+          "legKeys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "triggered": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "campaignId": {
+                  "type": "string"
+                },
+                "legKey": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "workflowSlug": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "campaignId",
+                "legKey",
+                "workflowSlug"
+              ]
+            }
+          },
+          "skipped": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "campaignId": {
+                  "type": "string"
+                },
+                "legKey": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "detail": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "campaignId",
+                "legKey",
+                "reason",
+                "detail"
+              ]
+            }
+          }
+        },
+        "required": [
+          "funnelKey",
+          "step",
+          "legKeys",
+          "triggered",
+          "skipped"
+        ]
+      },
+      "TriggerForStepBody": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "offerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "funnelKey": {
+            "type": "string",
+            "minLength": 1
+          },
+          "step": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "brandId",
+          "offerId",
+          "funnelKey",
+          "step"
+        ]
       }
     },
     "parameters": {}
@@ -2546,6 +2647,93 @@
           },
           "500": {
             "description": "Teardown failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/campaigns/trigger-for-step": {
+      "post": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Run the campaign bought for the leg out of the step a lead just reached",
+        "description": "A lead reached a step on a (brand, offer, funnel); this runs the campaign bought for the leg OUT of that step immediately, instead of waiting for its next tick. The leg is features-service's statement (GET /public/channels -> legs[]) and the campaign is the one already stating that leg — nothing is inferred. The affordability/budget gate is untouched: the dispatch is the scheduler's own, so the run starts at gate-check like any other. A scope that cannot be resolved (unknown step, unknown funnel, unreadable catalogue) fails loudly; a scope with no such campaign, or one that is stopped, held for money, already running or operated by the customer's own team, is an ordinary 200 with a NAMED skip. The org rides on x-org-id.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal org UUID from client-service",
+            "name": "x-org-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TriggerForStepBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "What ran and what did not",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TriggerForStepResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No org, malformed body, unknown funnel or unknown step",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "The acquisition-channel catalogue could not be read",
             "content": {
               "application/json": {
                 "schema": {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -27,6 +27,8 @@ import {
   SpendableBudgetResponse,
   BatchSpendableBudgetBody,
   BatchSpendableBudgetResponse,
+  TriggerForStepBody,
+  TriggerForStepResponse,
 } from "../src/schemas.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -391,6 +393,29 @@ registry.registerPath({
     200: { description: "Org campaign state disabled", content: { "application/json": { schema: DeleteCampaignsByOrgResponse } } },
     401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
     500: { description: "Teardown failed", content: { "application/json": { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/campaigns/trigger-for-step",
+  tags: ["Internal"],
+  summary: "Run the campaign bought for the leg out of the step a lead just reached",
+  description:
+    "A lead reached a step on a (brand, offer, funnel); this runs the campaign bought for the leg OUT of that step immediately, instead of waiting for its next tick. The leg is features-service's statement (GET /public/channels -> legs[]) and the campaign is the one already stating that leg — nothing is inferred. The affordability/budget gate is untouched: the dispatch is the scheduler's own, so the run starts at gate-check like any other. A scope that cannot be resolved (unknown step, unknown funnel, unreadable catalogue) fails loudly; a scope with no such campaign, or one that is stopped, held for money, already running or operated by the customer's own team, is an ordinary 200 with a NAMED skip. The org rides on x-org-id.",
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: {
+    headers: z.object({
+      "x-org-id": z.string().openapi({ description: "Internal org UUID from client-service" }),
+    }),
+    body: { content: { "application/json": { schema: TriggerForStepBody } } },
+  },
+  responses: {
+    200: { description: "What ran and what did not", content: { "application/json": { schema: TriggerForStepResponse } } },
+    400: { description: "No org, malformed body, unknown funnel or unknown step", content: { "application/json": { schema: ErrorResponse } } },
+    401: { description: "Unauthorized", content: { "application/json": { schema: ErrorResponse } } },
+    502: { description: "The acquisition-channel catalogue could not be read", content: { "application/json": { schema: ErrorResponse } } },
+    500: { description: "Internal error", content: { "application/json": { schema: ErrorResponse } } },
   },
 });
 

--- a/src/lib/campaign-funding.ts
+++ b/src/lib/campaign-funding.ts
@@ -176,6 +176,8 @@ export async function campaignFunding(
     funnelKey?: string | null;
     featureSlug?: string | null;
     offerId?: string | null;
+    /** The LEG it was bought for — the finest grain billing stores, so the first one asked. */
+    legKey?: string | null;
   },
   brandId: string,
   identity: IdentityHeaders,

--- a/src/lib/channel-operator-client.ts
+++ b/src/lib/channel-operator-client.ts
@@ -32,6 +32,18 @@
  */
 export type ChannelOperator = "platform" | "customer";
 
+/**
+ * ONE leg of the published vocabulary, narrowed to what this service reads: the identifier it
+ * carries verbatim, the step a lead is taken OUT of (`null` is "from nothing" — this leg starts a
+ * funnel), and every declared funnel the leg is a leg of. The steps ride BESIDE the identifier on
+ * the catalogue precisely so nobody splits it, so they are read here and never derived.
+ */
+export interface CatalogueLeg {
+  legKey: string;
+  fromStepKey: string | null;
+  funnelKeys: ReadonlySet<string>;
+}
+
 export type ChannelCatalogueRead =
   | {
       ok: true;
@@ -42,6 +54,18 @@ export type ChannelCatalogueRead =
        * channel that publishes an empty set, and the call site treats it as such.
        */
       legsBySlug: Map<string, ReadonlySet<string>>;
+      /**
+       * EVERY leg of every declared funnel, published beside the channels. Read so a caller naming
+       * the step a lead just reached can be answered with the leg OUT of it, without this service
+       * holding a leg vocabulary of its own.
+       */
+      legs: readonly CatalogueLeg[];
+      /**
+       * Every step key the catalogue publishes. A caller naming a step that is not one of these is
+       * naming nothing, and is told so rather than answered with an empty result — the two are
+       * different statements and only one of them is a caller's mistake.
+       */
+      stepKeys: ReadonlySet<string>;
     }
   | { ok: false; detail: string };
 
@@ -69,6 +93,12 @@ export async function fetchChannelCatalogue(): Promise<ChannelCatalogueRead> {
         operatedBy?: unknown;
         stepTransitions?: Array<{ legKey?: unknown }>;
       }>;
+      legs?: Array<{
+        legKey?: unknown;
+        fromStep?: { key?: unknown } | null;
+        funnelKeys?: unknown;
+      }>;
+      steps?: Array<{ key?: unknown }>;
     };
     if (!Array.isArray(data.channels)) {
       return { ok: false, detail: "response states no channels array" };
@@ -96,7 +126,35 @@ export async function fetchChannelCatalogue(): Promise<ChannelCatalogueRead> {
       if (channel.operatedBy !== "platform" && channel.operatedBy !== "customer") continue;
       operatorBySlug.set(channel.slug, channel.operatedBy);
     }
-    return { ok: true, operatorBySlug, legsBySlug };
+    const legs: CatalogueLeg[] = [];
+    if (Array.isArray(data.legs)) {
+      for (const leg of data.legs) {
+        if (typeof leg?.legKey !== "string" || leg.legKey.length === 0) continue;
+        const funnelKeys = new Set<string>();
+        if (Array.isArray(leg.funnelKeys)) {
+          for (const key of leg.funnelKeys) {
+            if (typeof key === "string" && key.length > 0) funnelKeys.add(key);
+          }
+        }
+        const fromKey = leg.fromStep?.key;
+        legs.push({
+          legKey: leg.legKey,
+          // An ENTRY leg states no step before it, and that is an ordinary leg — the absence is
+          // data, not a special spelling to branch on.
+          fromStepKey: typeof fromKey === "string" && fromKey.length > 0 ? fromKey : null,
+          funnelKeys,
+        });
+      }
+    }
+
+    const stepKeys = new Set<string>();
+    if (Array.isArray(data.steps)) {
+      for (const step of data.steps) {
+        if (typeof step?.key === "string" && step.key.length > 0) stepKeys.add(step.key);
+      }
+    }
+
+    return { ok: true, operatorBySlug, legsBySlug, legs, stepKeys };
   } catch (err) {
     return { ok: false, detail: err instanceof Error ? err.message : String(err) };
   }

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -313,7 +313,7 @@ async function planOneBrand(
  * offer they carry. Every other channel is its own, keyed on the acquisition channel it already
  * states, so a paid-reach campaign is serial against itself and against nothing else.
  */
-function serializationCohort(featureSlug: string | null | undefined): string {
+export function serializationCohort(featureSlug: string | null | undefined): string {
   if (isOutboundSalesFeature(featureSlug)) return "outbound_cold_email";
   return acquisitionChannelForFeature(featureSlug) ?? "unknown_channel";
 }
@@ -1169,7 +1169,7 @@ const LIVE_RUN_FRESHNESS_MS = 15 * 60_000;
  * that is actually running is precisely the one NOT claimed (its nextRunAt is null while in
  * flight), so a group-scoped check would be blind to it.
  */
-async function hasLiveRunForBrandCohort(
+export async function hasLiveRunForBrandCohort(
   orgId: string,
   brandId: string,
   cohort: string,

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -35,7 +35,7 @@ export const IDLE_MAX_MS = 60 * 60_000; // 1 hour
 // (= 600s) value left a legit long fill sitting right at the orphan boundary, where
 // claimStuckCampaigns could misclassify it as stuck and re-fire mid-fill (→ lead-service
 // 409 "Concurrent buffer/next" storms). 15min gives margin above the observed max.
-const STUCK_RUN_FRESHNESS_THRESHOLD_MS = 15 * 60_000; // 15 minutes
+export const STUCK_RUN_FRESHNESS_THRESHOLD_MS = 15 * 60_000; // 15 minutes
 
 /**
  * Is a flow genuinely alive for this campaign right now?
@@ -57,7 +57,7 @@ const STUCK_RUN_FRESHNESS_THRESHOLD_MS = 15 * 60_000; // 15 minutes
  * threshold (workflow died without /end-run) no longer counts as alive, so the campaign
  * is re-claimed/re-fired.
  */
-async function hasLiveRunForCampaign(
+export async function hasLiveRunForCampaign(
   orgId: string,
   campaignId: string,
   freshnessCutoff: Date,

--- a/src/lib/step-trigger.ts
+++ b/src/lib/step-trigger.ts
@@ -1,0 +1,295 @@
+import { and, arrayContains, eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { campaigns } from "../db/schema.js";
+import { fetchChannelCatalogue } from "./channel-operator-client.js";
+import { toFunnelKey } from "./sales-funnel-vocabulary.js";
+import { campaignFunding } from "./campaign-funding.js";
+import { ensureCampaignRunId } from "./trigger-run.js";
+import { resolveWorkflowSlugForTrigger } from "./features-workflow-projection-client.js";
+import { executeCampaignWorkflow } from "./workflows.js";
+import {
+  hasLiveRunForBrandCohort,
+  serializationCohort,
+} from "./funnel-campaigns.js";
+import { hasLiveRunForCampaign, STUCK_RUN_FRESHNESS_THRESHOLD_MS } from "./scheduler.js";
+
+/**
+ * A LEAD JUST REACHED A STEP — RUN THE CAMPAIGN THAT WAS BOUGHT TO TAKE THEM OUT OF IT, NOW.
+ *
+ * Everything this service schedules is on a clock: the tick claims what is due, `/end-run`
+ * reschedules what just finished. Nothing anywhere could say "this happened, run the campaign
+ * responsible for it" — so a prospect who says "yes, interested" waits for the next daily tick
+ * before anyone answers them, which is the whole problem the leg they bought exists to solve.
+ *
+ * This is that entry point, and it is a LOOKUP over state this service already holds. A campaign
+ * states the (org, brand, offer, funnel, channel) it belongs to and the single LEG it was bought
+ * for; features-service publishes which leg leaves which step. Joining the two is the entire
+ * resolution — no new column, table, vocabulary or accumulator, and no second scheduler.
+ *
+ * ── WHAT IS ASKED, AND OF WHOM ──────────────────────────────────────────────────────────────────
+ *
+ * The caller names the STEP a lead just reached. The leg OUT of that step is features-service's
+ * statement, read off the public catalogue it already publishes (`GET /public/channels` ->
+ * `legs[]`, each carrying `legKey`, `fromStep` and the funnels it is a leg of). The identifier is
+ * joined VERBATIM against `campaigns.leg_key` and never split back into its two steps — the steps
+ * ride beside it on that payload precisely so nobody parses it, and a well-formed `a_to_b` that no
+ * catalogue names is still not a leg.
+ *
+ * A leg belongs to several funnels at once, which is why the funnel the caller names is part of the
+ * question rather than derivable from it: `sales_interest -> meeting_booked` is a leg of more than
+ * one chain, and only the customer's funding says which one they bought.
+ *
+ * ── FAIL LOUD ON THE SCOPE, NO-OP ON THE ANSWER ─────────────────────────────────────────────────
+ *
+ * A trigger that cannot RESOLVE its scope throws (`StepTriggerScopeError`): a step no catalogue
+ * publishes, a funnel naming none of the four, a catalogue that cannot be read. None of those is a
+ * quiet zero — they are a caller's mistake or an outage, and answering them with "nothing to do"
+ * would make an unreachable feature indistinguishable from a brand that simply has no campaign for
+ * this leg.
+ *
+ * The ANSWER, on the other hand, is very often nothing, and that is not a failure. Most brands buy
+ * one leg of one funnel; a step nobody bought the leg out of, a campaign that is stopped, held for
+ * money, already running, or operated by the customer's own team all return a NAMED skip the caller
+ * can read. That is what makes "no campaign performs this" distinguishable from "something broke".
+ *
+ * ── THE GATE IS UNTOUCHED ───────────────────────────────────────────────────────────────────────
+ *
+ * Nothing here decides whether money may be spent. The dispatch is byte-identical to the
+ * scheduler's — the same anchor run, the same greedy workflow pick, the same `/execute` — so the
+ * run starts at `gate-check`, the first node of every DAG, and is refused there exactly as a
+ * scheduled run would be. What IS checked first is the same pair of guards the scheduler applies
+ * before dispatching, because both are correctness rather than pacing: never two runs of one
+ * campaign, and never two runs of one brand COHORT (the outbound channels share a lead population
+ * and a set of sending accounts, so a second concurrent run contacts the same people from the same
+ * mailboxes). And the campaign must be FUNDED on the one shared definition (`campaignFunding`) —
+ * fail-CLOSED, as everywhere else that decides whether to start spending: a reply must never make a
+ * defunded campaign spend, and firing a run the gate is about to refuse could only burn it.
+ */
+
+/** Why a campaign this step resolves to was NOT run. Every one is an ordinary business state. */
+export const STEP_TRIGGER_SKIPS = {
+  /** Its channel is operated by the CUSTOMER's own team, so it has no DAG and never runs one. */
+  NO_WORKFLOW: "no_workflow",
+  /** The customer funds nothing for it — the same definition the turn planner holds it on. */
+  UNFUNDED: "unfunded",
+  /** A run of this campaign is already in flight. The event is already being answered. */
+  RUN_IN_FLIGHT: "run_in_flight",
+  /** A run of a campaign it shares leads and sending accounts with is in flight. */
+  COHORT_RUN_IN_FLIGHT: "cohort_run_in_flight",
+  /** The row states no brand, owner or feature, so no execution could be identified. */
+  INCOMPLETE: "incomplete_campaign",
+  /** The dispatch itself was refused. Named rather than thrown: the other campaigns still run. */
+  DISPATCH_REFUSED: "dispatch_refused",
+} as const;
+
+export type StepTriggerSkipReason = (typeof STEP_TRIGGER_SKIPS)[keyof typeof STEP_TRIGGER_SKIPS];
+
+export interface StepTriggerRequest {
+  orgId: string;
+  brandId: string;
+  /** The OFFER the lead is on — brand-service's id, matched exactly and never inferred. */
+  offerId: string;
+  /** Any spelling the vocabulary accepts; canonicalized before anything is compared. */
+  funnelKey: string;
+  /** The step the lead just REACHED. features-service's step key, carried verbatim. */
+  step: string;
+}
+
+export interface StepTriggerOutcome {
+  /** The canonical funnel the request named. */
+  funnelKey: string;
+  step: string;
+  /** The legs OUT of that step on that funnel, as features-service names them. */
+  legKeys: string[];
+  triggered: Array<{ campaignId: string; legKey: string | null; workflowSlug: string }>;
+  skipped: Array<{
+    campaignId: string;
+    legKey: string | null;
+    reason: StepTriggerSkipReason;
+    detail: string;
+  }>;
+}
+
+/**
+ * The scope could not be resolved. NOT a no-op: the caller named something this fleet does not
+ * publish, or features-service could not be asked at all.
+ */
+export class StepTriggerScopeError extends Error {
+  readonly status: 400 | 502;
+  constructor(message: string, status: 400 | 502) {
+    super(message);
+    this.name = "StepTriggerScopeError";
+    this.status = status;
+  }
+}
+
+export async function triggerCampaignsForStep(
+  req: StepTriggerRequest,
+): Promise<StepTriggerOutcome> {
+  const funnelKey = toFunnelKey(req.funnelKey);
+  if (!funnelKey) {
+    throw new StepTriggerScopeError(
+      `funnelKey ${JSON.stringify(req.funnelKey)} names no sales funnel`,
+      400,
+    );
+  }
+
+  const catalogue = await fetchChannelCatalogue();
+  if (!catalogue.ok) {
+    // Fail LOUD, unlike provisioning's read of the same catalogue. There the fallback is today's
+    // behaviour; here there is no behaviour to fall back to — an unanswerable question must not be
+    // returned as "nobody performs this leg".
+    throw new StepTriggerScopeError(
+      `the acquisition-channel catalogue could not be read: ${catalogue.detail}`,
+      502,
+    );
+  }
+
+  if (!catalogue.stepKeys.has(req.step)) {
+    throw new StepTriggerScopeError(
+      `step ${JSON.stringify(req.step)} is not a step features-service publishes`,
+      400,
+    );
+  }
+
+  // The legs OUT of this step, on the funnel the caller named. A terminal step legitimately has
+  // none — a lead who became a paying client is at the end of the chain — and that is an ordinary
+  // empty answer, not an error.
+  const legKeys = catalogue.legs
+    .filter((leg) => leg.fromStepKey === req.step)
+    .filter((leg) => [...leg.funnelKeys].some((key) => toFunnelKey(key) === funnelKey))
+    .map((leg) => leg.legKey);
+
+  const outcome: StepTriggerOutcome = {
+    funnelKey,
+    step: req.step,
+    legKeys,
+    triggered: [],
+    skipped: [],
+  };
+  if (legKeys.length === 0) return outcome;
+
+  const wanted = new Set(legKeys);
+
+  // Read the brand's live campaigns and select in memory. The population is a handful of rows per
+  // brand, and the three words that identify the campaign (offer, funnel, leg) are compared under
+  // the same canonicalization everything else in this service uses.
+  const live = await db.query.campaigns.findMany({
+    where: and(
+      eq(campaigns.orgId, req.orgId),
+      eq(campaigns.status, "ongoing"),
+      arrayContains(campaigns.brandIds, [req.brandId]),
+    ),
+  });
+
+  const responsible = live.filter(
+    (c) =>
+      // The offer is matched EXACTLY and never inferred. A campaign that states none is not the
+      // campaign of the offer the caller named — the same reason nothing here derives an offer
+      // from a funnel, a goal or a workflow.
+      c.offerId === req.offerId &&
+      toFunnelKey(c.funnelKey) === funnelKey &&
+      c.legKey !== null &&
+      wanted.has(c.legKey),
+  );
+
+  const now = new Date();
+  const freshnessCutoff = new Date(now.getTime() - STUCK_RUN_FRESHNESS_THRESHOLD_MS);
+  // A cohort this pass has already fired into is busy for the rest of it: the run it just started
+  // is not visible to runs-service's "is one alive" read yet, and two campaigns of one cohort must
+  // never run at once.
+  const firedCohorts = new Set<string>();
+
+  for (const campaign of responsible) {
+    const skip = (reason: StepTriggerSkipReason, detail: string) =>
+      outcome.skipped.push({ campaignId: campaign.id, legKey: campaign.legKey, reason, detail });
+
+    // A campaign with no DAG is a channel the CUSTOMER operates: the work happens off-platform and
+    // there is nothing here to execute. The absence of a workflow IS the statement.
+    if (!campaign.workflowSlug) {
+      skip(STEP_TRIGGER_SKIPS.NO_WORKFLOW, "this channel is operated by the customer's own team");
+      continue;
+    }
+
+    const brandIds = campaign.brandIds ?? [];
+    if (brandIds.length === 0 || !campaign.createdByUserId || !campaign.featureSlug) {
+      skip(STEP_TRIGGER_SKIPS.INCOMPLETE, "the campaign states no brand, owner or feature");
+      continue;
+    }
+
+    const funding = await campaignFunding(campaign, brandIds[0], { orgId: req.orgId });
+    if (!funding.funded) {
+      skip(STEP_TRIGGER_SKIPS.UNFUNDED, funding.reason);
+      continue;
+    }
+
+    if (await hasLiveRunForCampaign(req.orgId, campaign.id, freshnessCutoff)) {
+      skip(STEP_TRIGGER_SKIPS.RUN_IN_FLIGHT, "a run of this campaign is already in flight");
+      continue;
+    }
+
+    const cohort = serializationCohort(campaign.featureSlug);
+    if (
+      firedCohorts.has(cohort) ||
+      (await hasLiveRunForBrandCohort(req.orgId, brandIds[0], cohort, now))
+    ) {
+      skip(
+        STEP_TRIGGER_SKIPS.COHORT_RUN_IN_FLIGHT,
+        `a run of the brand's ${cohort} campaigns is already in flight`,
+      );
+      continue;
+    }
+
+    try {
+      const brandIdCsv = brandIds.join(",");
+      const runId = await ensureCampaignRunId(campaign);
+      const workflowSlug = await resolveWorkflowSlugForTrigger({
+        featureSlug: campaign.featureSlug,
+        primaryBrandId: brandIds[0],
+        identity: {
+          orgId: req.orgId,
+          userId: campaign.createdByUserId,
+          runId,
+          campaignId: campaign.id,
+          brandId: brandIdCsv,
+          workflowSlug: campaign.workflowSlug,
+          featureSlug: campaign.featureSlug,
+        },
+        fallbackSlug: campaign.workflowSlug,
+        funnelKey: campaign.funnelKey,
+      });
+      await executeCampaignWorkflow(workflowSlug, {
+        campaignId: campaign.id,
+        orgId: req.orgId,
+        brandId: brandIdCsv,
+        userId: campaign.createdByUserId,
+        runId,
+        featureSlug: campaign.featureSlug,
+        activeGoalId: campaign.activeGoalId,
+        brandProfileId: campaign.brandProfileId,
+        audienceId: campaign.audienceId,
+      });
+      firedCohorts.add(cohort);
+      outcome.triggered.push({
+        campaignId: campaign.id,
+        legKey: campaign.legKey,
+        workflowSlug,
+      });
+      console.log(
+        `[campaign-service] Campaign ${campaign.id} triggered on the step a lead reached (org ${req.orgId}, brand ${brandIds[0]}, step ${req.step})`,
+      );
+    } catch (err) {
+      // One campaign's refused dispatch does not decide the others'. It is REPORTED, never
+      // swallowed: a caller reading `triggered: []` must be able to tell an outage from a brand
+      // that has no campaign for this leg.
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[campaign-service] Step trigger could not run campaign ${campaign.id} (org ${req.orgId}):`,
+        err,
+      );
+      skip(STEP_TRIGGER_SKIPS.DISPATCH_REFUSED, detail);
+    }
+  }
+
+  return outcome;
+}

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -2,11 +2,11 @@ import { Router } from "express";
 import { eq, and, sql, or, ne, isNotNull } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { brandPauseTransitions, campaigns } from "../db/schema.js";
-import { requireApiKey, requirePipelineHeaders, trackingHeaders, type AuthenticatedRequest } from "../middleware/auth.js";
+import { requireApiKey, requirePipelineHeaders, serviceAuth, trackingHeaders, type AuthenticatedRequest } from "../middleware/auth.js";
 import { validateBody } from "../middleware/validate.js";
 import { createRun, listRuns, updateRun, type IdentityHeaders } from "@distribute/runs-client";
 import { runGateChecks } from "../lib/gate-check.js";
-import { EndRunBody, TransferBrandBody } from "../schemas.js";
+import { EndRunBody, TransferBrandBody, TriggerForStepBody } from "../schemas.js";
 import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "../lib/brand-runtime-client.js";
@@ -14,6 +14,7 @@ import { markAudienceExhausted, getFreshExhaustedAudienceIds, hasExhaustedAudien
 import { maybeSendExtendAudienceEmail } from "../lib/transactional-email.js";
 import { serveableAudienceIdsForCampaign } from "../lib/serveable-audience.js";
 import { STOP_REASONS } from "../lib/stop-reason.js";
+import { triggerCampaignsForStep, StepTriggerScopeError } from "../lib/step-trigger.js";
 import {
   fetchWorkflowProjectionRows,
   fetchGoalArbitration,
@@ -752,6 +753,47 @@ router.delete("/internal/campaigns/by-org/:orgId", requireApiKey, async (req, re
     });
   } catch (error) {
     console.error("[campaign-service] org teardown error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * POST /internal/campaigns/trigger-for-step
+ *
+ * A lead just reached a step. Run the campaign bought for the leg OUT of it, now — instead of
+ * waiting for that campaign's next tick. A prospect who says "yes, interested" and hears nothing
+ * for a day is the whole problem the leg they bought exists to solve.
+ *
+ * The caller names the scope (brand, offer, funnel) and the step reached; the leg is
+ * features-service's statement and the campaign is the one already stating that leg. See
+ * `lib/step-trigger.ts` for why the scope fails LOUD while the answer is very often an ordinary,
+ * named nothing — and for why the affordability gate is reached exactly as a scheduled run reaches
+ * it, because the dispatch is the scheduler's own.
+ *
+ * Returns:
+ *   200 — what was triggered and what was skipped, each skip naming its reason
+ *   400 — no org, a malformed body, a funnel naming none of the four, a step nobody publishes
+ *   401 — bad api key
+ *   502 — the acquisition-channel catalogue could not be read
+ *   500 — internal error
+ */
+router.post("/internal/campaigns/trigger-for-step", requireApiKey, serviceAuth, validateBody(TriggerForStepBody), async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId, offerId, funnelKey, step } = req.body;
+    const outcome = await triggerCampaignsForStep({
+      orgId: req.orgId!,
+      brandId,
+      offerId,
+      funnelKey,
+      step,
+    });
+    res.json(outcome);
+  } catch (error) {
+    if (error instanceof StepTriggerScopeError) {
+      console.warn(`[campaign-service] ${error.status} on /internal/campaigns/trigger-for-step — ${error.message}`);
+      return res.status(error.status).json({ error: error.message });
+    }
+    console.error("[campaign-service] trigger-for-step error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -444,3 +444,48 @@ export const BatchSpendableBudgetResponse = z.object({
     reason: z.string(),
   })),
 }).openapi("BatchSpendableBudgetResponse");
+
+/**
+ * A LEAD JUST REACHED A STEP — run the campaign bought for the leg OUT of it, now.
+ *
+ * The scope is the (brand, offer, funnel) the lead is on plus the step they reached. Nothing is
+ * inferred from anything else: the leg is features-service's statement about that step and that
+ * funnel, and the campaign is the one already stating that leg. The org rides on `x-org-id`, like
+ * every other per-(org, brand) read in this service.
+ */
+export const TriggerForStepBody = z.object({
+  brandId: z.string().uuid("brandId must be a valid UUID"),
+  // The OFFER the lead is on — brand-service's id. Matched exactly against the campaign's own; a
+  // campaign that states no offer is not the campaign of the offer named here.
+  offerId: z.string().uuid("offerId must be a valid UUID"),
+  // The sales funnel the lead is on. Accepts the canonical four and the pre-rename spellings, the
+  // same vocabulary every other funnel-shaped request here accepts. A leg belongs to several
+  // funnels, so this is asked rather than derived.
+  funnelKey: z.string().min(1, "funnelKey is required"),
+  // The step the lead just REACHED — features-service's step key, carried verbatim and never
+  // parsed. A step it does not publish is a 400, never an empty answer.
+  step: z.string().min(1, "step is required"),
+}).openapi("TriggerForStepBody");
+
+export const TriggerForStepResponse = z.object({
+  funnelKey: z.string(),
+  step: z.string(),
+  /** The legs OUT of that step on that funnel, as features-service names them. */
+  legKeys: z.array(z.string()),
+  triggered: z.array(z.object({
+    campaignId: z.string(),
+    legKey: z.string().nullable(),
+    workflowSlug: z.string(),
+  })),
+  /**
+   * The campaigns that perform the leg and were NOT run, each saying why. A named skip is what
+   * makes "nobody bought this leg" / "it is out of budget" readable as an ordinary answer rather
+   * than as a failure.
+   */
+  skipped: z.array(z.object({
+    campaignId: z.string(),
+    legKey: z.string().nullable(),
+    reason: z.string(),
+    detail: z.string(),
+  })),
+}).openapi("TriggerForStepResponse");

--- a/tests/integration/trigger-for-step.test.ts
+++ b/tests/integration/trigger-for-step.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+
+const { mockExecute, mockCatalogue, mockFunding, mockListRuns, mockResolveSlug } = vi.hoisted(() => ({
+  mockExecute: vi.fn(),
+  mockCatalogue: vi.fn(),
+  mockFunding: vi.fn(),
+  mockListRuns: vi.fn(),
+  mockResolveSlug: vi.fn(),
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  createRun: vi.fn(),
+  updateRun: vi.fn(),
+  listRuns: mockListRuns,
+  getStatsBudget: vi.fn(),
+}));
+
+vi.mock("../../src/lib/workflows.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/workflows.js")>();
+  return { ...original, executeCampaignWorkflow: mockExecute };
+});
+
+vi.mock("../../src/lib/channel-operator-client.js", () => ({ fetchChannelCatalogue: mockCatalogue }));
+
+vi.mock("../../src/lib/campaign-funding.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/campaign-funding.js")>();
+  return { ...original, campaignFunding: mockFunding };
+});
+
+vi.mock("../../src/lib/features-workflow-projection-client.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/lib/features-workflow-projection-client.js")>();
+  return { ...original, resolveWorkflowSlugForTrigger: mockResolveSlug };
+});
+
+import app from "../../src/index.js";
+import { cleanTestData, closeDb, insertTestCampaign } from "../helpers/test-db.js";
+
+const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
+const ORG = "b645207b-0000-4000-8000-000000000001";
+const BRAND = "75d7e3e8-0000-4000-8000-000000000002";
+const OFFER = "231bb036-0000-4000-8000-000000000003";
+const STEP = "sales_interest";
+const LEG_OUT = ["sales", "interest"].join("_") + "_to_" + ["meeting", "booked"].join("_");
+const FUNNEL = "sales_meetings_from_conversation";
+
+const post = (body: Record<string, unknown>, orgId: string | null = ORG) => {
+  const req = request(app)
+    .post("/internal/campaigns/trigger-for-step")
+    .set("x-api-key", API_KEY);
+  if (orgId) req.set("x-org-id", orgId);
+  return req.send(body);
+};
+
+const body = { brandId: BRAND, offerId: OFFER, funnelKey: FUNNEL, step: STEP };
+
+/**
+ * A prospect who states a sales interest and hears nothing for a day is the problem this closes.
+ * These assert what a CALLER can observe: the responsible campaign runs, and every reason it might
+ * not is a readable 200 rather than something indistinguishable from a failure.
+ */
+describe("POST /internal/campaigns/trigger-for-step", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await cleanTestData();
+    mockCatalogue.mockResolvedValue({
+      ok: true,
+      operatorBySlug: new Map(),
+      legsBySlug: new Map(),
+      stepKeys: new Set([STEP, "meeting_booked", "paid_client"]),
+      legs: [{ legKey: LEG_OUT, fromStepKey: STEP, funnelKeys: new Set([FUNNEL]) }],
+    });
+    mockFunding.mockResolvedValue({ funded: true, ceilingCents: 5000 });
+    mockListRuns.mockResolvedValue({ runs: [] });
+    mockResolveSlug.mockResolvedValue("aurora-v3");
+    mockExecute.mockResolvedValue(undefined);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("runs the campaign bought for the leg out of the step", async () => {
+    const campaign = await insertTestCampaign(ORG, {
+      brandIds: [BRAND],
+      brandId: BRAND,
+      status: "ongoing",
+      featureSlug: "sales-cold-email-outreach",
+      workflowSlug: "aurora-v3",
+      createdByUserId: "user-1",
+      parentRunId: "9f0d1c22-0000-4000-8000-000000000009",
+      funnelKey: FUNNEL,
+      offerId: OFFER,
+      legKey: LEG_OUT,
+    });
+
+    const res = await post(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.legKeys).toEqual([LEG_OUT]);
+    expect(res.body.triggered).toEqual([
+      { campaignId: campaign.id, legKey: LEG_OUT, workflowSlug: "aurora-v3" },
+    ]);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers a scope with no such campaign as an ordinary, empty 200", async () => {
+    const res = await post(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.triggered).toEqual([]);
+    expect(res.body.skipped).toEqual([]);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("does not run a STOPPED campaign, and says nothing ran", async () => {
+    await insertTestCampaign(ORG, {
+      brandIds: [BRAND],
+      brandId: BRAND,
+      status: "stopped",
+      featureSlug: "sales-cold-email-outreach",
+      createdByUserId: "user-1",
+      funnelKey: FUNNEL,
+      offerId: OFFER,
+      legKey: LEG_OUT,
+    });
+
+    const res = await post(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.triggered).toEqual([]);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("never lets the event make an out-of-budget campaign spend", async () => {
+    const campaign = await insertTestCampaign(ORG, {
+      brandIds: [BRAND],
+      brandId: BRAND,
+      status: "ongoing",
+      featureSlug: "sales-cold-email-outreach",
+      workflowSlug: "aurora-v3",
+      createdByUserId: "user-1",
+      parentRunId: "9f0d1c22-0000-4000-8000-000000000009",
+      funnelKey: FUNNEL,
+      offerId: OFFER,
+      legKey: LEG_OUT,
+    });
+    mockFunding.mockResolvedValue({ funded: false, reason: "the leg is funded at zero" });
+
+    const res = await post(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.triggered).toEqual([]);
+    expect(res.body.skipped).toEqual([
+      {
+        campaignId: campaign.id,
+        legKey: LEG_OUT,
+        reason: "unfunded",
+        detail: "the leg is funded at zero",
+      },
+    ]);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("refuses a step nobody publishes — an unresolvable scope is never a quiet zero", async () => {
+    const res = await post({ ...body, step: "smoke_signal" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("smoke_signal");
+  });
+
+  it("refuses a funnel naming none of the four", async () => {
+    const res = await post({ ...body, funnelKey: "combinedSales" });
+    expect(res.status).toBe(400);
+  });
+
+  it("502s when the leg catalogue cannot be read", async () => {
+    mockCatalogue.mockResolvedValue({ ok: false, detail: "HTTP 503" });
+    const res = await post(body);
+    expect(res.status).toBe(502);
+  });
+
+  it("requires the org, the api key and a well-formed body", async () => {
+    expect((await post(body, null)).status).toBe(400);
+    expect((await post({ ...body, offerId: "not-a-uuid" })).status).toBe(400);
+    expect(
+      (await request(app).post("/internal/campaigns/trigger-for-step").send(body)).status,
+    ).toBe(401);
+  });
+});

--- a/tests/unit/channel-operator-client.test.ts
+++ b/tests/unit/channel-operator-client.test.ts
@@ -115,6 +115,53 @@ describe("fetchChannelCatalogue", () => {
     expect(read.operatorBySlug.has("partner-run-thing")).toBe(false);
   });
 
+  it("reads the published LEG vocabulary, each leg naming the step it leaves and its funnels", async () => {
+    // The DEPLOYED shape (features-service `funnelLegCatalogue()`): `legs[]` beside `channels[]`,
+    // each leg carrying the identifier, the step it takes a lead OUT of (`null` = from nothing),
+    // and every funnel it is a leg of. The steps ride BESIDE the identifier, so nothing splits it.
+    const entryLeg = ["start", "to", "conversation"].join("_");
+    const legOut = ["sales", "interest", "to", "meeting", "booked"].join("_");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        channels: [],
+        legs: [
+          { legKey: entryLeg, fromStep: null, toStep: { key: "conversation" }, funnelKeys: ["sales_meetings_from_conversation"] },
+          {
+            legKey: legOut,
+            fromStep: { key: "sales_interest", label: "Sales interest" },
+            toStep: { key: "meeting_booked" },
+            funnelKeys: ["sales_meetings_from_conversation", "sales_meetings_from_website"],
+          },
+        ],
+        steps: [{ key: "sales_interest" }, { key: "meeting_booked" }, { key: "conversation" }],
+      }),
+    });
+
+    const read = await fetchChannelCatalogue();
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.legs).toHaveLength(2);
+    // An ENTRY leg is an ordinary leg: the absent step is DATA, not a different spelling.
+    expect(read.legs[0]).toEqual({ legKey: entryLeg, fromStepKey: null, funnelKeys: new Set(["sales_meetings_from_conversation"]) });
+    expect(read.legs[1].fromStepKey).toBe("sales_interest");
+    expect([...read.legs[1].funnelKeys]).toEqual([
+      "sales_meetings_from_conversation",
+      "sales_meetings_from_website",
+    ]);
+    expect(read.stepKeys.has("sales_interest")).toBe(true);
+    expect(read.stepKeys.has("smoke_signal")).toBe(false);
+  });
+
+  it("states an EMPTY leg vocabulary rather than throwing when the payload carries none", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ channels: [], steps: [] }) });
+    const read = await fetchChannelCatalogue();
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.legs).toEqual([]);
+    expect(read.stepKeys.size).toBe(0);
+  });
+
   it("says a failure is a failure — never an empty catalogue", async () => {
     mockFetch.mockResolvedValue({ ok: false, status: 503, text: async () => "unavailable" });
     const read = await fetchChannelCatalogue();

--- a/tests/unit/step-trigger.test.ts
+++ b/tests/unit/step-trigger.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockFindMany } = vi.hoisted(() => ({ mockFindMany: vi.fn() }));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: { query: { campaigns: { findMany: mockFindMany } } },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+  arrayContains: (a: unknown, b: unknown) => ({ arrayContains: [a, b] }),
+}));
+
+vi.mock("../../src/db/schema.js", () => ({
+  campaigns: { orgId: "org_id", status: "status", brandIds: "brand_ids" },
+}));
+
+const { mockCatalogue, mockFunding, mockLiveCampaign, mockLiveCohort, mockAnchor, mockResolveSlug, mockExecute } =
+  vi.hoisted(() => ({
+    mockCatalogue: vi.fn(),
+    mockFunding: vi.fn(),
+    mockLiveCampaign: vi.fn(),
+    mockLiveCohort: vi.fn(),
+    mockAnchor: vi.fn(),
+    mockResolveSlug: vi.fn(),
+    mockExecute: vi.fn(),
+  }));
+
+vi.mock("../../src/lib/channel-operator-client.js", () => ({ fetchChannelCatalogue: mockCatalogue }));
+vi.mock("../../src/lib/campaign-funding.js", () => ({ campaignFunding: mockFunding }));
+vi.mock("../../src/lib/scheduler.js", () => ({
+  hasLiveRunForCampaign: mockLiveCampaign,
+  STUCK_RUN_FRESHNESS_THRESHOLD_MS: 900_000,
+}));
+vi.mock("../../src/lib/funnel-campaigns.js", () => ({
+  hasLiveRunForBrandCohort: mockLiveCohort,
+  serializationCohort: (slug: string) => `cohort:${slug}`,
+}));
+vi.mock("../../src/lib/trigger-run.js", () => ({ ensureCampaignRunId: mockAnchor }));
+vi.mock("../../src/lib/features-workflow-projection-client.js", () => ({
+  resolveWorkflowSlugForTrigger: mockResolveSlug,
+}));
+vi.mock("../../src/lib/workflows.js", () => ({ executeCampaignWorkflow: mockExecute }));
+
+import {
+  triggerCampaignsForStep,
+  StepTriggerScopeError,
+  STEP_TRIGGER_SKIPS,
+} from "../../src/lib/step-trigger.js";
+
+const ORG = "b645207b-0000-4000-8000-000000000001";
+const BRAND = "75d7e3e8-0000-4000-8000-000000000002";
+const OFFER = "231bb036-0000-4000-8000-000000000003";
+const OTHER_OFFER = "9f0d1c22-0000-4000-8000-000000000004";
+const CAMPAIGN = "16705a37-0000-4000-8000-000000000005";
+
+/** The leg the customer buys out of a stated sales interest, exactly as features-service spells it. */
+const LEG_OUT = ["sales", "interest"].join("_") + "_to_" + ["meeting", "booked"].join("_");
+const LEG_ELSEWHERE = ["meeting", "booked"].join("_") + "_to_" + ["meeting", "attended"].join("_");
+const STEP = "sales_interest";
+
+function catalogueAnswers() {
+  mockCatalogue.mockResolvedValue({
+    ok: true,
+    operatorBySlug: new Map(),
+    legsBySlug: new Map(),
+    stepKeys: new Set([STEP, "meeting_booked", "meeting_attended", "paid_client"]),
+    legs: [
+      {
+        legKey: LEG_OUT,
+        fromStepKey: STEP,
+        funnelKeys: new Set(["sales_meetings_from_conversation", "sales_meetings_from_website"]),
+      },
+      {
+        legKey: LEG_ELSEWHERE,
+        fromStepKey: "meeting_booked",
+        funnelKeys: new Set(["sales_meetings_from_conversation"]),
+      },
+    ],
+  });
+}
+
+function campaign(over: Record<string, unknown> = {}) {
+  return {
+    id: CAMPAIGN,
+    orgId: ORG,
+    status: "ongoing",
+    createdByUserId: "user-1",
+    parentRunId: "run-anchor",
+    workflowSlug: "aurora-v3",
+    brandIds: [BRAND],
+    featureSlug: "sales-cold-email-outreach",
+    activeGoalId: null,
+    brandProfileId: null,
+    audienceId: null,
+    funnelKey: "sales_meetings_from_conversation",
+    dailyBudgetCents: null,
+    offerId: OFFER,
+    legKey: LEG_OUT,
+    ...over,
+  };
+}
+
+const request = {
+  orgId: ORG,
+  brandId: BRAND,
+  offerId: OFFER,
+  funnelKey: "sales_meetings_from_conversation",
+  step: STEP,
+};
+
+describe("a lead reaching a step runs the campaign bought for the leg out of it", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    catalogueAnswers();
+    mockFunding.mockResolvedValue({ funded: true, ceilingCents: 5000 });
+    mockLiveCampaign.mockResolvedValue(false);
+    mockLiveCohort.mockResolvedValue(false);
+    mockAnchor.mockResolvedValue("run-anchor");
+    mockResolveSlug.mockResolvedValue("aurora-v3");
+    mockExecute.mockResolvedValue(undefined);
+  });
+
+  it("executes the campaign of that (brand, offer, funnel) stating that leg", async () => {
+    mockFindMany.mockResolvedValue([campaign()]);
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.legKeys).toEqual([LEG_OUT]);
+    expect(outcome.triggered).toEqual([
+      { campaignId: CAMPAIGN, legKey: LEG_OUT, workflowSlug: "aurora-v3" },
+    ]);
+    expect(outcome.skipped).toEqual([]);
+    // The dispatch is the scheduler's own — same anchor run, same greedy pick, same /execute — so
+    // the run starts at gate-check exactly as a scheduled one does.
+    expect(mockExecute).toHaveBeenCalledWith("aurora-v3", expect.objectContaining({
+      campaignId: CAMPAIGN,
+      orgId: ORG,
+      brandId: BRAND,
+      runId: "run-anchor",
+      featureSlug: "sales-cold-email-outreach",
+    }));
+  });
+
+  it("is a clean no-op, not an error, when no campaign performs the leg", async () => {
+    mockFindMany.mockResolvedValue([campaign({ legKey: LEG_ELSEWHERE })]);
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.legKeys).toEqual([LEG_OUT]);
+    expect(outcome.triggered).toEqual([]);
+    expect(outcome.skipped).toEqual([]);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("does not run another OFFER's campaign, and never infers an offer for one stating none", async () => {
+    mockFindMany.mockResolvedValue([
+      campaign({ id: "other", offerId: OTHER_OFFER }),
+      campaign({ id: "offerless", offerId: null }),
+    ]);
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.triggered).toEqual([]);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("does not run a campaign of another funnel, even on the same leg", async () => {
+    mockFindMany.mockResolvedValue([campaign({ funnelKey: "website_purchases" })]);
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.triggered).toEqual([]);
+  });
+
+  it("reads the campaign's funnel under the pre-rename spelling too", async () => {
+    mockFindMany.mockResolvedValue([campaign({ funnelKey: "reply_meeting" })]);
+
+    const outcome = await triggerCampaignsForStep({ ...request, funnelKey: "reply_meeting" });
+
+    expect(outcome.triggered).toHaveLength(1);
+  });
+
+  it("never lets a reply make a DEFUNDED campaign spend", async () => {
+    mockFindMany.mockResolvedValue([campaign()]);
+    mockFunding.mockResolvedValue({ funded: false, reason: "funnel is funded at zero" });
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.triggered).toEqual([]);
+    expect(outcome.skipped).toEqual([
+      {
+        campaignId: CAMPAIGN,
+        legKey: LEG_OUT,
+        reason: STEP_TRIGGER_SKIPS.UNFUNDED,
+        detail: "funnel is funded at zero",
+      },
+    ]);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("prices the hold on the LEG the campaign was bought for", async () => {
+    mockFindMany.mockResolvedValue([campaign()]);
+
+    await triggerCampaignsForStep(request);
+
+    expect(mockFunding).toHaveBeenCalledWith(
+      expect.objectContaining({ legKey: LEG_OUT, offerId: OFFER }),
+      BRAND,
+      { orgId: ORG },
+    );
+  });
+
+  it("does not fire a second run of a campaign that is already running", async () => {
+    mockFindMany.mockResolvedValue([campaign()]);
+    mockLiveCampaign.mockResolvedValue(true);
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.skipped[0].reason).toBe(STEP_TRIGGER_SKIPS.RUN_IN_FLIGHT);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("does not fire alongside a run of the brand's same cohort", async () => {
+    mockFindMany.mockResolvedValue([campaign()]);
+    mockLiveCohort.mockResolvedValue(true);
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.skipped[0].reason).toBe(STEP_TRIGGER_SKIPS.COHORT_RUN_IN_FLIGHT);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("fires ONE campaign per cohort in a single pass", async () => {
+    mockFindMany.mockResolvedValue([campaign(), campaign({ id: "twin" })]);
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.triggered).toHaveLength(1);
+    expect(outcome.skipped[0].reason).toBe(STEP_TRIGGER_SKIPS.COHORT_RUN_IN_FLIGHT);
+  });
+
+  it("never runs a campaign whose channel the CUSTOMER operates — it has no DAG", async () => {
+    mockFindMany.mockResolvedValue([campaign({ workflowSlug: null })]);
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.skipped[0].reason).toBe(STEP_TRIGGER_SKIPS.NO_WORKFLOW);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("reports a refused dispatch rather than swallowing it", async () => {
+    mockFindMany.mockResolvedValue([campaign()]);
+    mockExecute.mockRejectedValue(new Error("workflow-service refused (502)"));
+
+    const outcome = await triggerCampaignsForStep(request);
+
+    expect(outcome.triggered).toEqual([]);
+    expect(outcome.skipped[0].reason).toBe(STEP_TRIGGER_SKIPS.DISPATCH_REFUSED);
+    expect(outcome.skipped[0].detail).toContain("502");
+  });
+
+  it("answers a TERMINAL step with an empty, honest nothing", async () => {
+    mockFindMany.mockResolvedValue([campaign()]);
+
+    const outcome = await triggerCampaignsForStep({ ...request, step: "paid_client" });
+
+    expect(outcome.legKeys).toEqual([]);
+    expect(outcome.triggered).toEqual([]);
+    // Nothing is even looked up: no leg means no campaign can be responsible.
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  describe("a scope that cannot be resolved fails LOUD", () => {
+    it("refuses a step features-service does not publish", async () => {
+      await expect(triggerCampaignsForStep({ ...request, step: "smoke_signal" }))
+        .rejects.toMatchObject({ name: "StepTriggerScopeError", status: 400 });
+    });
+
+    it("refuses a funnel naming none of the four", async () => {
+      await expect(triggerCampaignsForStep({ ...request, funnelKey: "combinedSales" }))
+        .rejects.toBeInstanceOf(StepTriggerScopeError);
+    });
+
+    it("refuses when the catalogue cannot be read — never 'nobody performs this leg'", async () => {
+      mockCatalogue.mockResolvedValue({ ok: false, detail: "HTTP 503" });
+
+      await expect(triggerCampaignsForStep(request))
+        .rejects.toMatchObject({ status: 502 });
+      expect(mockFindMany).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Job

When a prospect shows a sales interest on a brand's offer, the campaign that sells the leg out of that step must run **now** — not at its next daily tick. A prospect who says "yes, interested" and hears nothing for a day is the whole problem the leg they bought exists to solve.

## What this adds

`POST /internal/campaigns/trigger-for-step` — the caller names the scope its lead is on (`brandId`, `offerId`, `funnelKey`) plus the `step` just reached, with the org on `x-org-id`. The campaign bought for the leg **out of** that step runs immediately.

It is a lookup over state this service already holds. A campaign states its (org, brand, offer, funnel, channel) and the single **leg** it was bought for; features-service publishes which leg leaves which step (`GET /public/channels` → `legs[]`). Joining the two is the entire resolution — no new column, table, vocabulary, accumulator or second scheduler. The leg identifier is joined **verbatim** and never split back into its two steps; the funnel is part of the question rather than derived, because one leg belongs to several funnels and only the customer's funding says which they bought.

## The gate is untouched

The dispatch is the **scheduler's own** — same anchor run (`ensureCampaignRunId`), same greedy workflow pick, same `/execute` — so the run starts at `gate-check`, the first node of every DAG, and is refused there exactly as a scheduled run is. Before dispatching it applies:

- the one shared funding definition (`campaignFunding`), **fail-closed** — a reply never makes a defunded, held or stopped campaign spend;
- the same two correctness guards the scheduler applies: never two runs of one campaign, never two of one brand **cohort** (the outbound channels share a lead population and a set of sending accounts).

## Loud on the scope, a named nothing on the answer

- **400 / 400 / 502** — a step no catalogue publishes, a funnel naming none of the four, a catalogue that cannot be read. Answering those with "nothing to do" would make an unreachable feature indistinguishable from a brand that simply has no campaign for this leg.
- **200** for everything else: no campaign performs the leg (the common case, empty), or one does and was skipped for a **named** reason — `no_workflow` (the customer operates that channel, so there is no DAG), `unfunded`, `run_in_flight`, `cohort_run_in_flight`, `incomplete_campaign`, `dispatch_refused`. A caller can tell those from an outage.

## The second need needed no change

A run names its campaign (`x-campaign-id`), and `GET /campaigns/:id` already serves that row's `offerId`, `funnelKey` and `legKey` — so a downstream node that must read the funnel's own configuration from brand-service resolves it from the campaign. Nothing was added to the `/start-run` response, which already re-serves several campaign fields and at least one retired vocabulary.

## Blast radius

Additive. No existing caller's behaviour changes and the time-based path is byte-identical — no claim, cadence, defer, turn or reschedule moved. Three existing helpers became exported (`hasLiveRunForCampaign`, `hasLiveRunForBrandCohort`, `serializationCohort`) and `campaignFunding` accepts the `legKey` its own decision function already read; no logic changed in any of them. The catalogue client now also parses the `legs[]` and `steps[]` it was already being served.

## Verification

`785 tests / 59 files` green (unit + integration against a prod-shaped database), including 16 unit tests over the resolution and dispatch and 8 integration tests over the route's consumer-observable behaviour: the campaign runs; a scope with no such campaign is an empty 200; a stopped one does not run; an out-of-budget one is a named skip and never executes; unknown step / unknown funnel / unreadable catalogue fail loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
