### PR TITLE
feat(legs): every campaign that can state its leg states it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -812,6 +812,44 @@ campaign bought for the leg OUT of that step runs immediately.
 
 (Set 2026-09-02.)
 
+## A run that had NOTHING TO DO waits on the reason's timescale — the workflow SAYS so, and it is not exhaustion
+
+Everything on the `/end-run` path assumed a completed run had done work, so it rescheduled on the
+RUN cadence (`RERUN_GRACE_MS`, 10s). A channel that answers ONE interested prospect per run breaks
+that assumption: its DAG asks another service for the next person owed an answer, and when nobody
+is owed one the run legitimately does nothing, completes normally, and is re-fired eleven seconds
+later — forever. Measured in prod over 24h on ONE such campaign that had answered nobody: **14,841
+run rows attributed to it against 28,336 across the WHOLE fleet**, i.e. one idle campaign was 52%
+of the platform's entire run ledger (2.3 GB table), plus one affordability gate-check per turn for
+a run that would do nothing.
+
+- **The workflow SAYS it had nothing to do** — `noWorkAvailable` on the `/end-run` body
+  (`EndRunBody`, `src/schemas.ts`). OPTIONAL, and ABSENT means "this run did work": every caller
+  that does not send it behaves byte-identically to before the field existed, which is why cold
+  email is untouched without a single branch on a feature slug. This service cannot infer it —
+  only the DAG knows its branch was the empty one — and inferring it from an empty result would be
+  the same "empty remainder reads as a verdict" mistake the exhaustion gate already closed.
+- **It changes exactly ONE thing: the reschedule delay** (`NO_WORK_RECHECK_MS`, 10 min,
+  `src/lib/idle-run.ts`). It never stops a campaign, never marks anything exhausted, never touches
+  the stop reason, and no other decision reads it. The campaign is funded and correct; it simply
+  has nobody to answer this minute.
+- **DELIBERATELY NOT the audience-exhaustion recheck**, though both are ten minutes for the same
+  reason. `NO_SERVEABLE_AUDIENCE_RECHECK_MS` is reached through `stopCampaign=true`, whose whole
+  vocabulary is a cold-email AUDIENCE running out of PEOPLE, and it gates a STOP. Routing this
+  channel through it would conflate two different facts and put a campaign one evidence-check away
+  from `audience_exhausted`, which is sticky. Same figure, separate constant, separate reason.
+- **A FAILED run's claim is ignored** — the failure backoff (60s) still wins, because a run that
+  failed says nothing trustworthy about whether there was work to do.
+- **This is the idle BACKSTOP, not the reactivity.** When a prospect actually shows interest the
+  responsible campaign is run IMMEDIATELY through `POST /internal/campaigns/trigger-for-step`,
+  which dispatches without consulting `nextRunAt` at all — pinned by a test that parks a campaign
+  ten minutes out and asserts the event still fires it. The slow cadence is what happens when
+  nothing has happened, so ten minutes is the ceiling on IDLE latency, never on answering somebody.
+- **workflow-service half**: the DAG for that channel must send `noWorkAvailable: true` on its
+  nothing-to-do branch. Until it does, this field is never set and behaviour is exactly today's.
+
+(Set 2026-09-05.)
+
 ## The OFFER a campaign sells is brand-service's UUID, carried and never derived
 
 A new level sits between the brand and the campaign: **Org > Brand > Offer > Campaign**. An offer is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -822,6 +822,43 @@ campaign doing two jobs on money funded for two.
 
 (Set 2026-08-31.)
 
+## A campaign that CAN state its leg states it — the backfill is a SCRIPT, and it derives nothing new
+
+The write path states the leg, so every campaign created since migration 0055 carries one. Every
+campaign that predates it does not: 234 rows carry a funnel and a channel and no leg. While the
+column is blank, every consumer resolving what such a campaign buys falls back to DERIVING the leg
+from its funnel and its channel — the derivation the column exists to replace — per-leg attribution
+answers about one campaign in 235, and a ceiling stated at the leg grain cannot find the campaign it
+paces.
+
+- **`scripts/backfill-campaign-leg.ts` writes down the answer the consumers already compute.**
+  features-service publishes, on the ONE public catalogue this service reads
+  (`channel-operator-client.ts`), which legs each CHANNEL performs and which funnels each LEG is a
+  leg of. The leg a campaign is bought for is the one in BOTH sets. Nothing new is decided, so a
+  backfilled campaign reads identically to the way it read before — this makes explicit what is
+  already inferred and changes no campaign's meaning.
+- **The identifier is features-service's, read from what it publishes.** Nothing is minted, nothing
+  is parsed, no list of legs exists here — the same posture this service holds for the goal, the
+  offer and the channel.
+- **A campaign that does not resolve to EXACTLY ONE leg is LEFT ALONE**: no leg, several legs (the
+  funnel genuinely does not say which was bought), a channel the catalogue does not publish, a
+  funnel token no catalogue names. Each is reported with its reason, grouped by the (funnel,
+  channel) pair. An unreadable catalogue writes NOTHING at all and throws — "the catalogue states no
+  leg" and "the catalogue could not be asked" are different answers.
+- **Idempotent, reversible, previewable.** It selects and writes only rows whose `leg_key` is still
+  NULL and restates that guard in the UPDATE, so a second run writes nothing and a run racing a live
+  create cannot overwrite a leg a caller just stated; the previous value is NULL by construction, so
+  the undo is exactly the ids it prints (which it emits as a statement); and it DRY-RUNS by default,
+  `--apply` being the only way to write.
+- **`leg_key` is the only column that moves** (plus `updated_at`). No campaign is created or
+  deleted, and no status, money, schedule, history or other word of the identity is touched.
+- **Not a migration, because SQL cannot make the read** — the same reason the offer backfill is a
+  script. It is RE-RUNNABLE rather than one-shot: a channel that gains a leg upstream, or a campaign
+  that becomes resolvable later, is picked up by running it again, never by widening what it is
+  willing to guess.
+
+(Set 2026-09-06.)
+
 ## A lead reaching a STEP runs the campaign bought for the leg OUT of it, NOW — an event entry point beside the clock
 
 Everything this service schedules is on a clock: the tick claims what is due, `/end-run` reschedules

--- a/openapi.json
+++ b/openapi.json
@@ -1028,6 +1028,9 @@
           },
           "stopCampaign": {
             "type": "boolean"
+          },
+          "noWorkAvailable": {
+            "type": "boolean"
           }
         },
         "required": [

--- a/scripts/backfill-campaign-leg.ts
+++ b/scripts/backfill-campaign-leg.ts
@@ -1,0 +1,257 @@
+/**
+ * Backfill: every campaign that CAN state the LEG it is bought for, states it.
+ *
+ * A campaign is (brand, offer, funnel, acquisition channel, LEG). `campaigns.leg_key` (migration
+ * 0055) carries features-service's own identifier for the leg a customer bought, and the write
+ * path states it — but every campaign created before the column existed carries a funnel and a
+ * channel and no leg. While the column is blank, every consumer resolving what such a campaign
+ * buys falls back to DERIVING the leg from its funnel and its channel, which is the derivation the
+ * column exists to replace, and a ceiling stated at the leg grain cannot find the campaign it
+ * paces.
+ *
+ * THE RULE IS THE ONE THE CONSUMERS ALREADY USE — nothing new is decided here. features-service
+ * publishes, on one public catalogue, which legs each CHANNEL performs
+ * (`channels[].stepTransitions[].legKey`) and which funnels each LEG is a leg of
+ * (`legs[].funnelKeys`). The leg a campaign is bought for is the leg that sits in BOTH: performed
+ * by the campaign's channel, and a leg of the campaign's funnel. When exactly one leg satisfies
+ * both, that is what the derivation answers today and it is what this writes down. So a backfilled
+ * campaign reads identically to the way it reads now: this makes explicit what is already inferred
+ * and changes no campaign's meaning.
+ *
+ * THE IDENTIFIER IS features-service's, READ FROM WHAT IT PUBLISHES. Nothing is minted, nothing is
+ * parsed, and no list of legs exists here — the same posture this service holds for the goal, the
+ * offer and the channel. It reuses `fetchChannelCatalogue`, the ONE reader of that catalogue.
+ *
+ * LEFT ALONE, never guessed: a campaign whose (funnel, channel) resolves to no leg, or to SEVERAL,
+ * gets nothing. So does one whose channel the catalogue does not publish, and every campaign if the
+ * catalogue cannot be read at all. Each is reported with its reason, grouped by the pair.
+ *
+ * Idempotent: it only ever selects and writes rows whose `leg_key` is still NULL, and the UPDATE
+ * re-states that guard — so a second run writes nothing and a run racing a live create cannot
+ * overwrite a leg a caller just stated.
+ *
+ * Reversible: the previous value is NULL by construction (that is the guard), so the reverse of a
+ * run is exactly the ids it printed. The script emits the undo statement at the end.
+ *
+ * Dry run is the DEFAULT — it resolves and reports without writing. Pass --apply to write.
+ *
+ * Only `leg_key` (and `updated_at`) ever moves. Status, money, schedule, history and every other
+ * word of the identity are untouched, and no campaign is created or deleted.
+ *
+ * Usage:
+ *   CAMPAIGN_SERVICE_DATABASE_URL=... FEATURES_SERVICE_URL=... \
+ *     npx tsx scripts/backfill-campaign-leg.ts            # dry run, writes nothing
+ *   ... npx tsx scripts/backfill-campaign-leg.ts --apply  # writes
+ */
+
+import postgres from "postgres";
+import { fetchChannelCatalogue, type ChannelCatalogueRead } from "../src/lib/channel-operator-client";
+import { toFunnelKey } from "../src/lib/sales-funnel-vocabulary";
+
+/**
+ * What the catalogue answers for one (funnel, channel) pair.
+ *
+ * `legKey` is set ONLY when exactly one leg is both performed by the channel and a leg of the
+ * funnel. Anything else — none, several, a channel the catalogue does not publish — carries a
+ * `reason` and no identifier, and the caller leaves the campaign alone. There is deliberately no
+ * "pick the first" branch: several legs means the funnel genuinely does not say which one was
+ * bought, which is the entire reason this column exists.
+ */
+export type LegResolution =
+  | { legKey: string; reason?: undefined }
+  | { legKey: null; reason: string };
+
+export interface UnresolvedCampaign {
+  campaignId: string;
+  orgId: string;
+  funnelKey: string;
+  featureSlug: string;
+  reason: string;
+}
+
+export interface BackfillResult {
+  /** Rows written (or, on a dry run, rows that WOULD be written). */
+  written: number;
+  /** The campaign ids behind `written` — the exact set an undo would target. */
+  writtenCampaignIds: string[];
+  /** Campaigns left untouched because their (funnel, channel) does not resolve to exactly one leg. */
+  unresolved: UnresolvedCampaign[];
+  dryRun: boolean;
+}
+
+/**
+ * The leg a (funnel, channel) is bought for, under the catalogue features-service published.
+ *
+ * Both halves of the join are features-service's own statements, joined VERBATIM: a channel that
+ * the catalogue does not publish is a different answer from one that publishes an empty set, and
+ * both are reported as themselves rather than collapsed into a silent nothing.
+ */
+export function resolveLeg(
+  read: Extract<ChannelCatalogueRead, { ok: true }>,
+  funnelKey: string,
+  featureSlug: string,
+): LegResolution {
+  const performed = read.legsBySlug.get(featureSlug);
+  if (!performed) {
+    return { legKey: null, reason: "features-service's catalogue publishes no such channel" };
+  }
+
+  const candidates = read.legs
+    .filter((leg) => performed.has(leg.legKey) && leg.funnelKeys.has(funnelKey))
+    .map((leg) => leg.legKey);
+
+  if (candidates.length === 1) return { legKey: candidates[0] };
+  return {
+    legKey: null,
+    reason:
+      candidates.length === 0
+        ? "features-service states no leg of this funnel that this channel performs"
+        : `this channel performs ${candidates.length} legs of this funnel (${candidates.join(", ")}) — the funnel does not say which was bought`,
+  };
+}
+
+/**
+ * Write each campaign the leg its (funnel, channel) resolves to.
+ *
+ * One catalogue read for the whole run — it is a public, brand-agnostic product statement, so a
+ * campaign is not a reason to ask it again.
+ */
+export async function backfillCampaignLegs(
+  querySql: postgres.Sql,
+  readCatalogue: () => Promise<ChannelCatalogueRead>,
+  options: { dryRun?: boolean } = {},
+): Promise<BackfillResult> {
+  const dryRun = options.dryRun !== false;
+
+  // Only a campaign that carries BOTH a funnel and a channel can be asked about at all: the join
+  // is over those two words, so a row missing either is not a gap the catalogue could close.
+  const rows = (await querySql`
+    SELECT "id", "org_id", "funnel_key", "feature_slug"
+    FROM "campaigns"
+    WHERE "leg_key" IS NULL
+      AND "funnel_key" IS NOT NULL
+      AND "feature_slug" IS NOT NULL
+    ORDER BY "created_at"
+  `) as unknown as Array<{ id: string; org_id: string; funnel_key: string; feature_slug: string }>;
+
+  console.log(`Found ${rows.length} campaign(s) stating a funnel and a channel and no leg`);
+
+  const writtenCampaignIds: string[] = [];
+  const unresolved: UnresolvedCampaign[] = [];
+  if (rows.length === 0) {
+    return { written: 0, writtenCampaignIds, unresolved, dryRun };
+  }
+
+  const read = await readCatalogue();
+  if (!read.ok) {
+    // Fail LOUD and write nothing. A catalogue that cannot be read is not a catalogue that states
+    // no leg, and inventing the difference is the one thing this must never do.
+    throw new Error(`Could not READ features-service's channel catalogue: ${read.detail}`);
+  }
+
+  // The answer is a property of the (funnel, channel) PAIR, so it is resolved once per pair and
+  // every campaign of that pair takes it.
+  const cache = new Map<string, LegResolution>();
+
+  for (const row of rows) {
+    // Every spelling in, one canonical token out — billing and the older campaign rows still carry
+    // the pre-rename funnel keys, and comparing a raw token against the catalogue's canonical ones
+    // reads a perfectly ordinary campaign as naming a funnel nobody publishes.
+    const funnelKey = toFunnelKey(row.funnel_key);
+    if (!funnelKey) {
+      unresolved.push({
+        campaignId: row.id,
+        orgId: row.org_id,
+        funnelKey: row.funnel_key,
+        featureSlug: row.feature_slug,
+        reason: "campaign states a funnel no catalogue names",
+      });
+      continue;
+    }
+
+    const key = `${funnelKey}::${row.feature_slug}`;
+    let resolution = cache.get(key);
+    if (!resolution) {
+      resolution = resolveLeg(read, funnelKey, row.feature_slug);
+      cache.set(key, resolution);
+    }
+
+    if (!resolution.legKey) {
+      unresolved.push({
+        campaignId: row.id,
+        orgId: row.org_id,
+        funnelKey,
+        featureSlug: row.feature_slug,
+        reason: resolution.reason,
+      });
+      continue;
+    }
+
+    if (!dryRun) {
+      // The `leg_key IS NULL` guard is restated here, not just in the SELECT: it is what makes a
+      // re-run a no-op and what stops this overwriting a leg a live create stated meanwhile.
+      await querySql`
+        UPDATE "campaigns"
+        SET "leg_key" = ${resolution.legKey}, "updated_at" = now()
+        WHERE "id" = ${row.id} AND "leg_key" IS NULL
+      `;
+    }
+    console.log(`  ${dryRun ? "[dry-run] would set" : "set"} campaign ${row.id} leg → ${resolution.legKey}`);
+    writtenCampaignIds.push(row.id);
+  }
+
+  return { written: writtenCampaignIds.length, writtenCampaignIds, unresolved, dryRun };
+}
+
+async function main() {
+  const DATABASE_URL = process.env.CAMPAIGN_SERVICE_DATABASE_URL;
+
+  if (!DATABASE_URL || !process.env.FEATURES_SERVICE_URL) {
+    console.error("Required: CAMPAIGN_SERVICE_DATABASE_URL, FEATURES_SERVICE_URL");
+    process.exit(1);
+  }
+
+  // Dry run unless --apply is stated. A backfill that writes by default is one nobody inspected.
+  const dryRun = !process.argv.includes("--apply");
+
+  const sql = postgres(DATABASE_URL);
+  console.log(`=== Backfilling campaign legs ${dryRun ? "(DRY RUN — nothing is written)" : "(APPLYING)"} ===\n`);
+
+  const result = await backfillCampaignLegs(sql, fetchChannelCatalogue, { dryRun });
+
+  console.log(`\n${result.written} campaign(s) ${dryRun ? "would be" : ""} written, ${result.unresolved.length} left alone`);
+
+  if (result.unresolved.length > 0) {
+    // Grouped by (funnel, channel): the reason is a property of the PAIR, so one line per campaign
+    // prints the same sentence a hundred times and buries how many distinct things are unanswered.
+    const byPair = new Map<string, { funnelKey: string; featureSlug: string; reason: string; campaigns: number }>();
+    for (const u of result.unresolved) {
+      const key = `${u.funnelKey}::${u.featureSlug}`;
+      const entry = byPair.get(key);
+      if (entry) entry.campaigns++;
+      else byPair.set(key, { funnelKey: u.funnelKey, featureSlug: u.featureSlug, reason: u.reason, campaigns: 1 });
+    }
+    console.error(
+      `\nLEFT ALONE — ${result.unresolved.length} campaign(s) across ${byPair.size} (funnel, channel) pair(s) that do not resolve to exactly one leg. No leg is invented for these:`,
+    );
+    for (const p of byPair.values()) {
+      console.error(`  funnel ${p.funnelKey}, channel ${p.featureSlug} (${p.campaigns} campaign(s)): ${p.reason}`);
+    }
+  }
+
+  if (result.written > 0) {
+    const ids = result.writtenCampaignIds.map((id) => `'${id}'`).join(", ");
+    console.log(`\nUndo this run:\n  UPDATE "campaigns" SET "leg_key" = NULL WHERE "id" IN (${ids});`);
+  }
+
+  await sql.end();
+}
+
+// Only run main() when executed directly (not imported in tests)
+const isDirectRun = process.argv[1]?.includes("backfill-campaign-leg");
+if (isDirectRun) {
+  main().catch(async (err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/src/lib/idle-run.ts
+++ b/src/lib/idle-run.ts
@@ -1,0 +1,28 @@
+/**
+ * A run that had NOTHING TO DO waits on the timescale of the reason it had nothing to do.
+ *
+ * Some acquisition channels serve ONE interested prospect per run: the DAG asks another service
+ * for the next person owed an answer, and when nobody is owed one the run legitimately does
+ * nothing. That run completes normally, so the campaign used to be rescheduled on the RUN cadence
+ * (`RERUN_GRACE_MS`, 10s) — a workflow every eleven seconds, forever, for a campaign whose
+ * situation cannot change in eleven seconds. Measured in prod over 24h on ONE such campaign that
+ * had answered nobody: 14,841 run rows attributed to it against 28,336 across the whole fleet, so
+ * one idle campaign was 52% of the platform's entire run ledger — plus one affordability
+ * gate-check per turn for a run that would do nothing.
+ *
+ * "Nobody to answer right now" is the MONEY kind of wait, not the TURN kind: it moves when a
+ * prospect states an interest, minutes or hours apart. So it reschedules on the same 10 minutes
+ * and for the same reason as `FUNDING_RECHECK_MS` and `NO_SERVEABLE_AUDIENCE_RECHECK_MS`, and
+ * that interval IS the idle latency ceiling.
+ *
+ * It is a CEILING and not the reactivity: when a prospect actually shows interest the responsible
+ * campaign is run IMMEDIATELY through `POST /internal/campaigns/trigger-for-step`, which dispatches
+ * without consulting `nextRunAt` at all. This slower cadence is only what happens when nothing has
+ * happened.
+ *
+ * It is deliberately NOT the audience-exhaustion recheck, whose vocabulary is a cold-email audience
+ * running out of PEOPLE — a different fact, reached by a different signal, that gates a STOP.
+ * Nothing on this path stops a campaign or marks anything exhausted: the campaign is funded and
+ * correct, it simply has nobody to answer this minute.
+ */
+export const NO_WORK_RECHECK_MS = 10 * 60_000; // 10 min

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -11,6 +11,7 @@ import { wakeScheduler } from "../lib/scheduler.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { fetchBrandRuntimeContext, type RuntimeGoal } from "../lib/brand-runtime-client.js";
 import { markAudienceExhausted, getFreshExhaustedAudienceIds, hasExhaustedAudience, isExhaustionStopWarranted, NO_SERVEABLE_AUDIENCE_RECHECK_MS } from "../lib/audience-exhaustion.js";
+import { NO_WORK_RECHECK_MS } from "../lib/idle-run.js";
 import { maybeSendExtendAudienceEmail } from "../lib/transactional-email.js";
 import { serveableAudienceIdsForCampaign } from "../lib/serveable-audience.js";
 import { STOP_REASONS } from "../lib/stop-reason.js";
@@ -443,7 +444,7 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
   try {
     const campaignId = req.campaignId!;
     const orgId = req.orgId!;
-    const { success, stopCampaign } = req.body;
+    const { success, stopCampaign, noWorkAvailable } = req.body;
 
     const status = success === true ? "completed" : "failed";
     const identity: IdentityHeaders = {
@@ -460,8 +461,8 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       traceEvent(req.runId, {
         service: "campaign-service",
         event: "end-run",
-        detail: `Ending run for campaign ${campaignId} — success=${success}, stopCampaign=${stopCampaign}, status=${status}`,
-        data: { campaignId, success, stopCampaign, status },
+        detail: `Ending run for campaign ${campaignId} — success=${success}, stopCampaign=${stopCampaign}, noWorkAvailable=${noWorkAvailable === true}, status=${status}`,
+        data: { campaignId, success, stopCampaign, noWorkAvailable: noWorkAvailable === true, status },
       }, req.headers).catch(() => {});
     }
 
@@ -607,11 +608,18 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
       // re-run tick — otherwise the in-flight guard sees it alive and forces +60s.
       // A campaign waiting for somebody to contact waits on that reason's cadence — it is not
       // waiting its turn, and firing it sooner cannot change the answer.
+      // Same argument, different reason: a run that reported it had NOTHING TO DO (nobody owed an
+      // answer this minute) waits on the idle cadence rather than re-firing in ten seconds. A
+      // FAILED run is not that case — it says nothing trustworthy about whether there was work —
+      // so the failure backoff still wins.
+      const idle = noWorkAvailable === true && status !== "failed";
       const delayMs = waitingForAudience
         ? NO_SERVEABLE_AUDIENCE_RECHECK_MS
         : status === "failed"
           ? 60_000
-          : RERUN_GRACE_MS;
+          : idle
+            ? NO_WORK_RECHECK_MS
+            : RERUN_GRACE_MS;
       const nextRunAt = new Date(Date.now() + delayMs);
 
       if (req.runId) {
@@ -637,6 +645,10 @@ router.post("/end-run", requireApiKey, requirePipelineHeaders, trackingHeaders, 
         // the logs.
       } else if (status === "failed") {
         console.warn(`[campaign-service] Run failed — rescheduled campaign ${campaignId} in ${delayMs}ms (nextRunAt=${nextRunAt.toISOString()})`);
+      } else if (idle) {
+        // Expected business state, not a fault, and it fires on the idle cadence rather than once
+        // per run — which is the whole point of this branch.
+        console.log(`[campaign-service] Run had nothing to do for campaign ${campaignId} — waiting ${delayMs}ms instead of the run cadence (nextRunAt=${nextRunAt.toISOString()}); an interested prospect still triggers it immediately`);
       } else {
         console.log(`[campaign-service] Set nextRunAt=${nextRunAt.toISOString()} for campaign ${campaignId} (status=${status})`);
       }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -336,6 +336,19 @@ export const StartRunResponse = z.object({
 export const EndRunBody = z.object({
   success: z.boolean(),
   stopCampaign: z.boolean(),
+  /**
+   * The run completed normally and found NOTHING TO DO — a channel that answers one interested
+   * prospect per run, asked for the next person owed an answer, and nobody was owed one.
+   *
+   * It changes ONE thing: the campaign is rescheduled on the idle cadence
+   * (`NO_WORK_RECHECK_MS`, 10 min) instead of the run cadence, because the answer cannot change
+   * in ten seconds. It never stops a campaign and never marks anything exhausted — that is
+   * `stopCampaign`'s (audience-scoped, cold-email) vocabulary and it stays separate.
+   *
+   * OPTIONAL and absent means "this run did work": every caller that does not send it behaves
+   * byte-identically to before the field existed.
+   */
+  noWorkAvailable: z.boolean().optional(),
 }).openapi("EndRunBody");
 
 export const EndRunResponse = z.object({

--- a/tests/integration/internal-routes.test.ts
+++ b/tests/integration/internal-routes.test.ts
@@ -1140,6 +1140,98 @@ describe("Pipeline routes", () => {
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
+    it("noWorkAvailable=true reschedules on the idle cadence (~10min), does NOT stop the campaign and marks nothing exhausted", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        status: "ongoing",
+        workflowSlug: "ai-meeting-booking-v1",
+        featureSlug: "ai-meeting-booking",
+        createdByUserId: "user_test",
+      });
+
+      const before = Date.now();
+
+      const res = await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .send({ success: true, stopCampaign: false, noWorkAvailable: true })
+        .expect(200);
+
+      expect(res.body.status).toBe("completed");
+      await new Promise((r) => setTimeout(r, 100));
+
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      // The reason it had nothing to do cannot change in ten seconds, so it waits on the idle
+      // cadence instead of the run cadence.
+      const nextRunTime = new Date(updated!.nextRunAt!).getTime();
+      expect(nextRunTime).toBeGreaterThanOrEqual(before + 9 * 60_000);
+      expect(nextRunTime).toBeLessThan(before + 11 * 60_000);
+      // Nothing here stops a campaign or marks anything exhausted.
+      expect(updated!.status).toBe("ongoing");
+      expect(updated!.stopReason).toBeNull();
+      const marks = await db.select().from(campaignAudienceExhaustion)
+        .where(eq(campaignAudienceExhaustion.campaignId, campaign.id));
+      expect(marks).toHaveLength(0);
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it("noWorkAvailable=false is the run cadence — a run that DID work is unchanged", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        status: "ongoing",
+        workflowSlug: "ai-meeting-booking-v1",
+        featureSlug: "ai-meeting-booking",
+        createdByUserId: "user_test",
+      });
+
+      const before = Date.now();
+
+      await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .send({ success: true, stopCampaign: false, noWorkAvailable: false })
+        .expect(200);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      const nextRunTime = new Date(updated!.nextRunAt!).getTime();
+      expect(nextRunTime).toBeGreaterThanOrEqual(before + 9_000);
+      expect(nextRunTime).toBeLessThan(before + 15_000);
+    });
+
+    it("a FAILED run claiming noWorkAvailable still takes the failure backoff", async () => {
+      const campaign = await insertTestCampaign(orgId, {
+        brandIds,
+        status: "ongoing",
+        workflowSlug: "ai-meeting-booking-v1",
+        featureSlug: "ai-meeting-booking",
+        createdByUserId: "user_test",
+      });
+
+      const before = Date.now();
+
+      await request(app)
+        .post("/end-run")
+        .set(pipelineHeaders({ "x-org-id": orgId, "x-campaign-id": campaign.id }))
+        .send({ success: false, stopCampaign: false, noWorkAvailable: true })
+        .expect(200);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      const updated = await db.query.campaigns.findFirst({
+        where: eq(campaigns.id, campaign.id),
+      });
+      const nextRunTime = new Date(updated!.nextRunAt!).getTime();
+      // A failed run says nothing trustworthy about whether there was work to do.
+      expect(nextRunTime).toBeGreaterThanOrEqual(before + 55_000);
+      expect(nextRunTime).toBeLessThan(before + 65_000);
+    });
+
     it("should NOT set nextRunAt if campaign is stopped", async () => {
       const campaign = await insertTestCampaign(orgId, {
         brandIds,

--- a/tests/integration/trigger-for-step.test.ts
+++ b/tests/integration/trigger-for-step.test.ts
@@ -104,6 +104,32 @@ describe("POST /internal/campaigns/trigger-for-step", () => {
     expect(mockExecute).toHaveBeenCalledTimes(1);
   });
 
+  it("runs a campaign PARKED on the idle cadence immediately — the event path never consults nextRunAt", async () => {
+    // A channel that answers one prospect per run parks on the ~10min idle cadence when nobody is
+    // owed an answer. The whole point is that a prospect stating an interest does not wait for it.
+    const campaign = await insertTestCampaign(ORG, {
+      brandIds: [BRAND],
+      brandId: BRAND,
+      status: "ongoing",
+      featureSlug: "ai-meeting-booking",
+      workflowSlug: "aurora-v3",
+      createdByUserId: "user-1",
+      parentRunId: "9f0d1c22-0000-4000-8000-000000000009",
+      funnelKey: FUNNEL,
+      offerId: OFFER,
+      legKey: LEG_OUT,
+      nextRunAt: new Date(Date.now() + 10 * 60_000),
+    });
+
+    const res = await post(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.triggered).toEqual([
+      { campaignId: campaign.id, legKey: LEG_OUT, workflowSlug: "aurora-v3" },
+    ]);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
   it("answers a scope with no such campaign as an ordinary, empty 200", async () => {
     const res = await post(body);
 

--- a/tests/unit/campaign-leg-backfill.test.ts
+++ b/tests/unit/campaign-leg-backfill.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  backfillCampaignLegs,
+  resolveLeg,
+  type BackfillResult,
+} from "../../scripts/backfill-campaign-leg.js";
+import type { ChannelCatalogueRead } from "../../src/lib/channel-operator-client.js";
+
+/**
+ * A catalogue exactly as features-service publishes one: which legs each CHANNEL performs, and
+ * which funnels each LEG is a leg of. Both statements are its own; this service joins them.
+ */
+function catalogue(
+  legsBySlug: Record<string, string[]>,
+  legs: Array<{ legKey: string; funnelKeys: string[] }>,
+): Extract<ChannelCatalogueRead, { ok: true }> {
+  return {
+    ok: true,
+    operatorBySlug: new Map(Object.keys(legsBySlug).map((slug) => [slug, "platform" as const])),
+    legsBySlug: new Map(Object.entries(legsBySlug).map(([slug, keys]) => [slug, new Set(keys)])),
+    legs: legs.map((l) => ({ legKey: l.legKey, fromStepKey: null, funnelKeys: new Set(l.funnelKeys) })),
+    stepKeys: new Set<string>(),
+  };
+}
+
+const CATALOGUE = catalogue(
+  {
+    "sales-cold-email-outreach": ["entry_leg", "conversation_leg"],
+    "google-ads": ["visit_leg"],
+    "ai-meeting-booking": ["conversation_leg", "second_leg"],
+  },
+  [
+    { legKey: "entry_leg", funnelKeys: ["sales_meetings_from_conversation"] },
+    { legKey: "conversation_leg", funnelKeys: ["sales_meetings_from_conversation", "website_purchases"] },
+    { legKey: "second_leg", funnelKeys: ["sales_meetings_from_conversation"] },
+    { legKey: "visit_leg", funnelKeys: ["sales_meetings_from_website"] },
+  ],
+);
+
+/**
+ * Minimal tagged-template mock mimicking postgres `sql`: the first call is the SELECT and returns
+ * `rows`; every later call is an UPDATE and is recorded.
+ */
+function createMockSql(rows: Record<string, unknown>[]) {
+  let callCount = 0;
+  const updates: Array<{ legKey: unknown; campaignId: unknown }> = [];
+  const selects: string[] = [];
+  const fn = async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    callCount++;
+    if (callCount === 1) {
+      selects.push(strings.join("?"));
+      return rows;
+    }
+    updates.push({ legKey: values[0], campaignId: values[1] });
+    return [];
+  };
+  return { sql: fn as unknown as Parameters<typeof backfillCampaignLegs>[0], updates, selects };
+}
+
+function row(
+  id: string,
+  funnelKey = "sales_meetings_from_conversation",
+  featureSlug = "google-ads",
+  orgId = "org-1",
+) {
+  return { id, org_id: orgId, funnel_key: funnelKey, feature_slug: featureSlug };
+}
+
+const reading = (read: ChannelCatalogueRead) => () => Promise.resolve(read);
+
+describe("resolveLeg — the rule every consumer already uses", () => {
+  it("answers the one leg the channel performs that is a leg of the funnel", () => {
+    expect(resolveLeg(CATALOGUE, "sales_meetings_from_website", "google-ads")).toEqual({ legKey: "visit_leg" });
+  });
+
+  it("answers nothing when the channel performs no leg of that funnel", () => {
+    const r = resolveLeg(CATALOGUE, "website_purchases", "google-ads");
+    expect(r.legKey).toBeNull();
+    expect(r.reason).toMatch(/no leg of this funnel/);
+  });
+
+  it("answers nothing when SEVERAL legs qualify — the funnel does not say which was bought", () => {
+    const r = resolveLeg(CATALOGUE, "sales_meetings_from_conversation", "sales-cold-email-outreach");
+    expect(r.legKey).toBeNull();
+    expect(r.reason).toMatch(/performs 2 legs/);
+  });
+
+  it("distinguishes a channel the catalogue does not publish from one that performs no such leg", () => {
+    const r = resolveLeg(CATALOGUE, "sales_meetings_from_website", "never-published");
+    expect(r.legKey).toBeNull();
+    expect(r.reason).toMatch(/publishes no such channel/);
+  });
+});
+
+describe("backfillCampaignLegs", () => {
+  it("writes each campaign the single leg its (funnel, channel) resolves to", async () => {
+    const { sql, updates } = createMockSql([
+      row("c1", "sales_meetings_from_website", "google-ads"),
+      row("c2", "sales_meetings_from_website", "google-ads"),
+    ]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(result.written).toBe(2);
+    expect(result.writtenCampaignIds).toEqual(["c1", "c2"]);
+    expect(result.unresolved).toEqual([]);
+    expect(updates).toEqual([
+      { legKey: "visit_leg", campaignId: "c1" },
+      { legKey: "visit_leg", campaignId: "c2" },
+    ]);
+  });
+
+  it("reads the catalogue ONCE for the whole run", async () => {
+    const { sql } = createMockSql([
+      row("c1", "sales_meetings_from_website", "google-ads"),
+      row("c2", "sales_meetings_from_website", "google-ads"),
+    ]);
+    const read = vi.fn().mockResolvedValue(CATALOGUE);
+
+    await backfillCampaignLegs(sql, read, { dryRun: false });
+
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects only rows still stating NO leg, and restates that guard on the write", async () => {
+    const { sql, selects, updates } = createMockSql([row("c1", "sales_meetings_from_website", "google-ads")]);
+
+    await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(selects[0]).toMatch(/"leg_key" IS NULL/);
+    expect(updates).toHaveLength(1);
+  });
+
+  it("dry-runs by DEFAULT — it resolves, reports, and writes nothing", async () => {
+    const { sql, updates } = createMockSql([row("c1", "sales_meetings_from_website", "google-ads")]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE));
+
+    expect(result.dryRun).toBe(true);
+    expect(result.written).toBe(1);
+    expect(updates).toEqual([]);
+  });
+
+  it("accepts a LEGACY funnel spelling — a pre-rename row is an ordinary campaign", async () => {
+    const { sql, updates } = createMockSql([row("c1", "visit_meeting", "google-ads")]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(result.written).toBe(1);
+    expect(updates).toEqual([{ legKey: "visit_leg", campaignId: "c1" }]);
+  });
+
+  it("LEAVES ALONE a campaign whose pair resolves to several legs, naming the pair", async () => {
+    const { sql, updates } = createMockSql([
+      row("c1", "sales_meetings_from_conversation", "sales-cold-email-outreach"),
+    ]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(result.written).toBe(0);
+    expect(updates).toEqual([]);
+    expect(result.unresolved).toEqual([
+      expect.objectContaining({
+        campaignId: "c1",
+        funnelKey: "sales_meetings_from_conversation",
+        featureSlug: "sales-cold-email-outreach",
+      }),
+    ]);
+  });
+
+  it("LEAVES ALONE a campaign stating a funnel no catalogue names", async () => {
+    const { sql, updates } = createMockSql([row("c1", "not_a_funnel", "google-ads")]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(result.written).toBe(0);
+    expect(updates).toEqual([]);
+    expect(result.unresolved[0].reason).toMatch(/no catalogue names/);
+  });
+
+  it("writes NOTHING and fails LOUD when the catalogue cannot be READ", async () => {
+    const { sql, updates } = createMockSql([row("c1", "sales_meetings_from_website", "google-ads")]);
+
+    await expect(
+      backfillCampaignLegs(sql, reading({ ok: false, detail: "HTTP 502" }), { dryRun: false }),
+    ).rejects.toThrow(/HTTP 502/);
+    expect(updates).toEqual([]);
+  });
+
+  it("asks nothing at all when no campaign is missing a leg — a second run is a no-op", async () => {
+    const { sql, updates } = createMockSql([]);
+    const read = vi.fn().mockResolvedValue(CATALOGUE);
+
+    const result: BackfillResult = await backfillCampaignLegs(sql, read, { dryRun: false });
+
+    expect(result.written).toBe(0);
+    expect(updates).toEqual([]);
+    expect(read).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Job

Every campaign that can state the leg it is bought for, states it.

## Problem

A campaign is (brand, offer, funnel, acquisition channel, **LEG**). The column shipped with migration 0055 and the write path works — but 234 campaigns predate it: they carry a funnel and a channel and no leg. While they stay blank:

- every consumer resolving what such a campaign buys falls back to a derivation from its funnel and its channel, which is the thing the column exists to replace;
- per-leg attribution answers about 1 campaign out of 235;
- a ceiling stated at the leg grain cannot find the campaign it paces.

## What this ships

`scripts/backfill-campaign-leg.ts` — it writes down the answer the consumers already compute.

features-service publishes, on the ONE public catalogue this service reads (`channel-operator-client.ts`), which legs each **channel** performs (`channels[].stepTransitions[].legKey`) and which funnels each **leg** is a leg of (`legs[].funnelKeys`). The leg a campaign is bought for is the leg in BOTH sets. Nothing new is decided, so a backfilled campaign reads identically to the way it reads today.

- **The identifier is features-service's**, read from what it publishes. Nothing minted, nothing parsed, no list of legs held here.
- **Left alone, never guessed** — no leg, several legs (the funnel does not say which was bought), a channel the catalogue does not publish, a funnel token no catalogue names. Each reported with its reason, grouped by the (funnel, channel) pair.
- **An unreadable catalogue writes NOTHING and throws.** "States no leg" and "could not be asked" are different answers.
- **Idempotent** — selects and writes only rows whose `leg_key` is still NULL, and restates that guard in the UPDATE, so a second run writes nothing and a run racing a live create cannot overwrite a leg a caller just stated.
- **Reversible** — the previous value is NULL by construction, so the undo is exactly the ids it prints, which it emits as a statement.
- **Previewable** — dry run is the DEFAULT; `--apply` is the only way to write.
- **`leg_key` is the only column that moves** (plus `updated_at`). No campaign created or deleted; no status, money, schedule, history or other word of the identity touched.

Not a migration, because SQL cannot make the read — the same reason the offer backfill is a script, and re-runnable for the same reason.

## Verification

- `tests/unit/campaign-leg-backfill.test.ts` — 13 tests: the join rule in all four directions, catalogue read once per run, the `leg_key IS NULL` guard on select and write, dry-run default, legacy funnel spelling accepted, each left-alone reason, throw-and-write-nothing on an unreadable catalogue, no catalogue read at all when nothing is missing.
- Full unit suite green (523 tests, 37 files); `pnpm run build` green.
- Production run happens after promote, dry run first.