### PR TITLE
docs(events): name the step by the key features-service publishes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,9 +736,10 @@ campaign bought for the leg OUT of that step runs immediately.
   `fromStep` and the funnels it is a leg of), joined VERBATIM against `campaigns.leg_key`. The steps
   ride beside the identifier precisely so nobody splits it, and a well-formed `a_to_b` no catalogue
   names is still not a leg. `channel-operator-client.ts` stays the ONE reader of that catalogue.
-- **The FUNNEL is part of the question because a leg belongs to several.** `sales_interest ->
+- **The FUNNEL is part of the question because a leg belongs to several.** `conversation ->
   meeting_booked` is a leg of more than one chain, and only the customer's funding says which one
-  they bought — so it is named by the caller rather than derived from the leg.
+  they bought — so it is named by the caller rather than derived from the leg. (`conversation` is
+  the step key every customer-facing surface labels "sales interest"; the label is not the token.)
 - **THE GATE IS UNTOUCHED.** The dispatch is the SCHEDULER'S OWN — same anchor run
   (`ensureCampaignRunId`), same greedy workflow pick, same `/execute` — so the run starts at
   `gate-check`, the first node of every DAG, and is refused there exactly as a scheduled run is.

--- a/src/lib/step-trigger.ts
+++ b/src/lib/step-trigger.ts
@@ -36,8 +36,9 @@ import { hasLiveRunForCampaign, STUCK_RUN_FRESHNESS_THRESHOLD_MS } from "./sched
  * catalogue names is still not a leg.
  *
  * A leg belongs to several funnels at once, which is why the funnel the caller names is part of the
- * question rather than derivable from it: `sales_interest -> meeting_booked` is a leg of more than
- * one chain, and only the customer's funding says which one they bought.
+ * question rather than derivable from it: `conversation -> meeting_booked` is a leg of more than one
+ * chain, and only the customer's funding says which one they bought. (`conversation` is the step
+ * key every customer-facing surface labels "sales interest" — the label is not the token.)
  *
  * ── FAIL LOUD ON THE SCOPE, NO-OP ON THE ANSWER ─────────────────────────────────────────────────
  *

--- a/tests/integration/trigger-for-step.test.ts
+++ b/tests/integration/trigger-for-step.test.ts
@@ -40,8 +40,8 @@ const API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "test-api-key";
 const ORG = "b645207b-0000-4000-8000-000000000001";
 const BRAND = "75d7e3e8-0000-4000-8000-000000000002";
 const OFFER = "231bb036-0000-4000-8000-000000000003";
-const STEP = "sales_interest";
-const LEG_OUT = ["sales", "interest"].join("_") + "_to_" + ["meeting", "booked"].join("_");
+const STEP = "conversation";
+const LEG_OUT = "conversation" + "_to_" + ["meeting", "booked"].join("_");
 const FUNNEL = "sales_meetings_from_conversation";
 
 const post = (body: Record<string, unknown>, orgId: string | null = ORG) => {

--- a/tests/unit/channel-operator-client.test.ts
+++ b/tests/unit/channel-operator-client.test.ts
@@ -120,7 +120,7 @@ describe("fetchChannelCatalogue", () => {
     // each leg carrying the identifier, the step it takes a lead OUT of (`null` = from nothing),
     // and every funnel it is a leg of. The steps ride BESIDE the identifier, so nothing splits it.
     const entryLeg = ["start", "to", "conversation"].join("_");
-    const legOut = ["sales", "interest", "to", "meeting", "booked"].join("_");
+    const legOut = ["conversation","to","meeting","booked"].join("_");
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -129,12 +129,12 @@ describe("fetchChannelCatalogue", () => {
           { legKey: entryLeg, fromStep: null, toStep: { key: "conversation" }, funnelKeys: ["sales_meetings_from_conversation"] },
           {
             legKey: legOut,
-            fromStep: { key: "sales_interest", label: "Sales interest" },
+            fromStep: { key: "conversation", label: "Sales interest" },
             toStep: { key: "meeting_booked" },
             funnelKeys: ["sales_meetings_from_conversation", "sales_meetings_from_website"],
           },
         ],
-        steps: [{ key: "sales_interest" }, { key: "meeting_booked" }, { key: "conversation" }],
+        steps: [{ key: "conversation" }, { key: "meeting_booked" }, { key: "conversation" }],
       }),
     });
 
@@ -144,12 +144,12 @@ describe("fetchChannelCatalogue", () => {
     expect(read.legs).toHaveLength(2);
     // An ENTRY leg is an ordinary leg: the absent step is DATA, not a different spelling.
     expect(read.legs[0]).toEqual({ legKey: entryLeg, fromStepKey: null, funnelKeys: new Set(["sales_meetings_from_conversation"]) });
-    expect(read.legs[1].fromStepKey).toBe("sales_interest");
+    expect(read.legs[1].fromStepKey).toBe("conversation");
     expect([...read.legs[1].funnelKeys]).toEqual([
       "sales_meetings_from_conversation",
       "sales_meetings_from_website",
     ]);
-    expect(read.stepKeys.has("sales_interest")).toBe(true);
+    expect(read.stepKeys.has("conversation")).toBe(true);
     expect(read.stepKeys.has("smoke_signal")).toBe(false);
   });
 

--- a/tests/unit/step-trigger.test.ts
+++ b/tests/unit/step-trigger.test.ts
@@ -56,9 +56,9 @@ const OTHER_OFFER = "9f0d1c22-0000-4000-8000-000000000004";
 const CAMPAIGN = "16705a37-0000-4000-8000-000000000005";
 
 /** The leg the customer buys out of a stated sales interest, exactly as features-service spells it. */
-const LEG_OUT = ["sales", "interest"].join("_") + "_to_" + ["meeting", "booked"].join("_");
+const LEG_OUT = "conversation" + "_to_" + ["meeting", "booked"].join("_");
 const LEG_ELSEWHERE = ["meeting", "booked"].join("_") + "_to_" + ["meeting", "attended"].join("_");
-const STEP = "sales_interest";
+const STEP = "conversation";
 
 function catalogueAnswers() {
   mockCatalogue.mockResolvedValue({


### PR DESCRIPTION
The illustrative leg was written `sales_interest -> meeting_booked`. `sales_interest` is not a step key — features-service publishes the step as `conversation` and labels it "Sales interest" on customer-facing surfaces. Writing a token no catalogue names, in the one file explaining that a token no catalogue names is not a thing, is exactly the drift this service keeps deleting.

Docs and test fixtures only. No behaviour change: the step is carried verbatim from the caller and matched against the live catalogue, so nothing was ever compared against a local spelling.

785 tests / 59 files green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)