### PR TITLE
feat(scheduler): a run that had nothing to do waits on that reason's cadence, not the run cadence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -812,6 +812,44 @@ campaign bought for the leg OUT of that step runs immediately.
 
 (Set 2026-09-02.)
 
+## A run that had NOTHING TO DO waits on the reason's timescale — the workflow SAYS so, and it is not exhaustion
+
+Everything on the `/end-run` path assumed a completed run had done work, so it rescheduled on the
+RUN cadence (`RERUN_GRACE_MS`, 10s). A channel that answers ONE interested prospect per run breaks
+that assumption: its DAG asks another service for the next person owed an answer, and when nobody
+is owed one the run legitimately does nothing, completes normally, and is re-fired eleven seconds
+later — forever. Measured in prod over 24h on ONE such campaign that had answered nobody: **14,841
+run rows attributed to it against 28,336 across the WHOLE fleet**, i.e. one idle campaign was 52%
+of the platform's entire run ledger (2.3 GB table), plus one affordability gate-check per turn for
+a run that would do nothing.
+
+- **The workflow SAYS it had nothing to do** — `noWorkAvailable` on the `/end-run` body
+  (`EndRunBody`, `src/schemas.ts`). OPTIONAL, and ABSENT means "this run did work": every caller
+  that does not send it behaves byte-identically to before the field existed, which is why cold
+  email is untouched without a single branch on a feature slug. This service cannot infer it —
+  only the DAG knows its branch was the empty one — and inferring it from an empty result would be
+  the same "empty remainder reads as a verdict" mistake the exhaustion gate already closed.
+- **It changes exactly ONE thing: the reschedule delay** (`NO_WORK_RECHECK_MS`, 10 min,
+  `src/lib/idle-run.ts`). It never stops a campaign, never marks anything exhausted, never touches
+  the stop reason, and no other decision reads it. The campaign is funded and correct; it simply
+  has nobody to answer this minute.
+- **DELIBERATELY NOT the audience-exhaustion recheck**, though both are ten minutes for the same
+  reason. `NO_SERVEABLE_AUDIENCE_RECHECK_MS` is reached through `stopCampaign=true`, whose whole
+  vocabulary is a cold-email AUDIENCE running out of PEOPLE, and it gates a STOP. Routing this
+  channel through it would conflate two different facts and put a campaign one evidence-check away
+  from `audience_exhausted`, which is sticky. Same figure, separate constant, separate reason.
+- **A FAILED run's claim is ignored** — the failure backoff (60s) still wins, because a run that
+  failed says nothing trustworthy about whether there was work to do.
+- **This is the idle BACKSTOP, not the reactivity.** When a prospect actually shows interest the
+  responsible campaign is run IMMEDIATELY through `POST /internal/campaigns/trigger-for-step`,
+  which dispatches without consulting `nextRunAt` at all — pinned by a test that parks a campaign
+  ten minutes out and asserts the event still fires it. The slow cadence is what happens when
+  nothing has happened, so ten minutes is the ceiling on IDLE latency, never on answering somebody.
+- **workflow-service half**: the DAG for that channel must send `noWorkAvailable: true` on its
+  nothing-to-do branch. Until it does, this field is never set and behaviour is exactly today's.
+
+(Set 2026-09-05.)
+
 ## The OFFER a campaign sells is brand-service's UUID, carried and never derived
 
 A new level sits between the brand and the campaign: **Org > Brand > Offer > Campaign**. An offer is

--- a/openapi.json
+++ b/openapi.json
@@ -1028,6 +1028,9 @@
           },
           "stopCampaign": {
             "type": "boolean"
+          },
+          "noWorkAvailable": {
+            "type": "boolean"
           }
         },
         "required": [

--- a/src/lib/idle-run.ts
+++ b/src/lib/idle-run.ts
@@ -1,0 +1,28 @@
+/**
+ * A run that had NOTHING TO DO waits on the timescale of the reason it had nothing to do.
+ *
+ * Some acquisition channels serve ONE interested prospect per run: the DAG asks another service
+ * for the next person owed an answer, and when nobody is owed one the run legitimately does
+ * nothing. That run completes normally, so the campaign used to be rescheduled on the RUN cadence
+ * (`RERUN_GRACE_MS`, 10s) — a workflow every eleven seconds, forever, for a campaign whose
+ * situation cannot change in eleven seconds. Measured in prod over 24h on ONE such campaign that
+ * had answered nobody: 14,841 run rows attributed to it against 28,336 across the whole fleet, so
+ * one idle campaign was 52% of the platform's entire run ledger — plus one affordability
+ * gate-check per turn for a run that would do nothing.
+ *
+ * "Nobody to answer right now" is the MONEY kind of wait, not the TURN kind: it moves when a
+ * prospect states an interest, minutes or hours apart. So it reschedules on the same 10 minutes
+ * and for the same reason as `FUNDING_RECHECK_MS` and `NO_SERVEABLE_AUDIENCE_RECHECK_MS`, and
+ * that interval IS the idle latency ceiling.
+ *
+ * It is a CEILING and not the reactivity: when a prospect actually shows interest the responsible
+ * campaign is run IMMEDIATELY through `POST /internal/campaigns/trigger-for-step`, which dispatches
+ * without consulting `nextRunAt` at all. This slower cadence is only what happens when nothing has
+ * happened.
+ *
+ * It is deliberately NOT the audience-exhaustion recheck, whose vocabulary is a cold-email audience
+ * running out of PEOPLE — a different fact, reached by a different signal, that gates a STOP.
+ * Nothing on this path stops a campaign or marks anything exhausted: the campaign is funded and
+ * correct, it simply has nobody to answer this minute.
+ */
+export const NO_WORK_RECHECK_MS = 10 * 60_000; // 10 min

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -11,6 +11,7 @@ import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "../lib/brand-runtime-client.js";
 import { markAudienceExhausted, getFreshExhaustedAudienceIds, hasExhaustedAudience, isExhaustionStopWarranted, NO_SERVEABLE_AUDIENCE_RECHECK_MS } from "../lib/audience-exhaustion.js";
+import { NO_WORK_RECHECK_MS } from "../lib/idle-run.js";
 import { maybeSendExtendAudienceEmail } from "../lib/transactional-email.js";
 import { serveableAudienceIdsForCampaign } from "../lib/serveable-audience.js";
 import { STOP_REASONS } from "../lib/stop-reason.js";
@@ -443,7 +444,7 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
   try {
     const campaignId = req.campaignId!;
     const orgId = req.orgId!;
-    const { success, stopCampaign } = req.body;
+    const { success, stopCampaign, noWorkAvailable } = req.body;
 
     const status = success === true ? "completed" : "failed";
     const identity: IdentityHeaders = {
@@ -460,8 +461,8 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       traceEvent(req.runId, {
         service: "campaign-service",
         event: "end-run",
-        detail: `Ending run for campaign ${campaignId} — success=${success}, stopCampaign=${stopCampaign}, status=${status}`,
-        data: { campaignId, success, stopCampaign, status },
+        detail: `Ending run for campaign ${campaignId} — success=${success}, stopCampaign=${stopCampaign}, noWorkAvailable=${noWorkAvailable === true}, status=${status}`,
+        data: { campaignId, success, stopCampaign, noWorkAvailable: noWorkAvailable === true, status },
       }, req.headers).catch(() => {});
     }
 
@@ -607,11 +608,18 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       // re-run tick — otherwise the in-flight guard sees it alive and forces +60s.
       // A campaign waiting for somebody to contact waits on that reason's cadence — it is not
       // waiting its turn, and firing it sooner cannot change the answer.
+      // Same argument, different reason: a run that reported it had NOTHING TO DO (nobody owed an
+      // answer this minute) waits on the idle cadence rather than re-firing in ten seconds. A
+      // FAILED run is not that case — it says nothing trustworthy about whether there was work —
+      // so the failure backoff still wins.
+      const idle = noWorkAvailable === true && status !== "failed";
       const delayMs = waitingForAudience
         ? NO_SERVEABLE_AUDIENCE_RECHECK_MS
         : status === "failed"
           ? 60_000
-          : RERUN_GRACE_MS;
+          : idle
+            ? NO_WORK_RECHECK_MS
+            : RERUN_GRACE_MS;
       const nextRunAt = new Date(Date.now() + delayMs);
 
       if (req.runId) {
@@ -637,6 +645,10 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
         // the logs.
       } else if (status === "failed") {
         console.warn(`[campaign-service] Run failed — rescheduled campaign ${campaignId} in ${delayMs}ms (nextRunAt=${nextRunAt.toISOString()})`);
+      } else if (idle) {
+        // Expected business state, not a fault, and it fires on the idle cadence rather than once
+        // per run — which is the whole point of this branch.
+        console.log(`[campaign-service] Run had nothing to do for campaign ${campaignId} — waiting ${delayMs}ms instead of the run cadence (nextRunAt=${nextRunAt.toISOString()}); an interested prospect still triggers it immediately`);
       } else {
         console.log(`[campaign-service] Set nextRunAt=${nextRunAt.toISOString()} for campaign ${campaignId} (status=${status})`);
       }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -336,6 +336,19 @@ export const StartRunResponse = z.object({
 export const EndRunBody = z.object({
   success: z.boolean(),
   stopCampaign: z.boolean(),
+  /**
+   * The run completed normally and found NOTHING TO DO — a channel that answers one interested
+   * prospect per run, asked for the next person owed an answer, and nobody was owed one.
+   *
+   * It changes ONE thing: the campaign is rescheduled on the idle cadence
+   * (`NO_WORK_RECHECK_MS`, 10 min) instead of the run cadence, because the answer cannot change
+   * in ten seconds. It never stops a campaign and never marks anything exhausted — that is
+   * `stopCampaign`'s (audience-scoped, cold-email) vocabulary and it stays separate.
+   *
+   * OPTIONAL and absent means "this run did work": every caller that does not send it behaves
+   * byte-identically to before the field existed.
+   */
+  noWorkAvailable: z.boolean().optional(),
 }).openapi("EndRunBody");
 
 export const EndRunResponse = z.object({

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -1140,6 +1140,98 @@ describe("Pipeline routes", () => {
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
+    it("noWorkAvailable=true reschedules on the idle cadence (~10min), does NOT stop the campaign and marks nothing exhausted", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        status: "ongoing",
+        workflowSlug: "ai-meeting-booking-v1",
+        featureSlug: "ai-meeting-booking",
+        createdByUserId: "user_test",
+      });
+
+      const before = Date.now();
+
+      const res = await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .send({ success: true, stopCampaign: false, noWorkAvailable: true })
+        .expect(200);
+
+      expect(res.body.status).toBe("completed");
+      await new Promise((r) => setTimeout(r, 100));
+
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      // The reason it had nothing to do cannot change in ten seconds, so it waits on the idle
+      // cadence instead of the run cadence.
+      const nextRunTime = new Date(updated!.nextRunAt!).getTime();
+      expect(nextRunTime).toBeGreaterThanOrEqual(before + 9 * 60_000);
+      expect(nextRunTime).toBeLessThan(before + 11 * 60_000);
+      // Nothing here stops a campaign or marks anything exhausted.
+      expect(updated!.status).toBe("ongoing");
+      expect(updated!.stopReason).toBeNull();
+      const marks = await db.select().from(campaignAudienceExhaustion)
+        .where(eq(campaignAudienceExhaustion.campaignId, campaign.id));
+      expect(marks).toHaveLength(0);
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it("noWorkAvailable=false is the run cadence — a run that DID work is unchanged", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        status: "ongoing",
+        workflowSlug: "ai-meeting-booking-v1",
+        featureSlug: "ai-meeting-booking",
+        createdByUserId: "user_test",
+      });
+
+      const before = Date.now();
+
+      await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .send({ success: true, stopCampaign: false, noWorkAvailable: false })
+        .expect(200);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      const nextRunTime = new Date(updated!.nextRunAt!).getTime();
+      expect(nextRunTime).toBeGreaterThanOrEqual(before + 9_000);
+      expect(nextRunTime).toBeLessThan(before + 15_000);
+    });
+
+    it("a FAILED run claiming noWorkAvailable still takes the failure backoff", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        status: "ongoing",
+        workflowSlug: "ai-meeting-booking-v1",
+        featureSlug: "ai-meeting-booking",
+        createdByUserId: "user_test",
+      });
+
+      const before = Date.now();
+
+      await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .send({ success: false, stopCampaign: false, noWorkAvailable: true })
+        .expect(200);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      const nextRunTime = new Date(updated!.nextRunAt!).getTime();
+      // A failed run says nothing trustworthy about whether there was work to do.
+      expect(nextRunTime).toBeGreaterThanOrEqual(before + 55_000);
+      expect(nextRunTime).toBeLessThan(before + 65_000);
+    });
+
     it("should NOT set nextRunAt if campaign is stopped", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,

--- a/tests/integration/trigger-for-step.test.ts
+++ b/tests/integration/trigger-for-step.test.ts
@@ -104,6 +104,32 @@ describe("POST /internal/campaigns/trigger-for-step", () => {
     expect(mockExecute).toHaveBeenCalledTimes(1);
   });
 
+  it("runs a campaign PARKED on the idle cadence immediately — the event path never consults nextRunAt", async () => {
+    // A channel that answers one prospect per run parks on the ~10min idle cadence when nobody is
+    // owed an answer. The whole point is that a prospect stating an interest does not wait for it.
+    const campaign = await insertTestCampaign(ORG, {
+      brandIds: [BRAND],
+      brandId: BRAND,
+      status: "ongoing",
+      featureSlug: "ai-meeting-booking",
+      workflowSlug: "aurora-v3",
+      createdByUserId: "user-1",
+      parentRunId: "9f0d1c22-0000-4000-8000-000000000009",
+      funnelKey: FUNNEL,
+      offerId: OFFER,
+      legKey: LEG_OUT,
+      nextRunAt: new Date(Date.now() + 10 * 60_000),
+    });
+
+    const res = await post(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.triggered).toEqual([
+      { campaignId: campaign.id, legKey: LEG_OUT, workflowSlug: "aurora-v3" },
+    ]);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
   it("answers a scope with no such campaign as an ordinary, empty 200", async () => {
     const res = await post(body);
 


### PR DESCRIPTION
## Problem

A channel that answers ONE interested prospect per run asks another service for the next person owed an answer. When nobody is owed one, the run legitimately does nothing — but it reports as an ordinary completed run, so the campaign is rescheduled on the **run cadence** (`RERUN_GRACE_MS`, 10s) and re-fires every eleven seconds, forever.

Measured in prod over 24h on a single campaign that has answered nobody:

| | rows |
|---|---|
| Attributed to that one campaign | **14,841** (7,421 campaign-service + 7,420 workflow side) |
| Whole fleet, same window | 28,336 |

One idle campaign is **52% of the platform's entire run ledger** (2.3 GB table). Every one of those turns also performs an affordability gate-check for a run that will do nothing.

## Change

The workflow **says** it had nothing to do: **`noWorkAvailable`** on the `/end-run` body.

- **Optional, and absent means "this run did work"** — every caller that does not send it behaves byte-identically to before the field existed. Cold email is untouched with no branch on a feature slug.
- It changes **exactly one thing**: the reschedule delay becomes `NO_WORK_RECHECK_MS` (10 min, `src/lib/idle-run.ts`). It never stops a campaign, never marks anything exhausted, never touches the stop reason, and no other decision reads it.
- **Deliberately not the audience-exhaustion recheck**, though both are ten minutes for the same reason. `NO_SERVEABLE_AUDIENCE_RECHECK_MS` is reached through `stopCampaign=true`, whose whole vocabulary is a cold-email audience running out of PEOPLE, and it gates a STOP. Routing this channel through it would conflate two facts and put the campaign one evidence-check away from the sticky `audience_exhausted`.
- A **FAILED** run's claim is ignored — the 60s failure backoff still wins, because a failed run says nothing trustworthy about whether there was work.
- This service cannot infer the signal: only the DAG knows its branch was the empty one, and inferring it from an empty result is the same "empty remainder reads as a verdict" mistake the exhaustion gate already closed.

## Reactivity does not regress

This is the **idle backstop**. When a prospect actually shows interest, the responsible campaign is still run **immediately** through `POST /internal/campaigns/trigger-for-step`, which dispatches without consulting `nextRunAt` at all. Pinned by a new test that parks a campaign ten minutes out and asserts the event still fires it. Ten minutes is a ceiling on IDLE latency, never on answering somebody.

## ⚠️ workflow-service half is REQUIRED — please dispatch it

The DAG for the `ai-meeting-booking` channel lives in **workflow-service** and currently reports its nothing-to-do branch as an ordinary successful run. It must send **`noWorkAvailable: true`** in its `/end-run` body on that branch.

Until it does, this field is never set and behaviour is exactly today's — this PR is inert on its own and safe to merge first. The contract is additive and optional on this side, so there is no ordering constraint in either direction.

## Tests

- `noWorkAvailable=true` → nextRunAt ≈ +10 min, campaign stays `ongoing`, `stopReason` null, zero exhaustion rows
- `noWorkAvailable=false` → unchanged 10s grace
- failed run claiming `noWorkAvailable` → 60s backoff
- a campaign parked ten minutes out is still dispatched immediately by the step trigger

`vitest run`: 36 unit files / 506 tests, 23 integration files / 288 tests, all green. `pnpm run build` + regenerated `openapi.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
