### PR TITLE
hotfix: Backfill leg collision leaves the row alone, not the run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -822,6 +822,43 @@ campaign doing two jobs on money funded for two.
 
 (Set 2026-08-31.)
 
+## A campaign that CAN state its leg states it — the backfill is a SCRIPT, and it derives nothing new
+
+The write path states the leg, so every campaign created since migration 0055 carries one. Every
+campaign that predates it does not: 234 rows carry a funnel and a channel and no leg. While the
+column is blank, every consumer resolving what such a campaign buys falls back to DERIVING the leg
+from its funnel and its channel — the derivation the column exists to replace — per-leg attribution
+answers about one campaign in 235, and a ceiling stated at the leg grain cannot find the campaign it
+paces.
+
+- **`scripts/backfill-campaign-leg.ts` writes down the answer the consumers already compute.**
+  features-service publishes, on the ONE public catalogue this service reads
+  (`channel-operator-client.ts`), which legs each CHANNEL performs and which funnels each LEG is a
+  leg of. The leg a campaign is bought for is the one in BOTH sets. Nothing new is decided, so a
+  backfilled campaign reads identically to the way it read before — this makes explicit what is
+  already inferred and changes no campaign's meaning.
+- **The identifier is features-service's, read from what it publishes.** Nothing is minted, nothing
+  is parsed, no list of legs exists here — the same posture this service holds for the goal, the
+  offer and the channel.
+- **A campaign that does not resolve to EXACTLY ONE leg is LEFT ALONE**: no leg, several legs (the
+  funnel genuinely does not say which was bought), a channel the catalogue does not publish, a
+  funnel token no catalogue names. Each is reported with its reason, grouped by the (funnel,
+  channel) pair. An unreadable catalogue writes NOTHING at all and throws — "the catalogue states no
+  leg" and "the catalogue could not be asked" are different answers.
+- **Idempotent, reversible, previewable.** It selects and writes only rows whose `leg_key` is still
+  NULL and restates that guard in the UPDATE, so a second run writes nothing and a run racing a live
+  create cannot overwrite a leg a caller just stated; the previous value is NULL by construction, so
+  the undo is exactly the ids it prints (which it emits as a statement); and it DRY-RUNS by default,
+  `--apply` being the only way to write.
+- **`leg_key` is the only column that moves** (plus `updated_at`). No campaign is created or
+  deleted, and no status, money, schedule, history or other word of the identity is touched.
+- **Not a migration, because SQL cannot make the read** — the same reason the offer backfill is a
+  script. It is RE-RUNNABLE rather than one-shot: a channel that gains a leg upstream, or a campaign
+  that becomes resolvable later, is picked up by running it again, never by widening what it is
+  willing to guess.
+
+(Set 2026-09-06.)
+
 ## A lead reaching a STEP runs the campaign bought for the leg OUT of it, NOW — an event entry point beside the clock
 
 Everything this service schedules is on a clock: the tick claims what is due, `/end-run` reschedules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -850,6 +850,14 @@ paces.
   create cannot overwrite a leg a caller just stated; the previous value is NULL by construction, so
   the undo is exactly the ids it prints (which it emits as a statement); and it DRY-RUNS by default,
   `--apply` being the only way to write.
+- **A row whose leg would COLLIDE with a live sibling's identity is left alone, per row.** A
+  campaign is unique on (org, brand, funnel, offer, leg, channel) among `ongoing` rows and a
+  leg-less row keys as the empty string, so stating a leg can land a row exactly on top of a live
+  campaign that already states it — Postgres saying the two are the same campaign. That is a real
+  answer about the data, reported like any other left-alone reason. Caught PER ROW, because
+  unhandled it aborts the whole run on the first collision and leaves every later campaign
+  unwritten (observed in the production run: two campaigns provisioned mid-run, one of them a twin).
+  Any OTHER write error still throws.
 - **`leg_key` is the only column that moves** (plus `updated_at`). No campaign is created or
   deleted, and no status, money, schedule, history or other word of the identity is touched.
 - **Not a migration, because SQL cannot make the read** — the same reason the offer backfill is a

--- a/scripts/backfill-campaign-leg.ts
+++ b/scripts/backfill-campaign-leg.ts
@@ -188,13 +188,34 @@ export async function backfillCampaignLegs(
     }
 
     if (!dryRun) {
-      // The `leg_key IS NULL` guard is restated here, not just in the SELECT: it is what makes a
-      // re-run a no-op and what stops this overwriting a leg a live create stated meanwhile.
-      await querySql`
-        UPDATE "campaigns"
-        SET "leg_key" = ${resolution.legKey}, "updated_at" = now()
-        WHERE "id" = ${row.id} AND "leg_key" IS NULL
-      `;
+      try {
+        // The `leg_key IS NULL` guard is restated here, not just in the SELECT: it is what makes a
+        // re-run a no-op and what stops this overwriting a leg a live create stated meanwhile.
+        await querySql`
+          UPDATE "campaigns"
+          SET "leg_key" = ${resolution.legKey}, "updated_at" = now()
+          WHERE "id" = ${row.id} AND "leg_key" IS NULL
+        `;
+      } catch (err) {
+        // STATING THE LEG CAN COLLIDE WITH THE IDENTITY ANOTHER LIVE CAMPAIGN ALREADY HOLDS.
+        // A campaign is unique on (org, brand, funnel, offer, leg, channel) among `ongoing` rows,
+        // and a leg-less row keys as the empty string — so writing its leg can land it exactly on
+        // top of a live sibling that already states that leg. That is Postgres telling us the two
+        // rows are the same campaign, which is a real answer about the data and not something to
+        // resolve here: the row is LEFT ALONE and reported, exactly like a pair that resolves to
+        // several legs. Caught PER ROW because the alternative is what it did the first time —
+        // abort the whole run on the first collision and leave every later campaign unwritten.
+        const code = (err as { code?: string } | null)?.code;
+        if (code !== "23505") throw err;
+        unresolved.push({
+          campaignId: row.id,
+          orgId: row.org_id,
+          funnelKey,
+          featureSlug: row.feature_slug,
+          reason: `another live campaign already holds this identity stating leg ${resolution.legKey}`,
+        });
+        continue;
+      }
     }
     console.log(`  ${dryRun ? "[dry-run] would set" : "set"} campaign ${row.id} leg → ${resolution.legKey}`);
     writtenCampaignIds.push(row.id);

--- a/scripts/backfill-campaign-leg.ts
+++ b/scripts/backfill-campaign-leg.ts
@@ -1,0 +1,257 @@
+/**
+ * Backfill: every campaign that CAN state the LEG it is bought for, states it.
+ *
+ * A campaign is (brand, offer, funnel, acquisition channel, LEG). `campaigns.leg_key` (migration
+ * 0055) carries features-service's own identifier for the leg a customer bought, and the write
+ * path states it — but every campaign created before the column existed carries a funnel and a
+ * channel and no leg. While the column is blank, every consumer resolving what such a campaign
+ * buys falls back to DERIVING the leg from its funnel and its channel, which is the derivation the
+ * column exists to replace, and a ceiling stated at the leg grain cannot find the campaign it
+ * paces.
+ *
+ * THE RULE IS THE ONE THE CONSUMERS ALREADY USE — nothing new is decided here. features-service
+ * publishes, on one public catalogue, which legs each CHANNEL performs
+ * (`channels[].stepTransitions[].legKey`) and which funnels each LEG is a leg of
+ * (`legs[].funnelKeys`). The leg a campaign is bought for is the leg that sits in BOTH: performed
+ * by the campaign's channel, and a leg of the campaign's funnel. When exactly one leg satisfies
+ * both, that is what the derivation answers today and it is what this writes down. So a backfilled
+ * campaign reads identically to the way it reads now: this makes explicit what is already inferred
+ * and changes no campaign's meaning.
+ *
+ * THE IDENTIFIER IS features-service's, READ FROM WHAT IT PUBLISHES. Nothing is minted, nothing is
+ * parsed, and no list of legs exists here — the same posture this service holds for the goal, the
+ * offer and the channel. It reuses `fetchChannelCatalogue`, the ONE reader of that catalogue.
+ *
+ * LEFT ALONE, never guessed: a campaign whose (funnel, channel) resolves to no leg, or to SEVERAL,
+ * gets nothing. So does one whose channel the catalogue does not publish, and every campaign if the
+ * catalogue cannot be read at all. Each is reported with its reason, grouped by the pair.
+ *
+ * Idempotent: it only ever selects and writes rows whose `leg_key` is still NULL, and the UPDATE
+ * re-states that guard — so a second run writes nothing and a run racing a live create cannot
+ * overwrite a leg a caller just stated.
+ *
+ * Reversible: the previous value is NULL by construction (that is the guard), so the reverse of a
+ * run is exactly the ids it printed. The script emits the undo statement at the end.
+ *
+ * Dry run is the DEFAULT — it resolves and reports without writing. Pass --apply to write.
+ *
+ * Only `leg_key` (and `updated_at`) ever moves. Status, money, schedule, history and every other
+ * word of the identity are untouched, and no campaign is created or deleted.
+ *
+ * Usage:
+ *   CAMPAIGN_SERVICE_DATABASE_URL=... FEATURES_SERVICE_URL=... \
+ *     npx tsx scripts/backfill-campaign-leg.ts            # dry run, writes nothing
+ *   ... npx tsx scripts/backfill-campaign-leg.ts --apply  # writes
+ */
+
+import postgres from "postgres";
+import { fetchChannelCatalogue, type ChannelCatalogueRead } from "../src/lib/channel-operator-client";
+import { toFunnelKey } from "../src/lib/sales-funnel-vocabulary";
+
+/**
+ * What the catalogue answers for one (funnel, channel) pair.
+ *
+ * `legKey` is set ONLY when exactly one leg is both performed by the channel and a leg of the
+ * funnel. Anything else — none, several, a channel the catalogue does not publish — carries a
+ * `reason` and no identifier, and the caller leaves the campaign alone. There is deliberately no
+ * "pick the first" branch: several legs means the funnel genuinely does not say which one was
+ * bought, which is the entire reason this column exists.
+ */
+export type LegResolution =
+  | { legKey: string; reason?: undefined }
+  | { legKey: null; reason: string };
+
+export interface UnresolvedCampaign {
+  campaignId: string;
+  orgId: string;
+  funnelKey: string;
+  featureSlug: string;
+  reason: string;
+}
+
+export interface BackfillResult {
+  /** Rows written (or, on a dry run, rows that WOULD be written). */
+  written: number;
+  /** The campaign ids behind `written` — the exact set an undo would target. */
+  writtenCampaignIds: string[];
+  /** Campaigns left untouched because their (funnel, channel) does not resolve to exactly one leg. */
+  unresolved: UnresolvedCampaign[];
+  dryRun: boolean;
+}
+
+/**
+ * The leg a (funnel, channel) is bought for, under the catalogue features-service published.
+ *
+ * Both halves of the join are features-service's own statements, joined VERBATIM: a channel that
+ * the catalogue does not publish is a different answer from one that publishes an empty set, and
+ * both are reported as themselves rather than collapsed into a silent nothing.
+ */
+export function resolveLeg(
+  read: Extract<ChannelCatalogueRead, { ok: true }>,
+  funnelKey: string,
+  featureSlug: string,
+): LegResolution {
+  const performed = read.legsBySlug.get(featureSlug);
+  if (!performed) {
+    return { legKey: null, reason: "features-service's catalogue publishes no such channel" };
+  }
+
+  const candidates = read.legs
+    .filter((leg) => performed.has(leg.legKey) && leg.funnelKeys.has(funnelKey))
+    .map((leg) => leg.legKey);
+
+  if (candidates.length === 1) return { legKey: candidates[0] };
+  return {
+    legKey: null,
+    reason:
+      candidates.length === 0
+        ? "features-service states no leg of this funnel that this channel performs"
+        : `this channel performs ${candidates.length} legs of this funnel (${candidates.join(", ")}) — the funnel does not say which was bought`,
+  };
+}
+
+/**
+ * Write each campaign the leg its (funnel, channel) resolves to.
+ *
+ * One catalogue read for the whole run — it is a public, brand-agnostic product statement, so a
+ * campaign is not a reason to ask it again.
+ */
+export async function backfillCampaignLegs(
+  querySql: postgres.Sql,
+  readCatalogue: () => Promise<ChannelCatalogueRead>,
+  options: { dryRun?: boolean } = {},
+): Promise<BackfillResult> {
+  const dryRun = options.dryRun !== false;
+
+  // Only a campaign that carries BOTH a funnel and a channel can be asked about at all: the join
+  // is over those two words, so a row missing either is not a gap the catalogue could close.
+  const rows = (await querySql`
+    SELECT "id", "org_id", "funnel_key", "feature_slug"
+    FROM "campaigns"
+    WHERE "leg_key" IS NULL
+      AND "funnel_key" IS NOT NULL
+      AND "feature_slug" IS NOT NULL
+    ORDER BY "created_at"
+  `) as unknown as Array<{ id: string; org_id: string; funnel_key: string; feature_slug: string }>;
+
+  console.log(`Found ${rows.length} campaign(s) stating a funnel and a channel and no leg`);
+
+  const writtenCampaignIds: string[] = [];
+  const unresolved: UnresolvedCampaign[] = [];
+  if (rows.length === 0) {
+    return { written: 0, writtenCampaignIds, unresolved, dryRun };
+  }
+
+  const read = await readCatalogue();
+  if (!read.ok) {
+    // Fail LOUD and write nothing. A catalogue that cannot be read is not a catalogue that states
+    // no leg, and inventing the difference is the one thing this must never do.
+    throw new Error(`Could not READ features-service's channel catalogue: ${read.detail}`);
+  }
+
+  // The answer is a property of the (funnel, channel) PAIR, so it is resolved once per pair and
+  // every campaign of that pair takes it.
+  const cache = new Map<string, LegResolution>();
+
+  for (const row of rows) {
+    // Every spelling in, one canonical token out — billing and the older campaign rows still carry
+    // the pre-rename funnel keys, and comparing a raw token against the catalogue's canonical ones
+    // reads a perfectly ordinary campaign as naming a funnel nobody publishes.
+    const funnelKey = toFunnelKey(row.funnel_key);
+    if (!funnelKey) {
+      unresolved.push({
+        campaignId: row.id,
+        orgId: row.org_id,
+        funnelKey: row.funnel_key,
+        featureSlug: row.feature_slug,
+        reason: "campaign states a funnel no catalogue names",
+      });
+      continue;
+    }
+
+    const key = `${funnelKey}::${row.feature_slug}`;
+    let resolution = cache.get(key);
+    if (!resolution) {
+      resolution = resolveLeg(read, funnelKey, row.feature_slug);
+      cache.set(key, resolution);
+    }
+
+    if (!resolution.legKey) {
+      unresolved.push({
+        campaignId: row.id,
+        orgId: row.org_id,
+        funnelKey,
+        featureSlug: row.feature_slug,
+        reason: resolution.reason,
+      });
+      continue;
+    }
+
+    if (!dryRun) {
+      // The `leg_key IS NULL` guard is restated here, not just in the SELECT: it is what makes a
+      // re-run a no-op and what stops this overwriting a leg a live create stated meanwhile.
+      await querySql`
+        UPDATE "campaigns"
+        SET "leg_key" = ${resolution.legKey}, "updated_at" = now()
+        WHERE "id" = ${row.id} AND "leg_key" IS NULL
+      `;
+    }
+    console.log(`  ${dryRun ? "[dry-run] would set" : "set"} campaign ${row.id} leg → ${resolution.legKey}`);
+    writtenCampaignIds.push(row.id);
+  }
+
+  return { written: writtenCampaignIds.length, writtenCampaignIds, unresolved, dryRun };
+}
+
+async function main() {
+  const DATABASE_URL = process.env.CAMPAIGN_SERVICE_DATABASE_URL;
+
+  if (!DATABASE_URL || !process.env.FEATURES_SERVICE_URL) {
+    console.error("Required: CAMPAIGN_SERVICE_DATABASE_URL, FEATURES_SERVICE_URL");
+    process.exit(1);
+  }
+
+  // Dry run unless --apply is stated. A backfill that writes by default is one nobody inspected.
+  const dryRun = !process.argv.includes("--apply");
+
+  const sql = postgres(DATABASE_URL);
+  console.log(`=== Backfilling campaign legs ${dryRun ? "(DRY RUN — nothing is written)" : "(APPLYING)"} ===\n`);
+
+  const result = await backfillCampaignLegs(sql, fetchChannelCatalogue, { dryRun });
+
+  console.log(`\n${result.written} campaign(s) ${dryRun ? "would be" : ""} written, ${result.unresolved.length} left alone`);
+
+  if (result.unresolved.length > 0) {
+    // Grouped by (funnel, channel): the reason is a property of the PAIR, so one line per campaign
+    // prints the same sentence a hundred times and buries how many distinct things are unanswered.
+    const byPair = new Map<string, { funnelKey: string; featureSlug: string; reason: string; campaigns: number }>();
+    for (const u of result.unresolved) {
+      const key = `${u.funnelKey}::${u.featureSlug}`;
+      const entry = byPair.get(key);
+      if (entry) entry.campaigns++;
+      else byPair.set(key, { funnelKey: u.funnelKey, featureSlug: u.featureSlug, reason: u.reason, campaigns: 1 });
+    }
+    console.error(
+      `\nLEFT ALONE — ${result.unresolved.length} campaign(s) across ${byPair.size} (funnel, channel) pair(s) that do not resolve to exactly one leg. No leg is invented for these:`,
+    );
+    for (const p of byPair.values()) {
+      console.error(`  funnel ${p.funnelKey}, channel ${p.featureSlug} (${p.campaigns} campaign(s)): ${p.reason}`);
+    }
+  }
+
+  if (result.written > 0) {
+    const ids = result.writtenCampaignIds.map((id) => `'${id}'`).join(", ");
+    console.log(`\nUndo this run:\n  UPDATE "campaigns" SET "leg_key" = NULL WHERE "id" IN (${ids});`);
+  }
+
+  await sql.end();
+}
+
+// Only run main() when executed directly (not imported in tests)
+const isDirectRun = process.argv[1]?.includes("backfill-campaign-leg");
+if (isDirectRun) {
+  main().catch(async (err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/campaign-leg-backfill.test.ts
+++ b/tests/unit/campaign-leg-backfill.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  backfillCampaignLegs,
+  resolveLeg,
+  type BackfillResult,
+} from "../../scripts/backfill-campaign-leg.js";
+import type { ChannelCatalogueRead } from "../../src/lib/channel-operator-client.js";
+
+/**
+ * A catalogue exactly as features-service publishes one: which legs each CHANNEL performs, and
+ * which funnels each LEG is a leg of. Both statements are its own; this service joins them.
+ */
+function catalogue(
+  legsBySlug: Record<string, string[]>,
+  legs: Array<{ legKey: string; funnelKeys: string[] }>,
+): Extract<ChannelCatalogueRead, { ok: true }> {
+  return {
+    ok: true,
+    operatorBySlug: new Map(Object.keys(legsBySlug).map((slug) => [slug, "platform" as const])),
+    legsBySlug: new Map(Object.entries(legsBySlug).map(([slug, keys]) => [slug, new Set(keys)])),
+    legs: legs.map((l) => ({ legKey: l.legKey, fromStepKey: null, funnelKeys: new Set(l.funnelKeys) })),
+    stepKeys: new Set<string>(),
+  };
+}
+
+const CATALOGUE = catalogue(
+  {
+    "sales-cold-email-outreach": ["entry_leg", "conversation_leg"],
+    "google-ads": ["visit_leg"],
+    "ai-meeting-booking": ["conversation_leg", "second_leg"],
+  },
+  [
+    { legKey: "entry_leg", funnelKeys: ["sales_meetings_from_conversation"] },
+    { legKey: "conversation_leg", funnelKeys: ["sales_meetings_from_conversation", "website_purchases"] },
+    { legKey: "second_leg", funnelKeys: ["sales_meetings_from_conversation"] },
+    { legKey: "visit_leg", funnelKeys: ["sales_meetings_from_website"] },
+  ],
+);
+
+/**
+ * Minimal tagged-template mock mimicking postgres `sql`: the first call is the SELECT and returns
+ * `rows`; every later call is an UPDATE and is recorded.
+ */
+function createMockSql(rows: Record<string, unknown>[]) {
+  let callCount = 0;
+  const updates: Array<{ legKey: unknown; campaignId: unknown }> = [];
+  const selects: string[] = [];
+  const fn = async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    callCount++;
+    if (callCount === 1) {
+      selects.push(strings.join("?"));
+      return rows;
+    }
+    updates.push({ legKey: values[0], campaignId: values[1] });
+    return [];
+  };
+  return { sql: fn as unknown as Parameters<typeof backfillCampaignLegs>[0], updates, selects };
+}
+
+function row(
+  id: string,
+  funnelKey = "sales_meetings_from_conversation",
+  featureSlug = "google-ads",
+  orgId = "org-1",
+) {
+  return { id, org_id: orgId, funnel_key: funnelKey, feature_slug: featureSlug };
+}
+
+const reading = (read: ChannelCatalogueRead) => () => Promise.resolve(read);
+
+describe("resolveLeg — the rule every consumer already uses", () => {
+  it("answers the one leg the channel performs that is a leg of the funnel", () => {
+    expect(resolveLeg(CATALOGUE, "sales_meetings_from_website", "google-ads")).toEqual({ legKey: "visit_leg" });
+  });
+
+  it("answers nothing when the channel performs no leg of that funnel", () => {
+    const r = resolveLeg(CATALOGUE, "website_purchases", "google-ads");
+    expect(r.legKey).toBeNull();
+    expect(r.reason).toMatch(/no leg of this funnel/);
+  });
+
+  it("answers nothing when SEVERAL legs qualify — the funnel does not say which was bought", () => {
+    const r = resolveLeg(CATALOGUE, "sales_meetings_from_conversation", "sales-cold-email-outreach");
+    expect(r.legKey).toBeNull();
+    expect(r.reason).toMatch(/performs 2 legs/);
+  });
+
+  it("distinguishes a channel the catalogue does not publish from one that performs no such leg", () => {
+    const r = resolveLeg(CATALOGUE, "sales_meetings_from_website", "never-published");
+    expect(r.legKey).toBeNull();
+    expect(r.reason).toMatch(/publishes no such channel/);
+  });
+});
+
+describe("backfillCampaignLegs", () => {
+  it("writes each campaign the single leg its (funnel, channel) resolves to", async () => {
+    const { sql, updates } = createMockSql([
+      row("c1", "sales_meetings_from_website", "google-ads"),
+      row("c2", "sales_meetings_from_website", "google-ads"),
+    ]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(result.written).toBe(2);
+    expect(result.writtenCampaignIds).toEqual(["c1", "c2"]);
+    expect(result.unresolved).toEqual([]);
+    expect(updates).toEqual([
+      { legKey: "visit_leg", campaignId: "c1" },
+      { legKey: "visit_leg", campaignId: "c2" },
+    ]);
+  });
+
+  it("reads the catalogue ONCE for the whole run", async () => {
+    const { sql } = createMockSql([
+      row("c1", "sales_meetings_from_website", "google-ads"),
+      row("c2", "sales_meetings_from_website", "google-ads"),
+    ]);
+    const read = vi.fn().mockResolvedValue(CATALOGUE);
+
+    await backfillCampaignLegs(sql, read, { dryRun: false });
+
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects only rows still stating NO leg, and restates that guard on the write", async () => {
+    const { sql, selects, updates } = createMockSql([row("c1", "sales_meetings_from_website", "google-ads")]);
+
+    await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(selects[0]).toMatch(/"leg_key" IS NULL/);
+    expect(updates).toHaveLength(1);
+  });
+
+  it("dry-runs by DEFAULT — it resolves, reports, and writes nothing", async () => {
+    const { sql, updates } = createMockSql([row("c1", "sales_meetings_from_website", "google-ads")]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE));
+
+    expect(result.dryRun).toBe(true);
+    expect(result.written).toBe(1);
+    expect(updates).toEqual([]);
+  });
+
+  it("accepts a LEGACY funnel spelling — a pre-rename row is an ordinary campaign", async () => {
+    const { sql, updates } = createMockSql([row("c1", "visit_meeting", "google-ads")]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(result.written).toBe(1);
+    expect(updates).toEqual([{ legKey: "visit_leg", campaignId: "c1" }]);
+  });
+
+  it("LEAVES ALONE a campaign whose pair resolves to several legs, naming the pair", async () => {
+    const { sql, updates } = createMockSql([
+      row("c1", "sales_meetings_from_conversation", "sales-cold-email-outreach"),
+    ]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(result.written).toBe(0);
+    expect(updates).toEqual([]);
+    expect(result.unresolved).toEqual([
+      expect.objectContaining({
+        campaignId: "c1",
+        funnelKey: "sales_meetings_from_conversation",
+        featureSlug: "sales-cold-email-outreach",
+      }),
+    ]);
+  });
+
+  it("LEAVES ALONE a campaign stating a funnel no catalogue names", async () => {
+    const { sql, updates } = createMockSql([row("c1", "not_a_funnel", "google-ads")]);
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(result.written).toBe(0);
+    expect(updates).toEqual([]);
+    expect(result.unresolved[0].reason).toMatch(/no catalogue names/);
+  });
+
+  it("writes NOTHING and fails LOUD when the catalogue cannot be READ", async () => {
+    const { sql, updates } = createMockSql([row("c1", "sales_meetings_from_website", "google-ads")]);
+
+    await expect(
+      backfillCampaignLegs(sql, reading({ ok: false, detail: "HTTP 502" }), { dryRun: false }),
+    ).rejects.toThrow(/HTTP 502/);
+    expect(updates).toEqual([]);
+  });
+
+  it("asks nothing at all when no campaign is missing a leg — a second run is a no-op", async () => {
+    const { sql, updates } = createMockSql([]);
+    const read = vi.fn().mockResolvedValue(CATALOGUE);
+
+    const result: BackfillResult = await backfillCampaignLegs(sql, read, { dryRun: false });
+
+    expect(result.written).toBe(0);
+    expect(updates).toEqual([]);
+    expect(read).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/campaign-leg-backfill.test.ts
+++ b/tests/unit/campaign-leg-backfill.test.ts
@@ -41,7 +41,10 @@ const CATALOGUE = catalogue(
  * Minimal tagged-template mock mimicking postgres `sql`: the first call is the SELECT and returns
  * `rows`; every later call is an UPDATE and is recorded.
  */
-function createMockSql(rows: Record<string, unknown>[]) {
+function createMockSql(
+  rows: Record<string, unknown>[],
+  onUpdate?: (campaignId: unknown) => void,
+) {
   let callCount = 0;
   const updates: Array<{ legKey: unknown; campaignId: unknown }> = [];
   const selects: string[] = [];
@@ -51,10 +54,16 @@ function createMockSql(rows: Record<string, unknown>[]) {
       selects.push(strings.join("?"));
       return rows;
     }
+    onUpdate?.(values[1]);
     updates.push({ legKey: values[0], campaignId: values[1] });
     return [];
   };
   return { sql: fn as unknown as Parameters<typeof backfillCampaignLegs>[0], updates, selects };
+}
+
+/** The error Postgres raises when the write lands on the identity a live sibling already holds. */
+function uniqueViolation() {
+  return Object.assign(new Error("duplicate key value violates unique constraint"), { code: "23505" });
 }
 
 function row(
@@ -196,5 +205,34 @@ describe("backfillCampaignLegs", () => {
     expect(result.written).toBe(0);
     expect(updates).toEqual([]);
     expect(read).not.toHaveBeenCalled();
+  });
+  it("LEAVES ALONE a row whose leg would collide with a live sibling's identity, and keeps going", async () => {
+    const { sql, updates } = createMockSql(
+      [
+        row("c1", "sales_meetings_from_website", "google-ads"),
+        row("c2", "sales_meetings_from_website", "google-ads"),
+      ],
+      (campaignId) => {
+        if (campaignId === "c1") throw uniqueViolation();
+      },
+    );
+
+    const result = await backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false });
+
+    expect(result.writtenCampaignIds).toEqual(["c2"]);
+    expect(updates).toEqual([{ legKey: "visit_leg", campaignId: "c2" }]);
+    expect(result.unresolved).toEqual([
+      expect.objectContaining({ campaignId: "c1", reason: expect.stringMatching(/already holds this identity/) }),
+    ]);
+  });
+
+  it("still THROWS on a write error that is not a collision", async () => {
+    const { sql } = createMockSql([row("c1", "sales_meetings_from_website", "google-ads")], () => {
+      throw Object.assign(new Error("connection terminated"), { code: "08006" });
+    });
+
+    await expect(backfillCampaignLegs(sql, reading(CATALOGUE), { dryRun: false })).rejects.toThrow(
+      /connection terminated/,
+    );
   });
 });


### PR DESCRIPTION
Automated by release.sh