### PR TITLE
feat(identity): the OFFER is part of what one campaign is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -655,6 +655,68 @@ read as one campaign.
   — their history lives in runs-service, keyed on `campaign_id`, and repointing it is runs-service's
   own ledger to move. Deleting them would orphan the history, which is the one thing never allowed.
 
+## The OFFER is part of what ONE campaign IS — a brand funding two offers on one (funnel, channel, leg) gets two campaigns
+
+A customer funds their money PER OFFER: billing-service has keyed a daily ceiling on
+(org, brand, funnel, channel, OFFER, leg) since its migration 0037, and the dashboard lets each
+offer's ceiling be set separately on Offer Settings. This service carried `offer_id` (migration
+0050) but the offer was in NONE of the three places that decide whether a funded thing already has
+a campaign: not in the uniqueness Postgres polices, not in the existing-campaign lookup, and not in
+the grain the funded pairs are derived at — which deduplicated two stored ceilings differing only
+by offer into ONE provisioning question, on purpose. So a brand selling two offers through one
+(funnel, channel, leg) had two ceilings and ONE campaign: the second offer was funded and never
+provisioned, with no error, no log and no failing test. Verified in prod the day this shipped: 194
+offers across 144 brands, 22 brands holding two or more, and no brand yet funding two offers on one
+identity — armed, never fired.
+
+- **`fundedPairs` reads billing's OFFER grain**, between `channels` and `legs`: `legs` first (it
+  carries both the offer and the leg), then `offers`, then `channels`, then `funnels`. Each
+  fallback keeps the population below it byte-identical, and a row whose `offerId` is null is an
+  UNSCOPED ceiling — money written before a ceiling could name an offer — which provisions exactly
+  as it always did.
+- **Migration 0056 widens `uniq_campaigns_org_brand_funnel_channel` with `coalesce(offer_id, '')`.**
+  A pure LOOSENING, the same shape as 0055's leg: every row that states no offer keys byte-identically
+  to before, so no currently-valid state becomes invalid and no existing pair can start colliding.
+  The index NAME still says funnel_channel, for the same reason it did after the leg: the funnel is
+  still part of this identity and the ship that removes it renames the index.
+- **THE LOOKUP GIVES THE SAME ANSWER BILLING GIVES ABOUT WHICH MONEY IT IS.** A pair whose ceiling
+  NAMES an offer matches the campaign OF THAT OFFER. When that finds nothing there are two cases and
+  only one is a second campaign to have: a SINGLE offer funded on the identity (every brand alive
+  today) means the campaign already doing that work IS this pair's campaign whatever offer it
+  states, so it is matched exactly as it always was; SEVERAL offers funded on it means there are
+  genuinely two campaigns to have and this pair gets its own. `sharedIdentity` on the pair is that
+  count, and it is what makes the widening a loosening at runtime rather than only in the index.
+- **NOTHING IS EVER STAMPED ON A CAMPAIGN THAT STATES NO OFFER.** Only brand-service knows which
+  offer a live campaign belongs to (`adoptOfferForPairSafely` writes one, and only where the (org,
+  brand) pair holds exactly one), and guessing from a ceiling would move real money onto the wrong
+  proposition. That is why the single-funded-offer case LEAVES the campaign alone instead of
+  adopting it the way the leg did — the leg identifier came from the same customer statement the
+  campaign was already working; the offer does not.
+- **WHICH funnels a funded offer may be sold through is asked OF THAT OFFER.** A brand that funds a
+  NEW offer has no campaign stating it, so its declaration was never read by
+  `resolveDeclaredFunnels` — `funnelsByOffer` returns what that pass already read and the funded
+  offer is asked directly otherwise. An unreadable declaration provisions nothing and warns; an
+  offer that does not declare the funnel provisions nothing and says so. The `contested` refusal
+  (several offers declare one funnel, none outranks another) is now only reached by a pair whose
+  ceiling names NO offer — when the money names one, there is nothing ambiguous left to wait on.
+- **The deterministic NAME appends the offer when the pair states one**, before the leg. Two offers
+  of one (funnel, channel, leg) would otherwise collide on `uniq_campaigns_org_name` and the second
+  insert would be swallowed as a race — the funded-and-never-provisioned failure one layer down. An
+  offer-less campaign keeps the name it has always had, byte for byte.
+- **The create route matches the same way, in two steps**: the campaign of THIS offer wins, and only
+  when there is none does an offer-LESS incumbent match — which is what happened before the field
+  was part of the key, and is how such a campaign learns the offer it sells from a caller that now
+  states one. A create stating a DIFFERENT offer is a new campaign, and a `23505` hands back the
+  winner of the same offer rather than a campaign selling another one. A `PATCH` that moves a
+  campaign onto an identity another live campaign holds is a 409.
+- **Nothing about pacing, scheduling or serialization changed.** `offerCeilingCents` already paced
+  on the offer and `spendable-budget` already reported at that grain; what was missing was only that
+  a second campaign could not EXIST to be paced. No column, table, vocabulary or accumulator was
+  added, and no live campaign changed id, status, money or history.
+
+(Set 2026-09-06.)
+
+
 ## A campaign states the single funnel LEG it is bought for — features-service's identifier, carried and never parsed
 
 A sales funnel is a chain of steps, and the thing a customer actually BUYS is one of its **LEGS**:
@@ -834,9 +896,13 @@ attribution and on the customer's screen.
   change, so a create that states no offer behaves EXACTLY as it did before the column existed and
   callers state it as they migrate. It becomes required in a later wave, and only then. `PATCH` sets
   or clears it, which is how a campaign created before it could state one says which offer it runs.
-- **It is NOT part of the identity key.** `uniq_campaigns_org_brand_funnel_channel` is untouched:
-  widening it while the field is optional would let one brand grow unlimited offer-less campaigns on
-  one (funnel, channel). Widening it is the same later wave that makes the field required.
+- **It IS part of the identity key since 2026-09-06** (migration 0056 — see the section above).
+  `uniq_campaigns_org_brand_funnel_channel` spans `coalesce(offer_id, '')`, which is what lets a
+  brand funding two offers on one (funnel, channel, leg) hold two live campaigns. The `coalesce` is
+  load-bearing exactly as it is for the funnel and the leg: without it a brand could grow unlimited
+  offer-less campaigns on one (funnel, channel), and with it every row that states no offer keys
+  byte-identically to the way it did before. The field stays OPTIONAL; making it required is a later
+  wave and this widening did not need it.
 - **It decides no MONEY question** — no pacing, funding, gate or ranking decision reads it, and
   `idx_campaigns_org_offer` serves the per-offer attribution read it exists for. Since 2026-08-19 it
   decides exactly ONE thing: WHICH QUESTION this service asks brand-service about the funnels sold

--- a/drizzle/0056_campaign_offer_identity.sql
+++ b/drizzle/0056_campaign_offer_identity.sql
@@ -1,0 +1,38 @@
+-- The OFFER a campaign sells joins the identity Postgres polices.
+--
+-- A customer funds their money PER OFFER: billing-service has keyed a daily ceiling on
+-- (org, brand, funnel, channel, OFFER, leg) since its migration 0037, and the dashboard lets a
+-- customer set each offer's ceiling separately on Offer Settings. This service dedupes campaigns on
+-- (org, brand, funnel, leg, channel) and the offer is absent from that key, so a brand selling TWO
+-- offers through the same (funnel, channel, leg) has two ceilings and can hold only ONE campaign:
+-- the second offer is funded and never provisioned. Nothing errors, nothing is logged and no test
+-- fails — the ceiling simply sits there producing nothing, which is the exact failure the
+-- funded-but-never-runs work exists to prevent. Verified against production: 194 offers across 144
+-- brands, 22 brands already hold two or more, and no brand yet funds two offers on one identity.
+-- Armed, not yet fired.
+--
+-- brand-service OWNS the offer entity and mints its UUID; this column has carried that value since
+-- migration 0050 and is still never derived, parsed or minted here. What changes is only that
+-- Postgres now counts it when it asks whether two live campaigns are the same campaign.
+--
+-- This only ever LOOSENS. `coalesce(offer_id, '')` collapses every row that states no offer onto
+-- the value it keyed under before this migration, so every campaign alive today keys
+-- byte-identically, no currently-valid state becomes invalid, and no existing pair can start
+-- colliding. Nothing is backfilled: an offer is never stamped on a campaign that states none —
+-- only brand-service knows which offer a live campaign belongs to, and guessing would move real
+-- money onto the wrong proposition.
+--
+-- The NAME is deliberately left alone, for the same reason 0055 left it alone: the funnel is still
+-- part of this identity, and the ship that removes it renames the index along with it.
+DROP INDEX IF EXISTS "uniq_campaigns_org_brand_funnel_channel";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_campaigns_org_brand_funnel_channel"
+  ON "campaigns" USING btree (
+    "org_id",
+    "brand_id",
+    coalesce("funnel_key", ''),
+    coalesce("offer_id", ''),
+    coalesce("leg_key", ''),
+    "acquisition_channel"
+  )
+  WHERE "status" = 'ongoing' AND "brand_id" IS NOT NULL AND "acquisition_channel" IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1778000000000,
       "tag": "0055_campaign_leg_key",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1778100000000,
+      "tag": "0056_campaign_offer_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -237,21 +237,26 @@ export const campaigns = pgTable(
     index("idx_campaigns_resumable")
       .on(table.stopReason, table.updatedAt)
       .where(sql`${table.status} = 'stopped' and ${table.stopReason} is not null`),
-    // A campaign is unique on (org, brand, sales funnel, LEG, acquisition channel) — migration
-    // 0044, widened by 0055. Scoped to `ongoing`: a stopped row is history, not a competitor for
-    // the brand's turn. The leg is part of it because a campaign bought for one leg is not the
-    // campaign bought for another: without it a brand working ONE channel for TWO legs cannot hold
-    // two live campaigns at all, since the second create reads as a restatement of the first.
-    // `coalesce(..., '')` is load-bearing on BOTH — Postgres treats NULLs as distinct, so without
-    // it a brand could grow unlimited funnel-less (or leg-less) campaigns on one channel. It also
-    // makes the widening a pure loosening: every row that states no leg keys byte-identically to
-    // the way it did before the column existed. The NAME still says funnel_channel on purpose —
-    // the funnel is still part of this identity, and the ship that removes it renames the index.
+    // A campaign is unique on (org, brand, sales funnel, OFFER, LEG, acquisition channel) —
+    // migration 0044, widened by 0055 (leg) and 0056 (offer). Scoped to `ongoing`: a stopped row is
+    // history, not a competitor for the brand's turn. The leg is part of it because a campaign
+    // bought for one leg is not the campaign bought for another; the OFFER is part of it for the
+    // same reason one level up — a customer funds their money per offer (billing keys its daily
+    // ceiling on the offer), so two offers worked through the same (funnel, channel, leg) are two
+    // ceilings and must be able to be two campaigns. Without it the second offer is funded and
+    // never provisioned, silently.
+    // `coalesce(..., '')` is load-bearing on ALL THREE — Postgres treats NULLs as distinct, so
+    // without it a brand could grow unlimited funnel-less (or leg-less, or offer-less) campaigns on
+    // one channel. It also makes each widening a pure loosening: every row that states no offer or
+    // no leg keys byte-identically to the way it did before the column existed. The NAME still says
+    // funnel_channel on purpose — the funnel is still part of this identity, and the ship that
+    // removes it renames the index.
     uniqueIndex("uniq_campaigns_org_brand_funnel_channel")
       .on(
         table.orgId,
         table.brandId,
         sql`coalesce(${table.funnelKey}, '')`,
+        sql`coalesce(${table.offerId}, '')`,
         sql`coalesce(${table.legKey}, '')`,
         table.acquisitionChannel,
       )

--- a/src/lib/funnel-budget-client.ts
+++ b/src/lib/funnel-budget-client.ts
@@ -417,6 +417,22 @@ export function fundedChannelPairs(
 }
 
 /**
+ * The (funnel, acquisition channel, OFFER) rows this org actually FUNDS for the brand.
+ *
+ * The grain between `channels` and `legs`, and the one a campaign is provisioned per when billing
+ * serves no leg rows: a customer funds their money per offer, so a (funnel, channel) worked for
+ * TWO offers is two ceilings and two campaigns. `channels` is the SUM of these rows, so reading it
+ * there gives both offers one identity and lets each spend what the other was funded for.
+ *
+ * A ceiling of zero is a deliberate "do not work this", exactly as at every grain above.
+ */
+export function fundedOfferRows(
+  read: Extract<FunnelBudgetsRead, { ok: true }>,
+): FunnelOfferBudget[] {
+  return (read.offers ?? []).filter((o) => o.dailyBudgetCents > 0);
+}
+
+/**
  * The ceiling that binds ONE (funnel, acquisition channel, offer, LEG) row — the grain BELOW the
  * offer, and the finest billing stores.
  *

--- a/src/lib/funnel-campaigns.ts
+++ b/src/lib/funnel-campaigns.ts
@@ -7,6 +7,7 @@ import {
   fundedChannelPairs,
   fundedFunnels,
   fundedLegRows,
+  fundedOfferRows,
   type FunnelBudgetsRead,
 } from "./funnel-budget-client.js";
 import { fetchFeatureSalesFunnels, type FeatureSalesFunnelsRead } from "./feature-sales-funnels-client.js";
@@ -360,7 +361,7 @@ async function planOneCohort(
 }
 
 /**
- * One funded (sales funnel, acquisition-channel feature) pair — the unit ONE campaign is
+ * One funded (sales funnel, acquisition-channel feature, OFFER, leg) row — the unit ONE campaign is
  * provisioned per.
  */
 interface FundedPair {
@@ -373,20 +374,72 @@ interface FundedPair {
    * a leg: that pair provisions a leg-less campaign, exactly as it always did.
    */
   legKey: string | null;
+  /**
+   * The OFFER this money is behind — brand-service's UUID, carried verbatim from billing's ceiling
+   * and never derived, parsed or minted. NULL is an UNSCOPED ceiling, i.e. money written before a
+   * ceiling could name an offer: that pair provisions exactly as it always did, and the campaign it
+   * matches is matched without regard to the offer — billing's own rule for unscoped money.
+   */
+  offerId: string | null;
+  /**
+   * Whether SEVERAL offers are funded on this pair's (funnel, channel, leg) identity.
+   *
+   * That is the one case where an existing campaign of the identity cannot stand in for this pair:
+   * with two ceilings there are two campaigns to have, and letting either claim a campaign that
+   * does not state its offer hands one offer the money the other was funded for. With a SINGLE
+   * funded offer there is exactly one honest owner, so the campaign already doing that identity's
+   * work IS this pair's campaign — left exactly as it is, never stamped and never twinned. That
+   * fallback is what keeps every brand alive today byte-identical.
+   */
+  sharedIdentity: boolean;
+}
+
+/** The identity a campaign holds, minus the offer — what `sharedIdentity` is counted over. */
+function identityWithoutOffer(
+  funnelKey: string,
+  featureSlug: string,
+  legKey: string | null,
+): string {
+  return `${funnelKey} ${featureSlug} ${legKey ?? ""}`;
+}
+
+/** Mark every pair whose (funnel, channel, leg) identity is funded for MORE THAN ONE offer. */
+function withSharedIdentity(pairs: FundedPair[]): FundedPair[] {
+  const offersByIdentity = new Map<string, Set<string>>();
+  for (const p of pairs) {
+    if (!p.offerId) continue;
+    const key = identityWithoutOffer(p.funnelKey, p.featureSlug, p.legKey);
+    const set = offersByIdentity.get(key) ?? new Set<string>();
+    set.add(p.offerId);
+    offersByIdentity.set(key, set);
+  }
+  return pairs.map((p) => ({
+    ...p,
+    sharedIdentity:
+      (offersByIdentity.get(identityWithoutOffer(p.funnelKey, p.featureSlug, p.legKey))?.size ?? 0) >
+      1,
+  }));
 }
 
 /**
  * What the customer funds, at the grain a campaign is provisioned per.
  *
- * billing states every grain ADDITIVELY, so all three shapes are live at once and each fallback is
+ * billing states every grain ADDITIVELY, so all four shapes are live at once and each fallback is
  * what keeps the population below it untouched:
  *
- *   - LEG rows stated → one campaign per funded (funnel, channel, leg). A row whose leg is null is
- *     a ceiling written before legs existed and provisions a leg-less campaign, byte-identically
- *     to what the pair grain provisioned for it.
- *   - no legs (an older billing deploy) → one campaign per funded pair, each on its own channel.
- *   - no pairs either → one campaign per funded FUNNEL on the seed's channel, i.e. exactly what
+ *   - LEG rows stated -> one campaign per funded (funnel, channel, OFFER, leg). A row whose leg or
+ *     offer is null is a ceiling written before that word existed and provisions a leg-less (or
+ *     offer-less) campaign, byte-identically to what the coarser grain provisioned for it.
+ *   - no legs (an older billing deploy) -> one campaign per funded (funnel, channel, OFFER).
+ *   - no offers either -> one campaign per funded pair, each on its own channel.
+ *   - no pairs either -> one campaign per funded FUNNEL on the seed's channel, i.e. exactly what
  *     this did before.
+ *
+ * The OFFER is part of the grain because a customer funds their money PER OFFER: billing has keyed
+ * its ceiling on it since its migration 0037 and the dashboard lets each offer's ceiling be set
+ * separately, so two offers worked through one (funnel, channel, leg) are two ceilings. Collapsing
+ * them into one provisioning question is what left the second offer funded and never provisioned —
+ * no error, no log, no failing test, just a ceiling that produces nothing.
  */
 function fundedPairs(
   budgets: Extract<FunnelBudgetsRead, { ok: true }>,
@@ -398,28 +451,62 @@ function fundedPairs(
   // give them one identity and let each spend what the other was funded for.
   const legRows = fundedLegRows(budgets);
   if (legRows.length > 0) {
-    // Deduplicated on the identity a campaign holds. Two stored rows differing only by OFFER are
-    // one provisioning question here — which offer a new campaign is filed under is the DECLARING
-    // offer's answer, resolved further down, never billing's row.
+    // Deduplicated on the identity a campaign holds — which includes the OFFER, because that is the
+    // grain the money was funded at and the grain the customer set it at.
     const seen = new Set<string>();
     const pairs: FundedPair[] = [];
     for (const row of legRows) {
-      const key = `${row.funnelKey}\u0000${row.featureSlug}\u0000${row.legKey ?? ""}`;
+      const key = `${identityWithoutOffer(row.funnelKey, row.featureSlug, row.legKey)} ${row.offerId ?? ""}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      pairs.push({ funnelKey: row.funnelKey, featureSlug: row.featureSlug, legKey: row.legKey });
+      pairs.push({
+        funnelKey: row.funnelKey,
+        featureSlug: row.featureSlug,
+        legKey: row.legKey,
+        offerId: row.offerId,
+        sharedIdentity: false,
+      });
     }
-    return pairs;
+    return withSharedIdentity(pairs);
+  }
+
+  // The OFFER grain, for a billing deploy that serves no leg rows. `channels` is the SUM of these,
+  // so reading it there gives two offers one identity and lets each spend the other's money.
+  const offerRows = fundedOfferRows(budgets);
+  if (offerRows.length > 0) {
+    const seen = new Set<string>();
+    const pairs: FundedPair[] = [];
+    for (const row of offerRows) {
+      const key = `${identityWithoutOffer(row.funnelKey, row.featureSlug, null)} ${row.offerId ?? ""}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      pairs.push({
+        funnelKey: row.funnelKey,
+        featureSlug: row.featureSlug,
+        legKey: null,
+        offerId: row.offerId,
+        sharedIdentity: false,
+      });
+    }
+    return withSharedIdentity(pairs);
   }
 
   const pairs = fundedChannelPairs(budgets);
   if (pairs.length > 0) {
-    return pairs.map((p) => ({ funnelKey: p.funnelKey, featureSlug: p.featureSlug, legKey: null }));
+    return pairs.map((p) => ({
+      funnelKey: p.funnelKey,
+      featureSlug: p.featureSlug,
+      legKey: null,
+      offerId: null,
+      sharedIdentity: false,
+    }));
   }
   return fundedFunnels(budgets).map((f) => ({
     funnelKey: f.funnelKey,
     featureSlug: seedFeatureSlug,
     legKey: null,
+    offerId: null,
+    sharedIdentity: false,
   }));
 }
 
@@ -443,11 +530,21 @@ export interface ResolvedDeclaredFunnels {
    * provisioned for it and it is said out loud.
    */
   contested: Set<SalesFunnelKey>;
+  /**
+   * offerId -> the funnels THAT offer declares, for every offer actually read on this pass.
+   *
+   * `offerByFunnel` answers "who declares this funnel" and collapses to nothing when two offers
+   * both do; this answers the other question — "does offer X sell through funnel Y" — which is the
+   * one a ceiling that NAMES its offer asks. An offer absent here was never read, not read as
+   * declaring nothing.
+   */
+  funnelsByOffer: Map<string, Set<SalesFunnelKey>>;
 }
 
 const NO_DECLARED_FUNNELS: ResolvedDeclaredFunnels = {
   offerByFunnel: new Map(),
   contested: new Set(),
+  funnelsByOffer: new Map(),
 };
 
 /**
@@ -470,6 +567,7 @@ async function resolveDeclaredFunnels(
 
   const offerByFunnel = new Map<SalesFunnelKey, string | null>();
   const contested = new Set<SalesFunnelKey>();
+  const funnelsByOffer = new Map<string, Set<SalesFunnelKey>>();
 
   const note = (read: SalesFunnelsRead, what: string): void => {
     if (read.ok) return;
@@ -488,6 +586,7 @@ async function resolveDeclaredFunnels(
     const read = await fetchOfferSalesFunnels(offerId, identity);
     note(read, `offer ${offerId}`);
     if (!read.ok) continue;
+    funnelsByOffer.set(offerId, new Set(read.funnels.map((f) => f.funnelKey)));
     for (const f of read.funnels) {
       const seen = offerByFunnel.get(f.funnelKey);
       if (seen !== undefined && seen !== null && seen !== offerId) {
@@ -512,7 +611,7 @@ async function resolveDeclaredFunnels(
     }
   }
 
-  return { offerByFunnel, contested };
+  return { offerByFunnel, contested, funnelsByOffer };
 }
 
 /**
@@ -605,18 +704,65 @@ async function ensureFundedFunnelCampaigns({
   // funnel-ancestor-adoption.ts for the rule and why it cannot stay a one-shot migration.
   const adoptFor = new Set<string>();
 
+  // The declaration of an offer the customer's MONEY names, asked of that offer directly rather
+  // than taken from the map derived from the brand's existing campaigns: a brand that funds a NEW
+  // offer has no campaign stating it yet, so that offer's declaration was never read. Cached per
+  // pass, and only ever reached for a pair whose ceiling names an offer — every brand whose
+  // ceilings are unscoped makes no extra read at all.
+  const declaredByFundedOffer = new Map<string, SalesFunnelsRead>();
+  type FundedOfferDeclaration =
+    | { ok: true; funnels: Set<SalesFunnelKey> }
+    | Extract<SalesFunnelsRead, { ok: false }>;
+  const fundedOfferDeclares = async (offerId: string): Promise<FundedOfferDeclaration> => {
+    // Already read while resolving the brand's declarations — a campaign of the group states this
+    // offer, so its funnels are known and no second call is made.
+    const known = declared.funnelsByOffer.get(offerId);
+    if (known) return { ok: true, funnels: known };
+    const cached = declaredByFundedOffer.get(offerId) ?? (await fetchOfferSalesFunnels(offerId, identity));
+    declaredByFundedOffer.set(offerId, cached);
+    return cached.ok
+      ? { ok: true, funnels: new Set(cached.funnels.map((d) => d.funnelKey)) }
+      : cached;
+  };
+
   for (const f of funded) {
-    if (declared.contested.has(f.funnelKey)) {
-      // Several offers of this brand sell through this funnel. Provisioning one campaign would file
-      // it under one of them, i.e. rank it on another product's economics — so it waits for a
-      // caller that states which offer it means, and it is not silent about waiting.
-      console.warn(
-        `[campaign-service] Not provisioning funnel ${f.funnelKey} for brand ${brandId} — several offers of this brand declare it and none outranks another`,
-      );
-      continue;
+    let offerId: string | null;
+    if (f.offerId) {
+      // billing NAMES the offer this money is, so there is nothing ambiguous to wait on — the only
+      // question left is whether THAT offer sells through this funnel. Asked of the offer, never of
+      // the brand: a brand holding several offers has no single answer, which is exactly why
+      // brand-service refuses the brand-keyed read.
+      const read = await fundedOfferDeclares(f.offerId);
+      if (!read.ok) {
+        console.warn(
+          `[campaign-service] Not provisioning funnel ${f.funnelKey} for offer ${f.offerId} (brand ${brandId}, org ${seed.orgId}) — could not read that offer's declared sales funnels: ${read.detail} (${read.reason})`,
+        );
+        continue;
+      }
+      if (!read.funnels.has(f.funnelKey)) {
+        // Funded, but this offer does not sell through this funnel. The money is real, so it is
+        // said once per sweep rather than dropped in silence.
+        console.log(
+          `[campaign-service] Not provisioning funnel ${f.funnelKey} for offer ${f.offerId} (brand ${brandId}) — that offer does not declare selling through it`,
+        );
+        continue;
+      }
+      offerId = f.offerId;
+    } else {
+      if (declared.contested.has(f.funnelKey)) {
+        // Several offers of this brand sell through this funnel and the money says which of them it
+        // is for NONE of them. Provisioning one campaign would file it under one, i.e. rank it on
+        // another product's economics — so it waits for a caller that states which offer it means,
+        // and it is not silent about waiting.
+        console.warn(
+          `[campaign-service] Not provisioning funnel ${f.funnelKey} for brand ${brandId} — several offers of this brand declare it and none outranks another`,
+        );
+        continue;
+      }
+      const declaredOffer = declared.offerByFunnel.get(f.funnelKey);
+      if (declaredOffer === undefined) continue; // funded, but nobody declares selling through it
+      offerId = declaredOffer;
     }
-    const offerId = declared.offerByFunnel.get(f.funnelKey);
-    if (offerId === undefined) continue; // funded, but nobody declares selling through it
     const featureSlug = f.featureSlug;
 
     // A channel the PLATFORM operates but this service does not pace.
@@ -715,20 +861,43 @@ async function ensureFundedFunnelCampaigns({
     // unique index (ongoing rows only), and it is thrown INSIDE planFunnelTurns, which fail-closes
     // and holds the whole brand: every tick, forever, for a brand whose campaign is running fine.
     // At most one ongoing campaign per identity holds, so there is at most one such row to prefer.
-    const existing = await db.query.campaigns.findFirst({
-      where: and(
-        eq(campaigns.orgId, seed.orgId),
-        eq(campaigns.featureSlug, featureSlug),
-        eq(campaigns.funnelKey, f.funnelKey),
-        // The campaign bought for one LEG is not the campaign bought for another, so a pair is
-        // only ever matched against the campaign of ITS leg. Without this, a brand working one
-        // channel for two legs finds the first campaign for the second pair and never provisions
-        // it — the exact pair the leg exists to tell apart, collapsed back into one.
-        f.legKey ? eq(campaigns.legKey, f.legKey) : isNull(campaigns.legKey),
-        arrayContains(campaigns.brandIds, [brandId]),
-      ),
-      orderBy: [desc(sql`(${campaigns.status} = 'ongoing')`), desc(campaigns.createdAt)],
-    });
+    //
+    // WHICH campaign is THIS money's campaign has to be the same answer billing gives about which
+    // money it is, or the two disagree about what one campaign is. A pair whose ceiling NAMES an
+    // offer is matched against the campaign OF THAT OFFER: a brand selling two offers through one
+    // (funnel, channel, leg) holds two ceilings, and matching them both against the same campaign
+    // is what left the second one funded and never provisioned.
+    //
+    // When that strict match finds nothing there are two cases, and only one of them is a second
+    // campaign to have:
+    //
+    //   - ONE offer funded on this identity (every brand alive today) → the campaign already doing
+    //     this identity's work IS this pair's campaign, whatever offer it states, because there is
+    //     exactly one honest owner for the money. It is matched as it always was and left exactly
+    //     as it is — no twin beside it, and no offer stamped on it either: only brand-service knows
+    //     which offer a live campaign belongs to, and guessing moves real money onto the wrong
+    //     proposition.
+    //   - SEVERAL offers funded on it → there are genuinely two campaigns to have, so this pair
+    //     gets its own rather than claiming one that does not state its offer.
+    const findExisting = (matchOffer: boolean) =>
+      db.query.campaigns.findFirst({
+        where: and(
+          eq(campaigns.orgId, seed.orgId),
+          eq(campaigns.featureSlug, featureSlug),
+          eq(campaigns.funnelKey, f.funnelKey),
+          // The campaign bought for one LEG is not the campaign bought for another, so a pair is
+          // only ever matched against the campaign of ITS leg. Without this, a brand working one
+          // channel for two legs finds the first campaign for the second pair and never provisions
+          // it — the exact pair the leg exists to tell apart, collapsed back into one.
+          f.legKey ? eq(campaigns.legKey, f.legKey) : isNull(campaigns.legKey),
+          matchOffer && f.offerId ? eq(campaigns.offerId, f.offerId) : undefined,
+          arrayContains(campaigns.brandIds, [brandId]),
+        ),
+        orderBy: [desc(sql`(${campaigns.status} = 'ongoing')`), desc(campaigns.createdAt)],
+      });
+
+    let existing = await findExisting(true);
+    if (!existing && f.offerId && !f.sharedIdentity) existing = await findExisting(false);
 
     // A campaign that already exists for this (funnel, channel) but states NO leg, on a pair the
     // customer now funds AT the leg grain, is that pair's campaign — it is doing exactly this
@@ -748,6 +917,11 @@ async function ensureFundedFunnelCampaigns({
               eq(campaigns.featureSlug, featureSlug),
               eq(campaigns.funnelKey, f.funnelKey),
               isNull(campaigns.legKey),
+              // Scoped to this pair's OFFER only when the identity is funded for several of them:
+              // then a leg-less campaign of ANOTHER offer is not this pair's campaign and adopting
+              // it would move one offer's history onto the other's money. With a single funded
+              // offer this is exactly the lookup it has always been.
+              f.sharedIdentity && f.offerId ? eq(campaigns.offerId, f.offerId) : undefined,
               arrayContains(campaigns.brandIds, [brandId]),
             ),
             orderBy: [desc(sql`(${campaigns.status} = 'ongoing')`), desc(campaigns.createdAt)],
@@ -852,7 +1026,7 @@ async function ensureFundedFunnelCampaigns({
     // here (brand_ids is a text[], so no unique index can span it), which makes a duplicate
     // provision a constraint violation rather than a second campaign for the same pair. The name
     // already carries the channel, so two channels of one funnel never collide on it.
-    const name = funnelCampaignName(featureSlug, brandId, f.funnelKey, f.legKey);
+    const name = funnelCampaignName(featureSlug, brandId, f.funnelKey, f.legKey, f.offerId);
 
     try {
       await db.insert(campaigns).values({
@@ -903,13 +1077,18 @@ export function funnelCampaignName(
   brandId: string,
   funnelKey: string,
   legKey?: string | null,
+  offerId?: string | null,
 ): string {
   // The name is the only uniqueness Postgres can enforce on an INSERT here (brand_ids is a
-  // text[]), so it has to separate everything a campaign is. The LEG is appended only when the
-  // campaign states one: a leg-less campaign keeps the name it has always had, byte for byte, so
-  // nothing alive today is renamed or re-provisioned.
-  const base = `${featureSlug} - ${brandId} - ${funnelKey}`;
-  return legKey ? `${base} - ${legKey}` : base;
+  // text[]), so it has to separate everything a campaign is. The OFFER and the LEG are appended
+  // only when the campaign states one: an offer-less, leg-less campaign keeps the name it has
+  // always had, byte for byte, so nothing alive today is renamed or re-provisioned. Two offers of
+  // one (funnel, channel, leg) would otherwise collide here and the second insert would be
+  // swallowed as a race — the funded-and-never-provisioned failure, one layer down.
+  let name = `${featureSlug} - ${brandId} - ${funnelKey}`;
+  if (offerId) name = `${name} - ${offerId}`;
+  if (legKey) name = `${name} - ${legKey}`;
+  return name;
 }
 
 /**

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -208,26 +208,39 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
     // could read as one campaign. So a create that names an identity already alive UPDATES that
     // campaign to the requested workflow and configuration and hands it back.
     const identity = campaignIdentityColumns({ brandIds, featureSlug: resolvedFeatureSlug });
-    const incumbent = identity.brandId && identity.acquisitionChannel
-      ? await db.query.campaigns.findFirst({
-          where: and(
-            eq(campaigns.orgId, req.orgId!),
-            eq(campaigns.status, "ongoing"),
-            eq(campaigns.brandId, identity.brandId),
-            eq(campaigns.acquisitionChannel, identity.acquisitionChannel),
-            // The identity includes the funnel: an incumbent is the campaign alive on THIS funnel
-            // (or the funnel-less one, for a feature that sells through no sales funnel).
-            funnelKey ? eq(campaigns.funnelKey, funnelKey) : isNull(campaigns.funnelKey),
-            // ...and the LEG it is bought for. A campaign bought for one leg is not the campaign
-            // bought for another, so a create stating a different leg is a NEW campaign rather
-            // than a restatement of the live one — which is the only way a brand can work one
-            // channel for two legs at once. A create that states NO leg matches the leg-less row
-            // exactly as it did before the field existed.
-            legKey ? eq(campaigns.legKey, legKey) : isNull(campaigns.legKey),
-          ),
-          orderBy: [campaigns.createdAt],
-        })
-      : null;
+    // The OFFER is part of the identity too: a customer funds their money per offer, so two offers
+    // worked through one (funnel, channel, leg) are two ceilings and must be able to be two
+    // campaigns — a create stating a different offer is a NEW campaign, not a restatement of the
+    // live one. It is matched in two steps so that widening can only ever LOOSEN: the campaign of
+    // THIS offer wins, and only when there is none does an offer-LESS incumbent match, which is
+    // exactly what happened before this field was part of the key (and which is how such a campaign
+    // learns the offer it sells from a caller that now states one).
+    const findIncumbent = (matchOffer: boolean) =>
+      db.query.campaigns.findFirst({
+        where: and(
+          eq(campaigns.orgId, req.orgId!),
+          eq(campaigns.status, "ongoing"),
+          eq(campaigns.brandId, identity.brandId!),
+          eq(campaigns.acquisitionChannel, identity.acquisitionChannel!),
+          // The identity includes the funnel: an incumbent is the campaign alive on THIS funnel
+          // (or the funnel-less one, for a feature that sells through no sales funnel).
+          funnelKey ? eq(campaigns.funnelKey, funnelKey) : isNull(campaigns.funnelKey),
+          // ...and the LEG it is bought for. A campaign bought for one leg is not the campaign
+          // bought for another, so a create stating a different leg is a NEW campaign rather
+          // than a restatement of the live one — which is the only way a brand can work one
+          // channel for two legs at once. A create that states NO leg matches the leg-less row
+          // exactly as it did before the field existed.
+          legKey ? eq(campaigns.legKey, legKey) : isNull(campaigns.legKey),
+          matchOffer && offerId ? eq(campaigns.offerId, offerId) : undefined,
+          matchOffer ? undefined : isNull(campaigns.offerId),
+        ),
+        orderBy: [campaigns.createdAt],
+      });
+    let incumbent =
+      identity.brandId && identity.acquisitionChannel ? (await findIncumbent(true)) ?? null : null;
+    if (!incumbent && offerId && identity.brandId && identity.acquisitionChannel) {
+      incumbent = (await findIncumbent(false)) ?? null;
+    }
 
     if (incumbent) {
       // Only what the caller actually sent moves. The NAME is deliberately left alone: it is the
@@ -387,6 +400,9 @@ router.post("/campaigns", requireApiKey, serviceAuth, validateBody(CreateCampaig
           // The leg is part of the identity that collided, so it is part of finding the winner —
           // otherwise the loser is handed back a campaign bought for a different leg.
           req.body.legKey ? eq(campaigns.legKey, req.body.legKey) : isNull(campaigns.legKey),
+          // The offer is part of the identity that collided too, for the same reason: otherwise the
+          // loser is handed back a campaign selling a different offer, on different money.
+          req.body.offerId ? eq(campaigns.offerId, req.body.offerId) : isNull(campaigns.offerId),
         ),
         orderBy: [campaigns.createdAt],
       });
@@ -502,11 +518,12 @@ router.patch("/campaigns/:id", requireApiKey, serviceAuth, validateBody(UpdateCa
     if (error?.code === "23505" && updateConstraint === "uniq_campaigns_org_name") {
       return res.status(409).json({ error: "A campaign with this name already exists in your organization" });
     }
-    // Restating the leg can move a campaign onto an identity another live campaign already holds.
+    // Restating the leg or the offer can move a campaign onto an identity another live campaign
+    // already holds.
     // That is a real conflict and it says so, rather than surfacing as an internal error.
     if (error?.code === "23505" && updateConstraint === "uniq_campaigns_org_brand_funnel_channel") {
       return res.status(409).json({
-        error: "Another live campaign already runs this (brand, sales funnel, leg, acquisition channel)",
+        error: "Another live campaign already runs this (brand, sales funnel, offer, leg, acquisition channel)",
       });
     }
     console.error("[campaign-service] Update campaign error:", error);

--- a/tests/integration/campaign-offer.test.ts
+++ b/tests/integration/campaign-offer.test.ts
@@ -123,15 +123,52 @@ describe("Campaign offer", () => {
     expect(again.body.campaign.offerId).toBe(offerId);
   });
 
-  it("a re-create that states a DIFFERENT offer moves the incumbent to it", async () => {
+  it("a create stating a DIFFERENT offer is a NEW campaign, not a restatement of the live one", async () => {
     const first = crypto.randomUUID();
     const second = crypto.randomUUID();
-    const body = baseBody("Moving Offer");
+    const body = baseBody("Two Offers, One Channel");
 
+    // A customer funds their money PER OFFER, so two offers worked through one (funnel, channel,
+    // leg) are two ceilings the customer set separately. Reading the second create as a
+    // restatement of the first is what left that second offer funded and never provisioned.
     const created = await createCampaign({ ...body, offerId: first }).expect(201);
-    const again = await createCampaign({ ...body, offerId: second }).expect(200);
+    const other = await createCampaign(
+      { ...body, name: "Two Offers, One Channel (second)", offerId: second },
+    ).expect(201);
+
+    expect(other.body.campaign.id).not.toBe(created.body.campaign.id);
+    expect(created.body.campaign.offerId).toBe(first);
+    expect(other.body.campaign.offerId).toBe(second);
+    // Both alive at once: the identity that could not be expressed now can be.
+    expect(created.body.campaign.status).toBe("ongoing");
+    expect(other.body.campaign.status).toBe("ongoing");
+  });
+
+  it("restating the SAME offer updates that offer's campaign rather than growing a second", async () => {
+    const offerId = crypto.randomUUID();
+    const body = baseBody("Restated Offer");
+
+    const created = await createCampaign({ ...body, offerId }).expect(201);
+    const again = await createCampaign(
+      { ...body, name: "Restated Offer (again)", offerId, workflowSlug: "sales-email-cold-outreach-v2" },
+    ).expect(200);
 
     expect(again.body.campaign.id).toBe(created.body.campaign.id);
-    expect(again.body.campaign.offerId).toBe(second);
+    expect(again.body.campaign.offerId).toBe(offerId);
+    expect(again.body.campaign.workflowSlug).toBe("sales-email-cold-outreach-v2");
+  });
+
+  it("a create that states an offer ADOPTS the offer-less campaign already holding the identity", async () => {
+    const offerId = crypto.randomUUID();
+    const body = baseBody("Pre-offer Campaign");
+
+    // The pre-offer population: one campaign on the identity, stating no offer. A create that now
+    // names one is that campaign saying which offer it sells — never a twin beside it.
+    const created = await createCampaign(body).expect(201);
+    expect(created.body.campaign.offerId).toBeNull();
+
+    const stated = await createCampaign({ ...body, offerId }).expect(200);
+    expect(stated.body.campaign.id).toBe(created.body.campaign.id);
+    expect(stated.body.campaign.offerId).toBe(offerId);
   });
 });

--- a/tests/unit/funnel-campaigns.test.ts
+++ b/tests/unit/funnel-campaigns.test.ts
@@ -146,6 +146,14 @@ function mockFunnelBudgets(
     legKey: string | null;
     dailyBudgetCents: string;
   }>,
+  // The OFFER grain, between `channels` and `legs`: one row per (funnel, channel, offer). Omitted
+  // = a billing deploy that does not serve it.
+  offers?: Array<{
+    funnelKey: string;
+    featureSlug: string;
+    offerId?: string | null;
+    dailyBudgetCents: string;
+  }>,
 ) {
   mockFetch.mockResolvedValueOnce({
     ok: true,
@@ -157,6 +165,9 @@ function mockFunnelBudgets(
           : brandDailyBudgetCents,
       funnels: funnels.map(f => ({ ...f, updatedAt: null })),
       ...(channels ? { channels: channels.map(c => ({ ...c, updatedAt: null })) } : {}),
+      ...(offers
+        ? { offers: offers.map(o => ({ offerId: null, ...o, updatedAt: null })) }
+        : {}),
       ...(legs
         ? { legs: legs.map(l => ({ offerId: null, ...l, updatedAt: null })) }
         : {}),
@@ -182,6 +193,63 @@ function mockDeclaredFunnels(funnels: Array<{ funnelKey: string; active?: boolea
         updatedAt: "2026-08-02T00:00:00.000Z",
       })),
     }),
+  });
+}
+
+/**
+ * The URL-answered reads every test shares: which funnels a channel may be sold through
+ * (features-service), which workflow can run it (workflow-service), and the public channel
+ * catalogue. Held as a named function rather than read back off the mock, because
+ * `getMockImplementation()` hands back the next QUEUED `mockResolvedValueOnce` when one is
+ * pending — so a helper that captured it after queueing would serve billing's payload to whatever
+ * called next.
+ */
+async function baseFetch(input: URL | string): Promise<any> {
+  const url = String(input);
+  if (url.includes("/features/")) {
+    return { ok: true, json: async () => ({ feature: { slug: new URL(url).pathname.split("/features/")[1], salesFunnels: [...SALES_FUNNEL_KEYS] } }) };
+  }
+  if (url.includes("/workflows")) {
+    return {
+      ok: true,
+      json: async () => ({
+        workflows: [{ workflowSlug: `${new URL(url).searchParams.get("featureSlug")}-seed`, createdAt: "2026-08-18T00:00:00.000Z" }],
+      }),
+    };
+  }
+  if (url.includes("/public/channels")) return catalogueResponse();
+  throw new Error(`unexpected fetch in test: ${url}`);
+}
+
+/**
+ * brand-service's PER-OFFER declaration, matched on the URL rather than queued: a funded ceiling
+ * that names its offer asks that offer directly, and that read interleaves with the catalogue read
+ * in an order no queue should have to encode.
+ */
+function mockOfferDeclarations(byOffer: Record<string, string[]>) {
+  mockFetch.mockImplementation(async (input: URL | string) => {
+    const url = String(input);
+    const match = url.match(/\/offers\/([^/]+)\/sales-funnels/);
+    if (match) {
+      const funnels = byOffer[match[1]] ?? [];
+      return {
+        ok: true,
+        json: async () => ({
+          funnels: funnels.map(funnelKey => ({
+            funnelKey,
+            active: true,
+            name: funnelKey,
+            steps: [],
+            rates: {},
+            lifetimeRevenueUsd: null,
+            destinationUrl: null,
+            bookingUrl: null,
+            updatedAt: "2026-08-02T00:00:00.000Z",
+          })),
+        }),
+      };
+    }
+    return baseFetch(input);
   });
 }
 
@@ -306,22 +374,7 @@ describe("planFunnelTurns", () => {
     // sold through (features-service) and which workflow can run it (workflow-service). Answered by
     // URL rather than by queue position, so every ordered `mockResolvedValueOnce` below — which
     // takes precedence — keeps describing the billing/brand sequence it always did.
-    mockFetch.mockImplementation(async (input: URL | string) => {
-      const url = String(input);
-      if (url.includes("/features/")) {
-        return { ok: true, json: async () => ({ feature: { slug: new URL(url).pathname.split("/features/")[1], salesFunnels: [...SALES_FUNNEL_KEYS] } }) };
-      }
-      if (url.includes("/workflows")) {
-        return {
-          ok: true,
-          json: async () => ({
-            workflows: [{ workflowSlug: `${new URL(url).searchParams.get("featureSlug")}-seed`, createdAt: "2026-08-18T00:00:00.000Z" }],
-          }),
-        };
-      }
-      if (url.includes("/public/channels")) return catalogueResponse();
-      throw new Error(`unexpected fetch in test: ${url}`);
-    });
+    mockFetch.mockImplementation(baseFetch);
     mockListRuns.mockResolvedValue({ runs: [] });
     mockFindFirst.mockResolvedValue({ id: "existing", name: "custom name", status: "ongoing" });
     // The only findMany left is the sales-scoped liveness check ({ id, featureSlug }). Default the
@@ -569,6 +622,113 @@ describe("planFunnelTurns", () => {
     expect(inserted[0].legKey).toBeNull();
     // The name it has always had, byte for byte, so nothing alive is renamed or re-provisioned.
     expect(inserted[0].name).toBe(funnelCampaignName(SALES, "brand-1", "sales_meetings_from_conversation"));
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────────────────
+  // The OFFER is what the money is funded PER, so it is part of what one campaign is. Two offers
+  // worked through one (funnel, channel, leg) are two ceilings the customer set separately — and
+  // were one campaign, which left the second offer funded and producing nothing.
+  // ─────────────────────────────────────────────────────────────────────────────────────────
+
+  it("provisions ONE campaign per funded OFFER on the same (funnel, channel, leg)", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+      "3000",
+      // billing serves the PAIR figure as the SUM of the two offers — pacing both campaigns on it
+      // is exactly what lets each offer spend what the other was funded for.
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "3000" }],
+      [
+        { funnelKey: "reply_meeting", featureSlug: SALES, offerId: "offer-a", legKey: ENTRY_LEG, dailyBudgetCents: "2000" },
+        { funnelKey: "reply_meeting", featureSlug: SALES, offerId: "offer-b", legKey: ENTRY_LEG, dailyBudgetCents: "1000" },
+      ],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]); // the brand-keyed read
+    mockOfferDeclarations({
+      "offer-a": ["sales_meetings_from_conversation"],
+      "offer-b": ["sales_meetings_from_conversation"],
+    });
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    const inserted = mockInsertValues.mock.calls.map(c => c[0]);
+    expect(inserted).toHaveLength(2);
+    expect(inserted.map(v => v.offerId).sort()).toEqual(["offer-a", "offer-b"]);
+    for (const values of inserted) {
+      expect(values.funnelKey).toBe("sales_meetings_from_conversation");
+      expect(values.legKey).toBe(ENTRY_LEG);
+      expect(values.name).toBe(
+        funnelCampaignName(values.featureSlug, "brand-1", values.funnelKey, values.legKey, values.offerId),
+      );
+    }
+    // Two names, or the unique-name index swallows the second insert as a race and the second
+    // offer is funded and never provisioned all over again.
+    expect(new Set(inserted.map(v => v.name)).size).toBe(2);
+  });
+
+  it("never provisions a funnel the funded OFFER does not declare selling through", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "1000" }],
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, offerId: "offer-a", legKey: ENTRY_LEG, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]); // the brand-keyed read
+    mockOfferDeclarations({ "offer-a": ["website_purchases"] }); // ...but not THIS offer
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("leaves the ONE campaign of a single funded offer exactly as it is — no twin, no stamp", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "1000" }],
+      "1000",
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "1000" }],
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, offerId: "offer-a", legKey: ENTRY_LEG, dailyBudgetCents: "1000" }],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    mockOfferDeclarations({ "offer-a": ["sales_meetings_from_conversation"] });
+    // No campaign STATES this offer; the live campaign of the identity states none at all. With a
+    // single funded offer there is exactly one honest owner, so that campaign IS this pair's.
+    mockFindFirst
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue({ id: "incumbent", status: "ongoing", stopReason: null, legKey: ENTRY_LEG, offerId: null });
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    expect(mockInsertValues).not.toHaveBeenCalled();
+    // Never stamped: only brand-service knows which offer a live campaign belongs to.
+    expect(mockUpdateSet).not.toHaveBeenCalledWith(expect.objectContaining({ offerId: "offer-a" }));
+  });
+
+  it("provisions per offer off billing's OFFER grain when it serves no leg rows", async () => {
+    mockFunnelBudgets(
+      [{ funnelKey: "reply_meeting", dailyBudgetCents: "3000" }],
+      "3000",
+      [{ funnelKey: "reply_meeting", featureSlug: SALES, dailyBudgetCents: "3000" }],
+      undefined,
+      [
+        { funnelKey: "reply_meeting", featureSlug: SALES, offerId: "offer-a", dailyBudgetCents: "2000" },
+        { funnelKey: "reply_meeting", featureSlug: SALES, offerId: "offer-b", dailyBudgetCents: "1000" },
+      ],
+    );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]); // the brand-keyed read
+    mockOfferDeclarations({
+      "offer-a": ["sales_meetings_from_conversation"],
+      "offer-b": ["sales_meetings_from_conversation"],
+    });
+    mockFindFirst.mockResolvedValue(undefined);
+
+    await planFunnelTurns([claimed({ funnelKey: "sales_meetings_from_conversation" })]);
+
+    const inserted = mockInsertValues.mock.calls.map(c => c[0]);
+    expect(inserted).toHaveLength(2);
+    expect(inserted.map(v => v.offerId).sort()).toEqual(["offer-a", "offer-b"]);
+    // No leg was funded, so none is fabricated: these are leg-less campaigns.
+    expect(inserted.every(v => v.legKey === null)).toBe(true);
   });
 
   it("never provisions a pair the channel may not be sold through", async () => {
@@ -1341,6 +1501,9 @@ describe("planFunnelTurns", () => {
         dailyBudgetCents: "1000",
       }],
     );
+    mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
+    // The ceiling NAMES its offer, so THAT offer is asked whether it sells through this funnel:
+    // the brand's own campaigns state no offer, so its declaration was not read above.
     mockDeclaredFunnels([{ funnelKey: "sales_meetings_from_conversation" }]);
     mockFindFirst.mockResolvedValue(undefined); // the pair has no campaign yet
 


### PR DESCRIPTION
## Problem

A customer funds their money **per offer**: billing-service has keyed a daily ceiling on `(org, brand, funnel, channel, offer, leg)` since its migration 0037, and the dashboard lets each offer's ceiling be set separately on Offer Settings.

campaign-service carried `offer_id` (migration 0050) but the offer was in **none** of the three places that decide whether a funded thing already has a campaign:

- not in the uniqueness Postgres polices (`uniq_campaigns_org_brand_funnel_channel`),
- not in the existing-campaign lookup provisioning uses,
- not in the grain `fundedPairs` derives, which deduplicated two stored ceilings differing only by offer into one provisioning question.

So a brand selling **two** offers through the same `(funnel, channel, leg)` got two ceilings and **one** campaign. The second offer was funded and never provisioned: nothing errored, nothing was logged, no test failed — the ceiling sat there producing nothing while the customer saw a budget they had set against a proposition that never ran.

Verified against production: 194 offers across 144 brands, 22 brands already hold two or more, and no brand yet funds two offers on one identity. Armed, not yet fired.

## Change

- **Migration 0056** widens `uniq_campaigns_org_brand_funnel_channel` with `coalesce(offer_id, '')`. A pure **loosening**, the same shape as 0055's leg: every row that states no offer keys byte-identically to before, so no currently-valid state becomes invalid and no existing pair can start colliding. Nothing is backfilled.
- **`fundedPairs` reads billing's OFFER grain** (`legs` → `offers` → `channels` → `funnels`), so one campaign is provisioned per funded `(funnel, channel, offer, leg)`. A row whose `offerId` is null is an unscoped, pre-offer ceiling and provisions exactly as it always did.
- **The lookup gives the same answer billing gives about which money it is.** A pair whose ceiling names an offer matches the campaign *of that offer*; when that finds nothing, a **single** funded offer on the identity means the campaign already doing that work stands in for it (matched exactly as before, left exactly as it is), and **several** funded offers mean there are genuinely two campaigns to have.
- **Nothing is ever stamped on a campaign that states no offer.** Only brand-service knows which offer a live campaign belongs to; guessing from a ceiling would move real money onto the wrong proposition.
- **Which funnels a funded offer may be sold through is asked of that offer** — a newly funded offer has no campaign stating it, so its declaration was never read.
- **The deterministic name appends the offer when the pair states one**, or two offers of one `(funnel, channel, leg)` collide on `uniq_campaigns_org_name` and the second insert is swallowed as a race.
- **The create route matches the same way, in two steps**, so an offer-less incumbent still learns the offer it sells from a caller that now states one, and a create stating a *different* offer is a new campaign.

No pacing, scheduling or serialization change. No new column, table, vocabulary or accumulator. No live campaign changes id, status, money or history.

## Tests

`796 passed` (59 files), including new coverage for: one campaign per funded offer on one `(funnel, channel, leg)`; the offer grain used when billing serves no leg rows; a funnel the funded offer does not declare; the single-funded-offer campaign left alone (no twin, no stamp); and the create-route identity (different offer → new campaign, same offer → update, offer-less incumbent adopted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)